### PR TITLE
safe-setting v1 release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
+# The organization where you want to register the app in the app creation manifest flow. 
+# If set, the app is registered for an organization (https://github.com/organizations/ORGANIZATION/settings/apps/new), 
+# if not set, the GitHub app would be registered for the user account (https://github.com/settings/apps/new).
+# GHE_ORG=
+
 # The ID of your GitHub App
-APP_ID=
-WEBHOOK_SECRET=development
+# APP_ID=
+# WEBHOOK_SECRET=development
 
 # Uncomment this to get verbose logging
 # LOG_LEVEL=trace # or `info` to show less

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -1,6 +1,8 @@
 name: Node.js CI
 "on":
   push:
+    branches:
+      - main-enterprise
   pull_request:
     types:
       - opened
@@ -97,5 +99,5 @@ jobs:
       with:
         workflow: deploy-k8s.yml
         token: ${{ secrets.pat }}
-        ref: ${{ github.ref }}
+        ref: ${{ github.ref || github.base_ref }}
         inputs: '{"release": "${{needs.build.outputs.release}}", "status": "passed" }'    

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -99,5 +99,5 @@ jobs:
       with:
         workflow: deploy-k8s.yml
         token: ${{ secrets.pat }}
-        ref: ${{ github.ref || github.base_ref }}
+        ref: ${{ format('{{0}{1}}}', github.ref, github.head_ref) }}
         inputs: '{"release": "${{needs.build.outputs.release}}", "status": "passed" }'    

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -99,5 +99,5 @@ jobs:
       with:
         workflow: deploy-k8s.yml
         token: ${{ secrets.pat }}
-        ref: ${{ format('{{0}{1}}}', github.ref, github.head_ref) }}
+        ref: ${{ format('{{{0}{1}}}', github.ref, github.head_ref) }}
         inputs: '{"release": "${{needs.build.outputs.release}}", "status": "passed" }'    

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -99,5 +99,5 @@ jobs:
       with:
         workflow: deploy-k8s.yml
         token: ${{ secrets.pat }}
-        ref: ${{ format('{{{0}{1}}}', github.ref, github.head_ref) }}
+        ref: ${{ format('{{{0}{1}}}', github.ref?, github.head_ref?) }}
         inputs: '{"release": "${{needs.build.outputs.release}}", "status": "passed" }'    

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -99,5 +99,5 @@ jobs:
       with:
         workflow: deploy-k8s.yml
         token: ${{ secrets.pat }}
-        ref: ${{ format('{{{0}{1}}}', github.ref?, github.head_ref?) }}
+        ref: ${{ github.event.pull_request.head.ref || github.ref }}
         inputs: '{"release": "${{needs.build.outputs.release}}", "status": "passed" }'    

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+deployment-settings.yml
 npm-debug.log
 .DS_Store
 node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.18-alpine
+FROM node:14.17.6-alpine
 ENV NODE_ENV production
 ## Set the Labels
 LABEL version="1.0" \

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The App listens to the following webhook events and does the following:
 
 - **push**: If settings are created or settings are modified, that is, if  push happens in the `default` branch of the `admin` repo and the file added or changed is `.github/settings.yml` or `.github/repos/*.yml`or `.github/suborgs/*.yml`, then the settings would be applied either globally to all the repos, or specific repos. For each repo the settings that would be applied depend on the default settings for the org, overlayed with settings for the suborg that the repo belongs to, overlayed with the settings for that specific repo.
   
-- **repository.created**: If a repository is created in the org, the settings for the repo - the default settings for the org, overlayed with settings for the suborg that the repo belongs to, overlayed with the settings for that specific repo - is applied. To prevent `infinite loop` if the repo created event is trigged by itself(bot), it would be ignored. This ensures that the policy is enforced even to nee repositories.
+- **repository.created**: If a repository is created in the org, the settings for the repo - the default settings for the org, overlayed with settings for the suborg that the repo belongs to, overlayed with the settings for that specific repo - is applied. To prevent `infinite loop` if the repo created event is trigged by itself(bot), it would be ignored. This ensures that the policy is enforced even to a single repositories.
 
 - **repository.edited**: If the `default` branch is changed if the the settings that would be applied for the repo
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,6 @@ It is loosely based on [Settings Probot](https://github.com/probot/settings) Git
 1. `Safe-settings` explicitly looks in the `admin` repo in the organization for the settings files. The `admin` repo should be a restricted repository with `branch protections` and `codeowners` . 
 1. To address the scalability concerns for large organizations having thousands of repos, it is recommended to break the settings into org-level, suborg-level, and repo-level units. This will allow different teams to be define and manage policies for their specific projects or business units.
 
-
-
-## Table of Contents
-[TOC]
-
-
 ## How it works
 
 The App listens to the following webhook events and does the following:

--- a/README.md
+++ b/README.md
@@ -83,9 +83,6 @@ repository:
   # Either `true` to enable the wiki for this repository, `false` to disable it.
   has_wiki: true
   
-  # Either `true` to enable downloads for this repository, `false` to disable them.
-  has_downloads: true
-  
   # The default branch for this repository.
   default_branch: main-enterprise
   
@@ -273,9 +270,6 @@ repository:
   # Either `true` to enable the wiki for this repository, `false` to disable it.
   has_wiki: true
   
-  # Either `true` to enable downloads for this repository, `false` to disable them.
-  has_downloads: true
-  
   # The default branch for this repository.
   default_branch: main-enterprise
   
@@ -448,9 +442,6 @@ repository:
   
   # Either `true` to enable the wiki for this repository, `false` to disable it.
   has_wiki: true
-  
-  # Either `true` to enable downloads for this repository, `false` to disable them.
-  has_downloads: true
   
   # The default branch for this repository.
   default_branch: main-enterprise

--- a/README.md
+++ b/README.md
@@ -10,22 +10,30 @@ It is loosely based on [Settings Probot](https://github.com/probot/settings) Git
 1. In `safe-settings` all the settings are stored centrally in an `admin` repo within the organization. 
 1. There are 3 levels at which the settings could be managed:
    1. Org-level settings are defined in `.github/settings.yml` 
-   1. The org-level settings could be overridden at a  `suborg` level. These would be a collection of repos belonging to a project or a business unit, or a team. The `suborg`settings reside in the `.github/suborgs`folder.
+   1. The org-level settings could be overridden at a  `suborg` level. A `suborg` is an arbitrary collection of repos belonging to projects, business units, or teams. The `suborg`settings reside in the `.github/suborgs`folder.
    1. Lastly, we could override settings for individual repos by creating a repo specific yaml in `.github/repos`folder
 1. `Safe-settings` explicitly looks in the `admin` repo in the organization for the settings files. The `admin` repo should be a restricted repository with `branch protections` and `codeowners` . 
 1. To address the scalability concerns for large organizations having thousands of repos, it is recommended to break the settings into org-level, suborg-level, and repo-level units. This will allow different teams to be define and manage policies for their specific projects or business units.
 
 ## How it works
 
+### Events
 The App listens to the following webhook events and does the following:
 
-- **push**: If settings are created or settings are modified, that is, if  push happens in the `default` branch of the `admin` repo and the file added or changed is `.github/settings.yml` or `.github/repos/*.yml`or `.github/suborgs/*.yml`, then the settings would be applied either globally to all the repos, or specific repos. For each repo the settings that would be applied depend on the default settings for the org, overlayed with settings for the suborg that the repo belongs to, overlayed with the settings for that specific repo.
+- **push**: If the settings are created or modified, that is, if  push happens in the `default` branch of the `admin` repo and the file added or changed is `.github/settings.yml` or `.github/repos/*.yml`or `.github/suborgs/*.yml`, then the settings would be applied either globally to all the repos, or specific repos. For each repo, the settings that is actually applied depend on the default settings for the org, overlayed with settings for the suborg that the repo belongs to, overlayed with the settings for that specific repo.
   
-- **repository.created**: If a repository is created in the org, the settings for the repo - the default settings for the org, overlayed with settings for the suborg that the repo belongs to, overlayed with the settings for that specific repo - is applied. To prevent `infinite loop` if the repo created event is trigged by itself(bot), it would be ignored. This ensures that the policy is enforced even to a single repositories.
+- **repository.created**: If a repository is created in the org, the settings for the repo - the default settings for the org, overlayed with settings for the suborg that the repo belongs to, overlayed with the settings for that specific repo - is applied. 
+
+- **branch_protection_rule**: If a branch protection rule is modified or deleted, `safe-settings` will `sync` the settings to prevent any unauthorized changes.
 
 - **repository.edited**: If the `default` branch is changed if the the settings that would be applied for the repo
 
+- **pull_request.opened**, **pull_request.reopened**, **check_suite.requested**: If the settings are changed, but it is not in the `default` branch, and there is an existing PR, the code will validate the settings changes by running safe-settings in `nop` mode and update the PR with the `dry-run` status. 
+
 **Exceptions:** Certain repos may be exempted by specifying them in a runtime config file called `depolyment-settings.yml`. If no file is specified, then the following repositories -  `'admin', '.github', 'safe-settings'` are exempted by default.
+
+### NOP/Dry-run mode
+When a changes happen to the settings files and there is a PR for merging the changes back to the `default` branch in the `admin` repo, `safe-settings` will run in a `**nop**` mode. The code will be executed but no API would be called; instead, the API calls and the Payload would be logged and the potential impact of the change will be displayed in the PR
 
 ## How to use
 
@@ -33,9 +41,9 @@ The App listens to the following webhook events and does the following:
 1. Create an `admin` repo within your organization (the repository must be called `admin`).
 2. Add the files for `org`,`suborg`, and `repo` settings.
 
-### Settings files
+### Settings file
 
-**.github/settings.yml:** This is the org-level settings file. The  `.github/settings.yml` file can have the following sections: 
+The settings file can have the following sections:
 1. The `repository`section contains the settings that would be applied to all the repositories in the org
 2. The `labels` section contains that labels that need to be created for all the repositories in the org
 4. The `collaborators` section contains the list of collaborators that need to be added to all the repositories in the org. It is possible to provide an `include` or `exclude` settings to restrict the collaborator to a list of repos or exclude a set of repos for a collaborator.
@@ -43,6 +51,7 @@ The App listens to the following webhook events and does the following:
 6. The `branches`section contains the list of `branch protections` that need to be applied to all the repos in the org.
 7. If the name of the branch is `default` in the settings, it is applied to the `default` branch of the repo.
 8. `Validator`section to validate repo names using `regex`patterns
+
 
 ```yaml
 # These settings are synced to GitHub by https://github.com/github/safe-settings
@@ -214,364 +223,29 @@ validator:
   #pattern: '[a-zA-Z0-9_-]+_[a-zA-Z0-9_-]+.*' 
   pattern: '[a-zA-Z0-9_-]+'
 ```
-**.github/suborgs/*.yml:** These files are for suborg settings. The file can have the following sections: 
 
+In addition to these settings, **.github/suborgs/\*.yml** can also have the following settings:
 1. The `suborgrepos`section contains list of repositories that belong to the suborg. The repo names could be a `Glob` pattern to allow wild-card expression to specify repos in a suborg
 2. The `suborgteams` section contains a list of teams whose repos belong to the suborg
-3. The `repository`section contains the settings that would be applied to all the repositories in the suborg
-4. The `labels` section contains that labels that need to be created for all the repositories in the suborg
-5. The `collaborators` section contains the list of collaborators that need to be added to all the repositories in the suborg. It is possible to provide an `include` or `exclude` settings to restrict the collaborator to a list of repos or exclude a set of repos for a collaborator.
-6. The `teams` section contains the list of teams that need to be added to all the repositories in the suborg.
-7. The `branches`section contains the list of `branch protections` that need to be applied to all the repos in the suborg.
-8. If the name of the branch is `default` in the settings, it is applied to the `default` branch of the repo.
 
 
-```yaml
-suborgrepos: 
-- new-repo
-- test* 
-
-suborgteams:
-- core
-
-repository: 
-  # This is the settings that need to be applied to all repositories in the suborg 
-  # See https://developer.github.com/v3/repos/#edit for all available settings for a repository  
-  # A short description of the repository that will show up on GitHub
-  description: description of the repo
-  
-  # A URL with more information about the repository
-  homepage: https://example.github.io/
-    
-  # Keep this as true for most cases
-  # A lot of the policies below cannot be implemented on bare repos
-  # Pass true to create an initial commit with empty README.
-  auto_init: true
-    
-  # A comma-separated list of topics to set on the repository
-  topics: github, probot, new-topic, another-topic, topic-12
-  
-  # Either `true` to make the repository private, or `false` to make it public. 
-  # If this value is changed and if Org members cannot change the visibility of repos
-  # it would result in an error when updating a repo
-  private: true
-  
-  # Can be public or private. If your organization is associated with an enterprise account using 
-  # GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+, visibility can also be internal. 
-  visibility: private
-  
-  # Either `true` to enable issues for this repository, `false` to disable them.
-  has_issues: true
-  
-  # Either `true` to enable projects for this repository, or `false` to disable them.
-  # If projects are disabled for the organization, passing `true` will cause an API error.
-  has_projects: true
-  
-  # Either `true` to enable the wiki for this repository, `false` to disable it.
-  has_wiki: true
-  
-  # The default branch for this repository.
-  default_branch: main-enterprise
-  
-  # Desired language or platform [.gitignore template](https://github.com/github/gitignore) 
-  # to apply. Use the name of the template without the extension. 
-  # For example, "Haskell".
-  gitignore_template: node
-  
-  # Choose an [open source license template](https://choosealicense.com/) 
-  # that best suits your needs, and then use the 
-  # [license keyword](https://help.github.com/articles/licensing-a-repository/#searching-github-by-license-type) 
-  # as the `license_template` string. For example, "mit" or "mpl-2.0".
-  license_template: mit
-  
-  # Either `true` to allow squash-merging pull requests, or `false` to prevent
-  # squash-merging.
-  allow_squash_merge: true
-  
-  # Either `true` to allow merging pull requests with a merge commit, or `false`
-  # to prevent merging pull requests with merge commits.
-  allow_merge_commit: true
-  
-  # Either `true` to allow rebase-merging pull requests, or `false` to prevent
-  # rebase-merging.
-  allow_rebase_merge: true
-  
-  # Either `true` to allow auto-merge on pull requests, 
-  # or `false` to disallow auto-merge.
-  # Default: `false`
-  allow_auto_merge: true
-  
-  # Either `true` to allow automatically deleting head branches 
-  # when pull requests are merged, or `false` to prevent automatic deletion.
-  # Default: `false`
-  delete_branch_on_merge: true  
-  
-# The following attributes are applied to any repo within the suborg
-# So if a repo is not listed above is created or edited
-# The app will apply the following settings to it
-labels:
-  # Labels: define labels for Issues and Pull Requests
-  - name: bug
-    color: CC0000
-    description: An issue with the system
-
-  - name: feature
-    # If including a `#`, make sure to wrap it with quotes!
-    color: '#336699'
-    description: New functionality.
-
-  - name: first-timers-only
-    # include the old name to rename an existing label
-    oldname: Help Wanted
-    color: '#326699'
-  - name: new-label
-    # include the old name to rename an existing label
-    oldname: Help Wanted
-    color: '#326699'
-
-collaborators:
-# Collaborators: give specific users access to any repository.
-# See https://developer.github.com/v3/repos/collaborators/#add-user-as-a-collaborator for available options
-
-- username: regpaco
-  permission: push
-# The permission to grant the collaborator. Can be one of:
-# * `pull` - can pull, but not push to or administer this repository.
-# * `push` - can pull and push, but not administer this repository.
-# * `admin` - can pull, push and administer this repository.
-- username: beetlejuice
-  permission: pull
-  exclude:
-  - actions-demo
-# You can exclude a list of repos for this collaborator and all repos except these repos would have this collaborator
-- username: thor
-  permission: push
-  include:
-  - actions-demo
-  - another-repo
-# You can include a list of repos for this collaborator and only those repos would have this collaborator
-
-# See https://developer.github.com/v3/teams/#add-or-update-team-repository for available options
-teams:
-  - name: core
-    # The permission to grant the team. Can be one of:
-    # * `pull` - can pull, but not push to or administer this repository.
-    # * `push` - can pull and push, but not administer this repository.
-    # * `admin` - can pull, push and administer this repository.
-    permission: admin
-  - name: docss
-    permission: push
-  - name: docs
-    permission: pull
-
-branches:
-  # If the name of the branch is default, it will create a branch protection for the default branch in the repo
-  - name: default
-    # https://developer.github.com/v3/repos/branches/#update-branch-protection
-    # Branch Protection settings. Set to null to disable
-    protection:
-      # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.
-      required_pull_request_reviews:
-        # The number of approvals required. (1-6)
-        required_approving_review_count: 1
-        # Dismiss approved reviews automatically when a new commit is pushed.
-        dismiss_stale_reviews: true
-        # Blocks merge until code owners have reviewed.
-        require_code_owner_reviews: true
-        # Specify which users and teams can dismiss pull request reviews. Pass an empty dismissal_restrictions object to disable. User and team dismissal_restrictions are only available for organization-owned repositories. Omit this parameter for personal repositories.
-        dismissal_restrictions:
-          users: []
-          teams: []
-      # Required. Require status checks to pass before merging. Set to null to disable
-      required_status_checks:
-        # Required. Require branches to be up to date before merging.
-        strict: true
-        # Required. The list of status checks to require in order to merge into this branch
-        contexts: []
-      # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
-      enforce_admins: true
-      # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
-      restrictions:
-        apps: []
-        users: []
-        teams: []
-        
-validator:
-  #pattern: '[a-zA-Z0-9_-]+_[a-zA-Z0-9_-]+.*' 
-  pattern: '[a-zA-Z0-9_-]+'
+### Env variables
+1. __CRON__ you can pass a cron input to run `safe-settings` at a regular cadence. This is based on [node-cron](https://www.npmjs.com/package/node-cron). For eg.
 ```
-
-**.github/repos/*.yml:** These files are for repo settings. Each file is for a specific repo. The file can have the following sections: 
-
-1. The `repository`section contains the settings for that specific repository.
-1. The rest of the sections could be `labels`,`collaborators`, `teams`, `branches`, `Validator` and they would be applied to that specific repo only.
-
-```yaml
-repository: 
-  # This is the settings that need to be applied to all repositories in the org 
-  # See https://developer.github.com/v3/repos/#edit for all available settings for a repository  
-  # A short description of the repository that will show up on GitHub
-  description: description of the repo
-  
-  # A URL with more information about the repository
-  homepage: https://example.github.io/
-    
-  # Keep this as true for most cases
-  # A lot of the policies below cannot be implemented on bare repos
-  # Pass true to create an initial commit with empty README.
-  auto_init: true
-    
-  # A comma-separated list of topics to set on the repository
-  topics: github, probot, new-topic, another-topic, topic-12
-  
-  # Either `true` to make the repository private, or `false` to make it public. 
-  # If this value is changed and if Org members cannot change the visibility of repos
-  # it would result in an error when updating a repo
-  private: true
-  
-  # Can be public or private. If your organization is associated with an enterprise account using 
-  # GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+, visibility can also be internal. 
-  visibility: private
-  
-  # Either `true` to enable issues for this repository, `false` to disable them.
-  has_issues: true
-  
-  # Either `true` to enable projects for this repository, or `false` to disable them.
-  # If projects are disabled for the organization, passing `true` will cause an API error.
-  has_projects: true
-  
-  # Either `true` to enable the wiki for this repository, `false` to disable it.
-  has_wiki: true
-  
-  # The default branch for this repository.
-  default_branch: main-enterprise
-  
-  # Desired language or platform [.gitignore template](https://github.com/github/gitignore) 
-  # to apply. Use the name of the template without the extension. 
-  # For example, "Haskell".
-  gitignore_template: node
-  
-  # Choose an [open source license template](https://choosealicense.com/) 
-  # that best suits your needs, and then use the 
-  # [license keyword](https://help.github.com/articles/licensing-a-repository/#searching-github-by-license-type) 
-  # as the `license_template` string. For example, "mit" or "mpl-2.0".
-  license_template: mit
-  
-  # Either `true` to allow squash-merging pull requests, or `false` to prevent
-  # squash-merging.
-  allow_squash_merge: true
-  
-  # Either `true` to allow merging pull requests with a merge commit, or `false`
-  # to prevent merging pull requests with merge commits.
-  allow_merge_commit: true
-  
-  # Either `true` to allow rebase-merging pull requests, or `false` to prevent
-  # rebase-merging.
-  allow_rebase_merge: true
-  
-  # Either `true` to allow auto-merge on pull requests, 
-  # or `false` to disallow auto-merge.
-  # Default: `false`
-  allow_auto_merge: true
-  
-  # Either `true` to allow automatically deleting head branches 
-  # when pull requests are merged, or `false` to prevent automatic deletion.
-  # Default: `false`
-  delete_branch_on_merge: true  
-
-# The following attributes are applied to any repo within the org
-# So if a repo is not listed above is created or edited
-# The app will apply the following settings to it
-labels:
-  # Labels: define labels for Issues and Pull Requests
-  - name: bug
-    color: CC0000
-    description: An issue with the system
-
-  - name: feature
-    # If including a `#`, make sure to wrap it with quotes!
-    color: '#336699'
-    description: New functionality.
-
-  - name: first-timers-only
-    # include the old name to rename an existing label
-    oldname: Help Wanted
-    color: '#326699'
-  - name: new-label
-    # include the old name to rename an existing label
-    oldname: Help Wanted
-    color: '#326699'
-
-collaborators:
-# Collaborators: give specific users access to any repository.
-# See https://developer.github.com/v3/repos/collaborators/#add-user-as-a-collaborator for available options
-
-- username: regpaco
-  permission: push
-# The permission to grant the collaborator. Can be one of:
-# * `pull` - can pull, but not push to or administer this repository.
-# * `push` - can pull and push, but not administer this repository.
-# * `admin` - can pull, push and administer this repository.
-- username: beetlejuice
-  permission: pull
-  exclude:
-  - actions-demo
-# You can exclude a list of repos for this collaborator and all repos except these repos would have this collaborator
-- username: thor
-  permission: push
-  include:
-  - actions-demo
-  - another-repo
-# You can include a list of repos for this collaborator and only those repos would have this collaborator
-
-# See https://developer.github.com/v3/teams/#add-or-update-team-repository for available options
-teams:
-  - name: core
-    # The permission to grant the team. Can be one of:
-    # * `pull` - can pull, but not push to or administer this repository.
-    # * `push` - can pull and push, but not administer this repository.
-    # * `admin` - can pull, push and administer this repository.
-    permission: admin
-  - name: docss
-    permission: push
-  - name: docs
-    permission: pull
-
-branches:
-  # If the name of the branch is default, it will create a branch protection for the default branch in the repo
-  - name: default
-    # https://developer.github.com/v3/repos/branches/#update-branch-protection
-    # Branch Protection settings. Set to null to disable
-    protection:
-      # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.
-      required_pull_request_reviews:
-        # The number of approvals required. (1-6)
-        required_approving_review_count: 1
-        # Dismiss approved reviews automatically when a new commit is pushed.
-        dismiss_stale_reviews: true
-        # Blocks merge until code owners have reviewed.
-        require_code_owner_reviews: true
-        # Specify which users and teams can dismiss pull request reviews. Pass an empty dismissal_restrictions object to disable. User and team dismissal_restrictions are only available for organization-owned repositories. Omit this parameter for personal repositories.
-        dismissal_restrictions:
-          users: []
-          teams: []
-      # Required. Require status checks to pass before merging. Set to null to disable
-      required_status_checks:
-        # Required. Require branches to be up to date before merging.
-        strict: true
-        # Required. The list of status checks to require in order to merge into this branch
-        contexts: []
-      # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
-      enforce_admins: true
-      # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
-      restrictions:
-        apps: []
-        users: []
-        teams: []
-        
-validator:
-  #pattern: '[a-zA-Z0-9_-]+_[a-zA-Z0-9_-]+.*' 
-  pattern: '[a-zA-Z0-9_-]+'
+# ┌────────────── second (optional)
+# │ ┌──────────── minute
+# │ │ ┌────────── hour
+# │ │ │ ┌──────── day of month
+# │ │ │ │ ┌────── month
+# │ │ │ │ │ ┌──── day of week
+# │ │ │ │ │ │
+# │ │ │ │ │ │
+# * * * * * *
+CRON=* * * * * # Run every minute
+```
+1. Logging level could be set using **LOG_LEVEL**. For e.g.
+```
+LOG_LEVEL=trace
 ```
 
 ### Runtime Settings 
@@ -579,6 +253,7 @@ validator:
 1. Besides the above settings files, the application can be bootstrapped with `runtime` settings.
 2. The `runtime` settings are configured in `deployment-settings.yml` that is in the directory from where the GitHub app is running.
 3. Currently the only setting that is possible are `restrictedRepos: [... ]` which allows you to configure a list of repos within your `org` that are excluded from the settings. If the `deployment-settings.yml` is not present, the following repos are added by default to the `restricted`repos list: `'admin', '.github', 'safe-settings'`
+
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GitHub Safe-Settings
 
 [![Node.js CI](https://github.com/github/safe-settings/actions/workflows/node-ci.yml/badge.svg)](https://github.com/github/safe-settings/actions/workflows/node-ci.yml)
-[![Dependabot][dependabot-badge]][dependabot-link]
+[![Dependabot](https://badgen.net/dependabot/probot/settings/?icon=dependabot)](https://dependabot.com/)
 
 `Safe-settings`– an app to manage policy-as-code and apply repository settings to repositories across an organization.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GitHub Safe-Settings
 
 [![Node.js CI](https://github.com/github/safe-settings/actions/workflows/node-ci.yml/badge.svg)](https://github.com/github/safe-settings/actions/workflows/node-ci.yml)
-[![Dependabot](https://badgen.net/dependabot/probot/settings/?icon=dependabot)](https://dependabot.com/)
+[![Dependabot][dependabot-badge]][dependabot-link]
 
 `Safe-settings`– an app to manage policy-as-code and apply repository settings to repositories across an organization.
 
@@ -291,7 +291,7 @@ LOG_LEVEL=trace
 
 2. Create an `admin` repo within your organization (the repository must be called `admin`). 
 
-3. Add the settings for the `org`, `suborgs`, and `repos` . List of sample files could be found here.
+3. Add the settings for the `org`, `suborgs`, and `repos` . List of sample files could be found [here](docs/sample-settings).
 
    
 

--- a/README.md
+++ b/README.md
@@ -36,22 +36,92 @@ The App listens to the following webhook events and does the following:
 ### Settings files
 
 **.github/settings.yml:** This is the org-level settings file. The  `.github/settings.yml` file can have the following sections: 
-1. The `repositories`section contains repositories that need to be configured explicitly. This is kept for backward compatibility and is usually left blank as the repository settings are done seperately.
-1. The `labels` section contains that labels that need to be created for all the repositories in the org
-1. The `collaborators` section contains the list of collaborators that need to be added to all the repositories in the org. It is possible to provide an `include` or `exclude` settings to restrict the collaborator to a list of repos or exclude a set of repos for a collaborator.
-1. The `teams` section contains the list of teams that need to be added to all the repositories in the org.
-1. The `branches`section contains the list of `branch protections` that need to be applied to all the repos in the org.
-1. If the name of the branch is `default` in the settings, it is applied to the `default` branch of the repo.
-1. `Validator`section to validate repo names using `regex`patterns
+1. The `repository`section contains the settings that would be applied to all the repositories in the org
+2. The `labels` section contains that labels that need to be created for all the repositories in the org
+4. The `collaborators` section contains the list of collaborators that need to be added to all the repositories in the org. It is possible to provide an `include` or `exclude` settings to restrict the collaborator to a list of repos or exclude a set of repos for a collaborator.
+5. The `teams` section contains the list of teams that need to be added to all the repositories in the org.
+6. The `branches`section contains the list of `branch protections` that need to be applied to all the repos in the org.
+7. If the name of the branch is `default` in the settings, it is applied to the `default` branch of the repo.
+8. `Validator`section to validate repo names using `regex`patterns
 
 ```yaml
-# These settings are synced by https://github.com/github/safe-settings
-# The `repositories` section contains repositories that need to be configured explicitly
-#
-# The `labels` section 
+# These settings are synced to GitHub by https://github.com/github/safe-settings
 
-repositories: []
- 
+repository: 
+  # This is the settings that need to be applied to all repositories in the org 
+  # See https://developer.github.com/v3/repos/#edit for all available settings for a repository  
+  # A short description of the repository that will show up on GitHub
+  description: description of the repo
+  
+  # A URL with more information about the repository
+  homepage: https://example.github.io/
+    
+  # Keep this as true for most cases
+  # A lot of the policies below cannot be implemented on bare repos
+  # Pass true to create an initial commit with empty README.
+  auto_init: true
+    
+  # A comma-separated list of topics to set on the repository
+  topics: github, probot, new-topic, another-topic, topic-12
+  
+  # Either `true` to make the repository private, or `false` to make it public. 
+  # If this value is changed and if Org members cannot change the visibility of repos
+  # it would result in an error when updating a repo
+  private: true
+  
+  # Can be public or private. If your organization is associated with an enterprise account using 
+  # GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+, visibility can also be internal. 
+  visibility: private
+  
+  # Either `true` to enable issues for this repository, `false` to disable them.
+  has_issues: true
+  
+  # Either `true` to enable projects for this repository, or `false` to disable them.
+  # If projects are disabled for the organization, passing `true` will cause an API error.
+  has_projects: true
+  
+  # Either `true` to enable the wiki for this repository, `false` to disable it.
+  has_wiki: true
+  
+  # Either `true` to enable downloads for this repository, `false` to disable them.
+  has_downloads: true
+  
+  # The default branch for this repository.
+  default_branch: main-enterprise
+  
+  # Desired language or platform [.gitignore template](https://github.com/github/gitignore) 
+  # to apply. Use the name of the template without the extension. 
+  # For example, "Haskell".
+  gitignore_template: node
+  
+  # Choose an [open source license template](https://choosealicense.com/) 
+  # that best suits your needs, and then use the 
+  # [license keyword](https://help.github.com/articles/licensing-a-repository/#searching-github-by-license-type) 
+  # as the `license_template` string. For example, "mit" or "mpl-2.0".
+  license_template: mit
+  
+  # Either `true` to allow squash-merging pull requests, or `false` to prevent
+  # squash-merging.
+  allow_squash_merge: true
+  
+  # Either `true` to allow merging pull requests with a merge commit, or `false`
+  # to prevent merging pull requests with merge commits.
+  allow_merge_commit: true
+  
+  # Either `true` to allow rebase-merging pull requests, or `false` to prevent
+  # rebase-merging.
+  allow_rebase_merge: true
+  
+  # Either `true` to allow auto-merge on pull requests, 
+  # or `false` to disallow auto-merge.
+  # Default: `false`
+  allow_auto_merge: true
+  
+  # Either `true` to allow automatically deleting head branches 
+  # when pull requests are merged, or `false` to prevent automatic deletion.
+  # Default: `false`
+  delete_branch_on_merge: true  
+      
 # The following attributes are applied to any repo within the org
 # So if a repo is not listed above is created or edited
 # The app will apply the following settings to it
@@ -150,7 +220,13 @@ validator:
 **.github/suborgs/*.yml:** These files are for suborg settings. The file can have the following sections: 
 
 1. The `suborgrepos`section contains list of repositories that belong to the suborg. The repo names could be a `Glob` pattern to allow wild-card expression to specify repos in a suborg
-1. The rest of the sections could be `labels`,`collaborators`, `teams`, `branches`, `Validator` and they would be applied to all the repos in the `suborg`
+2. The `suborgteams` section contains a list of teams whose repos belong to the suborg
+3. The `repository`section contains the settings that would be applied to all the repositories in the suborg
+4. The `labels` section contains that labels that need to be created for all the repositories in the suborg
+5. The `collaborators` section contains the list of collaborators that need to be added to all the repositories in the suborg. It is possible to provide an `include` or `exclude` settings to restrict the collaborator to a list of repos or exclude a set of repos for a collaborator.
+6. The `teams` section contains the list of teams that need to be added to all the repositories in the suborg.
+7. The `branches`section contains the list of `branch protections` that need to be applied to all the repos in the suborg.
+8. If the name of the branch is `default` in the settings, it is applied to the `default` branch of the repo.
 
 
 ```yaml
@@ -158,6 +234,84 @@ suborgrepos:
 - new-repo
 - test* 
 
+suborgteams:
+- core
+
+repository: 
+  # This is the settings that need to be applied to all repositories in the suborg 
+  # See https://developer.github.com/v3/repos/#edit for all available settings for a repository  
+  # A short description of the repository that will show up on GitHub
+  description: description of the repo
+  
+  # A URL with more information about the repository
+  homepage: https://example.github.io/
+    
+  # Keep this as true for most cases
+  # A lot of the policies below cannot be implemented on bare repos
+  # Pass true to create an initial commit with empty README.
+  auto_init: true
+    
+  # A comma-separated list of topics to set on the repository
+  topics: github, probot, new-topic, another-topic, topic-12
+  
+  # Either `true` to make the repository private, or `false` to make it public. 
+  # If this value is changed and if Org members cannot change the visibility of repos
+  # it would result in an error when updating a repo
+  private: true
+  
+  # Can be public or private. If your organization is associated with an enterprise account using 
+  # GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+, visibility can also be internal. 
+  visibility: private
+  
+  # Either `true` to enable issues for this repository, `false` to disable them.
+  has_issues: true
+  
+  # Either `true` to enable projects for this repository, or `false` to disable them.
+  # If projects are disabled for the organization, passing `true` will cause an API error.
+  has_projects: true
+  
+  # Either `true` to enable the wiki for this repository, `false` to disable it.
+  has_wiki: true
+  
+  # Either `true` to enable downloads for this repository, `false` to disable them.
+  has_downloads: true
+  
+  # The default branch for this repository.
+  default_branch: main-enterprise
+  
+  # Desired language or platform [.gitignore template](https://github.com/github/gitignore) 
+  # to apply. Use the name of the template without the extension. 
+  # For example, "Haskell".
+  gitignore_template: node
+  
+  # Choose an [open source license template](https://choosealicense.com/) 
+  # that best suits your needs, and then use the 
+  # [license keyword](https://help.github.com/articles/licensing-a-repository/#searching-github-by-license-type) 
+  # as the `license_template` string. For example, "mit" or "mpl-2.0".
+  license_template: mit
+  
+  # Either `true` to allow squash-merging pull requests, or `false` to prevent
+  # squash-merging.
+  allow_squash_merge: true
+  
+  # Either `true` to allow merging pull requests with a merge commit, or `false`
+  # to prevent merging pull requests with merge commits.
+  allow_merge_commit: true
+  
+  # Either `true` to allow rebase-merging pull requests, or `false` to prevent
+  # rebase-merging.
+  allow_rebase_merge: true
+  
+  # Either `true` to allow auto-merge on pull requests, 
+  # or `false` to disallow auto-merge.
+  # Default: `false`
+  allow_auto_merge: true
+  
+  # Either `true` to allow automatically deleting head branches 
+  # when pull requests are merged, or `false` to prevent automatic deletion.
+  # Default: `false`
+  delete_branch_on_merge: true  
+  
 # The following attributes are applied to any repo within the suborg
 # So if a repo is not listed above is created or edited
 # The app will apply the following settings to it
@@ -259,56 +413,80 @@ validator:
 1. The rest of the sections could be `labels`,`collaborators`, `teams`, `branches`, `Validator` and they would be applied to that specific repo only.
 
 ```yaml
-repository:
-  # See https://developer.github.com/v3/repos/#edit for all available settings for a repository
-    name: new-repo
+repository: 
+  # This is the settings that need to be applied to all repositories in the org 
+  # See https://developer.github.com/v3/repos/#edit for all available settings for a repository  
+  # A short description of the repository that will show up on GitHub
+  description: description of the repo
+  
+  # A URL with more information about the repository
+  homepage: https://example.github.io/
     
-    # The Organization the repo belongs to
-    org: github
+  # Keep this as true for most cases
+  # A lot of the policies below cannot be implemented on bare repos
+  # Pass true to create an initial commit with empty README.
+  auto_init: true
     
-    # A short description of the repository that will show up on GitHub
-    description: description of the repo
+  # A comma-separated list of topics to set on the repository
+  topics: github, probot, new-topic, another-topic, topic-12
   
-    # A URL with more information about the repository
-    homepage: https://example.github.io/
-    
-    # Keep this as true for most cases
-    # A lot of the policies below cannot be implemented on bare repos
-    auto_init: true
-    
-    # A comma-separated list of topics to set on the repository
-    topics: github, probot, new-topic, another-topic, topic-12
+  # Either `true` to make the repository private, or `false` to make it public. 
+  # If this value is changed and if Org members cannot change the visibility of repos
+  # it would result in an error when updating a repo
+  private: true
   
-    # Either `true` to make the repository private, or `false` to make it public. 
-    private: false
+  # Can be public or private. If your organization is associated with an enterprise account using 
+  # GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+, visibility can also be internal. 
+  visibility: private
   
-    # Either `true` to enable issues for this repository, `false` to disable them.
-    has_issues: true
+  # Either `true` to enable issues for this repository, `false` to disable them.
+  has_issues: true
   
-    # Either `true` to enable projects for this repository, or `false` to disable them.
-    # If projects are disabled for the organization, passing `true` will cause an API error.
-    has_projects: true
+  # Either `true` to enable projects for this repository, or `false` to disable them.
+  # If projects are disabled for the organization, passing `true` will cause an API error.
+  has_projects: true
   
-    # Either `true` to enable the wiki for this repository, `false` to disable it.
-    has_wiki: true
+  # Either `true` to enable the wiki for this repository, `false` to disable it.
+  has_wiki: true
   
-    # Either `true` to enable downloads for this repository, `false` to disable them.
-    has_downloads: true
+  # Either `true` to enable downloads for this repository, `false` to disable them.
+  has_downloads: true
   
-    # Updates the default branch for this repository.
-    default_branch: main-enterprise
+  # The default branch for this repository.
+  default_branch: main-enterprise
   
-    # Either `true` to allow squash-merging pull requests, or `false` to prevent
-    # squash-merging.
-    allow_squash_merge: true
+  # Desired language or platform [.gitignore template](https://github.com/github/gitignore) 
+  # to apply. Use the name of the template without the extension. 
+  # For example, "Haskell".
+  gitignore_template: node
   
-    # Either `true` to allow merging pull requests with a merge commit, or `false`
-    # to prevent merging pull requests with merge commits.
-    allow_merge_commit: true
+  # Choose an [open source license template](https://choosealicense.com/) 
+  # that best suits your needs, and then use the 
+  # [license keyword](https://help.github.com/articles/licensing-a-repository/#searching-github-by-license-type) 
+  # as the `license_template` string. For example, "mit" or "mpl-2.0".
+  license_template: mit
   
-    # Either `true` to allow rebase-merging pull requests, or `false` to prevent
-    # rebase-merging.
-    allow_rebase_merge: true
+  # Either `true` to allow squash-merging pull requests, or `false` to prevent
+  # squash-merging.
+  allow_squash_merge: true
+  
+  # Either `true` to allow merging pull requests with a merge commit, or `false`
+  # to prevent merging pull requests with merge commits.
+  allow_merge_commit: true
+  
+  # Either `true` to allow rebase-merging pull requests, or `false` to prevent
+  # rebase-merging.
+  allow_rebase_merge: true
+  
+  # Either `true` to allow auto-merge on pull requests, 
+  # or `false` to disallow auto-merge.
+  # Default: `false`
+  allow_auto_merge: true
+  
+  # Either `true` to allow automatically deleting head branches 
+  # when pull requests are merged, or `false` to prevent automatic deletion.
+  # Default: `false`
+  delete_branch_on_merge: true  
 
 # The following attributes are applied to any repo within the org
 # So if a repo is not listed above is created or edited
@@ -415,6 +593,7 @@ validator:
 
 1. Label color can also start with `#`, e.g. `color: '#F341B2'`. Make sure to wrap it with quotes!
 1. Each top-level element under branch protection must be filled (eg: `required_pull_request_reviews`, `required_status_checks`, `enforce_admins` and `restrictions`). If you don't want to use one of them you must set it to `null` (see comments in the example above). Otherwise, none of the settings will be applied.
+2. The precedence order is repository > suborg > org (.github/repos/*.yml > .github/suborgs/*.yml > .github/settings.yml
 
 ### Inheritance (there is none)
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ labels:
     # include the old name to rename an existing label
     oldname: Help Wanted
     color: '#326699'
+
   - name: new-label
     # include the old name to rename an existing label
     oldname: Help Wanted

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ teams:
     permission: pull
 
 branches:
-  # If the name of the branch is default, it will create a branch protection for the default branch in the repo
+  # If the name of the branch value is specified as `default`, then the app will create a branch protection rule to apply against the default branch in the repo
   - name: default
     # https://developer.github.com/v3/repos/branches/#update-branch-protection
     # Branch Protection settings. Set to null to disable

--- a/README.md
+++ b/README.md
@@ -1,34 +1,54 @@
-# GitHub Safe Settings
+# GitHub Safe-Settings
 
 [![Node.js CI](https://github.com/github/safe-settings/actions/workflows/node-ci.yml/badge.svg)](https://github.com/github/safe-settings/actions/workflows/node-ci.yml)
 [![Dependabot][dependabot-badge]][dependabot-link]
 
-This is a modified version of [Settings Probot](https://github.com/probot/settings) GitHub App. This differs from the original probot settings app in several ways:
+`Safe-settings`– an app to manage policy-as-code and apply repository settings to repositories across an organization.
 
-1. It does not use [probot-config](https://github.com/probot/probot-config). Instead, it reads the settings from `.github/settings.yml` file contained in the `admin` repo in the organization. The `admin` repo should be a restricted repository and contains the settings for all the repos within the organization.
-1. It manages the settings for all the repositories in the organization. Repositories could be explicitly defined in the settings config, but the app also manages any repo that is created in the organization.
-1. It will allow you to set branch protections on the `default` branch no matter what it is called by calling it `default` in `.github/settings.yml`.
+It is loosely based on [Settings Probot](https://github.com/probot/settings) GitHub App. However, it differs from the original probot settings app in several important ways:
 
-## Usage
+1. In `safe-settings` all the settings are stored centrally in an `admin` repo within the organization. 
+1. There are 3 levels at which the settings could be managed:
+   1. Org-level settings are defined in `.github/settings.yml` 
+   1. The org-level settings could be overridden at a  `suborg` level. These would be a collection of repos belonging to a project or a business unit, or a team. The `suborg`settings reside in the `.github/suborgs`folder.
+   1. Lastly, we could override settings for individual repos by creating a repo specific yaml in `.github/repos`folder
+1. `Safe-settings` explicitly looks in the `admin` repo in the organization for the settings files. The `admin` repo should be a restricted repository with `branch protections` and `codeowners` . 
+1. To address the scalability concerns for large organizations having thousands of repos, it is recommended to break the settings into org-level, suborg-level, and repo-level units. This will allow different teams to be define and manage policies for their specific projects or business units.
+
+
+
+## Table of Contents
+[TOC]
+
+
+## How it works
+
+The App listens to the following webhook events and does the following:
+
+- **push**: If settings are created or settings are modified, that is, if  push happens in the `default` branch of the `admin` repo and the file added or changed is `.github/settings.yml` or `.github/repos/*.yml`or `.github/suborgs/*.yml`, then the settings would be applied either globally to all the repos, or specific repos. For each repo the settings that would be applied depend on the default settings for the org, overlayed with settings for the suborg that the repo belongs to, overlayed with the settings for that specific repo.
+  
+- **repository.created**: If a repository is created in the org, the settings for the repo - the default settings for the org, overlayed with settings for the suborg that the repo belongs to, overlayed with the settings for that specific repo - is applied. To prevent `infinite loop` if the repo created event is trigged by itself(bot), it would be ignored. This ensures that the policy is enforced even to nee repositories.
+
+- **repository.edited**: If the `default` branch is changed if the the settings that would be applied for the repo
+
+**Exceptions:** Certain repos may be exempted by specifying them in a runtime config file called `depolyment-settings.yml`. If no file is specified, then the following repositories -  `'admin', '.github', 'safe-settings'` are exempted by default.
+
+## How to use
 
 1. __[Install the app](docs/deploy.md)__.
 1. Create an `admin` repo within your organization (the repository must be called `admin`).
+2. Add the files for `org`,`suborg`, and `repo` settings.
 
-### Config
+### Settings files
 
-1. Create a `.github/settings.yml` file in the `admin` repository. Changes to this file on the default branch will be synced to all the repos in the Org.
-1. The `repositories` section in the `settings` file contains repositories that need to be configured explicitly. If a repository in this section is not present, it would be created according to the configuration. Typical use cases are to configure repo specific items like `topics`, `issues`, `pages`, etc.
+**.github/settings.yml:** This is the org-level settings file. The  `.github/settings.yml` file can have the following sections: 
+1. The `repositories`section contains repositories that need to be configured explicitly. This is kept for backward compatibility and is usually left blank as the repository settings are done seperately.
 1. The `labels` section contains that labels that need to be created for all the repositories in the org
 1. The `collaborators` section contains the list of collaborators that need to be added to all the repositories in the org. It is possible to provide an `include` or `exclude` settings to restrict the collaborator to a list of repos or exclude a set of repos for a collaborator.
 1. The `teams` section contains the list of teams that need to be added to all the repositories in the org.
 1. The `branches`section contains the list of `branch protections` that need to be applied to all the repos in the org.
 1. If the name of the branch is `default` in the settings, it is applied to the `default` branch of the repo.
-
-### Global config
-
-1. Besides the `.github/settings.yml` the application can be bootstrapped with `global` settings.
-2. The `global` settings are configured in `deployment-settings.yml` that is in the directory from where the GitHub app is running.
-3. Currently the only setting that is possible are `restrictedRepos: [... ]` which allows you to configure a list of repos within your `org` that are excluded from the settings. If the `deployment-settings.yml` is not present, the following repos are added by default to the `restricted`repos list: `'admin', '.github', 'safe-settings'`
+1. `Validator`section to validate repo names using `regex`patterns
 
 ```yaml
 # These settings are synced by https://github.com/github/safe-settings
@@ -36,65 +56,7 @@ This is a modified version of [Settings Probot](https://github.com/probot/settin
 #
 # The `labels` section 
 
-repositories: 
-  # If the repository is not listed in the settings.yml, it will be created and synced.
-  # See https://developer.github.com/v3/repos/#edit for all available settings for a repository
-  - name: new-repo
-    
-    # The Organization the repo belongs to
-    org: github
-    
-    # A short description of the repository that will show up on GitHub
-    description: description of the repo
-  
-    # A URL with more information about the repository
-    homepage: https://example.github.io/
-    
-    # Keep this as true for most cases
-    # A lot of the policies below cannot be implemented on bare repos
-    auto_init: true
-    
-    # A comma-separated list of topics to set on the repository
-    topics: github, probot, new-topic, another-topic, topic-12
-  
-    # Either `true` to make the repository private, or `false` to make it public. 
-    private: false
-  
-    # Either `true` to enable issues for this repository, `false` to disable them.
-    has_issues: true
-  
-    # Either `true` to enable projects for this repository, or `false` to disable them.
-    # If projects are disabled for the organization, passing `true` will cause an API error.
-    has_projects: true
-  
-    # Either `true` to enable the wiki for this repository, `false` to disable it.
-    has_wiki: true
-  
-    # Either `true` to enable downloads for this repository, `false` to disable them.
-    has_downloads: true
-  
-    # Updates the default branch for this repository.
-    default_branch: main-enterprise
-  
-    # Either `true` to allow squash-merging pull requests, or `false` to prevent
-    # squash-merging.
-    allow_squash_merge: true
-  
-    # Either `true` to allow merging pull requests with a merge commit, or `false`
-    # to prevent merging pull requests with merge commits.
-    allow_merge_commit: true
-  
-    # Either `true` to allow rebase-merging pull requests, or `false` to prevent
-    # rebase-merging.
-    allow_rebase_merge: true
-    
-  # This is another repo
-  - name: another-repo
-    # Keep this as true as branch protections will not be applied otherwise
-    auto_init: true
-    org: github
-    # A short description of the repository that will show up on GitHub
-    description: description of another repo
+repositories: []
  
 # The following attributes are applied to any repo within the org
 # So if a repo is not listed above is created or edited
@@ -186,8 +148,273 @@ branches:
         users: []
         teams: []
         
-
+validator:
+  #pattern: '[a-zA-Z0-9_-]+_[a-zA-Z0-9_-]+.*' 
+  pattern: '[a-zA-Z0-9_-]+'
 ```
+**.github/suborgs/*.yml:** These files are for suborg settings. The file can have the following sections: 
+
+1. The `suborgrepos`section contains list of repositories that belong to the suborg. The repo names could be a `Glob` pattern to allow wild-card expression to specify repos in a suborg
+1. The rest of the sections could be `labels`,`collaborators`, `teams`, `branches`, `Validator` and they would be applied to all the repos in the `suborg`
+
+
+```yaml
+suborgrepos: 
+- new-repo
+- test* 
+
+# The following attributes are applied to any repo within the suborg
+# So if a repo is not listed above is created or edited
+# The app will apply the following settings to it
+labels:
+  # Labels: define labels for Issues and Pull Requests
+  - name: bug
+    color: CC0000
+    description: An issue with the system
+
+  - name: feature
+    # If including a `#`, make sure to wrap it with quotes!
+    color: '#336699'
+    description: New functionality.
+
+  - name: first-timers-only
+    # include the old name to rename an existing label
+    oldname: Help Wanted
+    color: '#326699'
+  - name: new-label
+    # include the old name to rename an existing label
+    oldname: Help Wanted
+    color: '#326699'
+
+collaborators:
+# Collaborators: give specific users access to any repository.
+# See https://developer.github.com/v3/repos/collaborators/#add-user-as-a-collaborator for available options
+
+- username: regpaco
+  permission: push
+# The permission to grant the collaborator. Can be one of:
+# * `pull` - can pull, but not push to or administer this repository.
+# * `push` - can pull and push, but not administer this repository.
+# * `admin` - can pull, push and administer this repository.
+- username: beetlejuice
+  permission: pull
+  exclude:
+  - actions-demo
+# You can exclude a list of repos for this collaborator and all repos except these repos would have this collaborator
+- username: thor
+  permission: push
+  include:
+  - actions-demo
+  - another-repo
+# You can include a list of repos for this collaborator and only those repos would have this collaborator
+
+# See https://developer.github.com/v3/teams/#add-or-update-team-repository for available options
+teams:
+  - name: core
+    # The permission to grant the team. Can be one of:
+    # * `pull` - can pull, but not push to or administer this repository.
+    # * `push` - can pull and push, but not administer this repository.
+    # * `admin` - can pull, push and administer this repository.
+    permission: admin
+  - name: docss
+    permission: push
+  - name: docs
+    permission: pull
+
+branches:
+  # If the name of the branch is default, it will create a branch protection for the default branch in the repo
+  - name: default
+    # https://developer.github.com/v3/repos/branches/#update-branch-protection
+    # Branch Protection settings. Set to null to disable
+    protection:
+      # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.
+      required_pull_request_reviews:
+        # The number of approvals required. (1-6)
+        required_approving_review_count: 1
+        # Dismiss approved reviews automatically when a new commit is pushed.
+        dismiss_stale_reviews: true
+        # Blocks merge until code owners have reviewed.
+        require_code_owner_reviews: true
+        # Specify which users and teams can dismiss pull request reviews. Pass an empty dismissal_restrictions object to disable. User and team dismissal_restrictions are only available for organization-owned repositories. Omit this parameter for personal repositories.
+        dismissal_restrictions:
+          users: []
+          teams: []
+      # Required. Require status checks to pass before merging. Set to null to disable
+      required_status_checks:
+        # Required. Require branches to be up to date before merging.
+        strict: true
+        # Required. The list of status checks to require in order to merge into this branch
+        contexts: []
+      # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
+      enforce_admins: true
+      # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
+      restrictions:
+        apps: []
+        users: []
+        teams: []
+        
+validator:
+  #pattern: '[a-zA-Z0-9_-]+_[a-zA-Z0-9_-]+.*' 
+  pattern: '[a-zA-Z0-9_-]+'
+```
+
+**.github/repos/*.yml:** These files are for repo settings. Each file is for a specific repo. The file can have the following sections: 
+
+1. The `repository`section contains the settings for that specific repository.
+1. The rest of the sections could be `labels`,`collaborators`, `teams`, `branches`, `Validator` and they would be applied to that specific repo only.
+
+```yaml
+repository:
+  # See https://developer.github.com/v3/repos/#edit for all available settings for a repository
+    name: new-repo
+    
+    # The Organization the repo belongs to
+    org: github
+    
+    # A short description of the repository that will show up on GitHub
+    description: description of the repo
+  
+    # A URL with more information about the repository
+    homepage: https://example.github.io/
+    
+    # Keep this as true for most cases
+    # A lot of the policies below cannot be implemented on bare repos
+    auto_init: true
+    
+    # A comma-separated list of topics to set on the repository
+    topics: github, probot, new-topic, another-topic, topic-12
+  
+    # Either `true` to make the repository private, or `false` to make it public. 
+    private: false
+  
+    # Either `true` to enable issues for this repository, `false` to disable them.
+    has_issues: true
+  
+    # Either `true` to enable projects for this repository, or `false` to disable them.
+    # If projects are disabled for the organization, passing `true` will cause an API error.
+    has_projects: true
+  
+    # Either `true` to enable the wiki for this repository, `false` to disable it.
+    has_wiki: true
+  
+    # Either `true` to enable downloads for this repository, `false` to disable them.
+    has_downloads: true
+  
+    # Updates the default branch for this repository.
+    default_branch: main-enterprise
+  
+    # Either `true` to allow squash-merging pull requests, or `false` to prevent
+    # squash-merging.
+    allow_squash_merge: true
+  
+    # Either `true` to allow merging pull requests with a merge commit, or `false`
+    # to prevent merging pull requests with merge commits.
+    allow_merge_commit: true
+  
+    # Either `true` to allow rebase-merging pull requests, or `false` to prevent
+    # rebase-merging.
+    allow_rebase_merge: true
+
+# The following attributes are applied to any repo within the org
+# So if a repo is not listed above is created or edited
+# The app will apply the following settings to it
+labels:
+  # Labels: define labels for Issues and Pull Requests
+  - name: bug
+    color: CC0000
+    description: An issue with the system
+
+  - name: feature
+    # If including a `#`, make sure to wrap it with quotes!
+    color: '#336699'
+    description: New functionality.
+
+  - name: first-timers-only
+    # include the old name to rename an existing label
+    oldname: Help Wanted
+    color: '#326699'
+  - name: new-label
+    # include the old name to rename an existing label
+    oldname: Help Wanted
+    color: '#326699'
+
+collaborators:
+# Collaborators: give specific users access to any repository.
+# See https://developer.github.com/v3/repos/collaborators/#add-user-as-a-collaborator for available options
+
+- username: regpaco
+  permission: push
+# The permission to grant the collaborator. Can be one of:
+# * `pull` - can pull, but not push to or administer this repository.
+# * `push` - can pull and push, but not administer this repository.
+# * `admin` - can pull, push and administer this repository.
+- username: beetlejuice
+  permission: pull
+  exclude:
+  - actions-demo
+# You can exclude a list of repos for this collaborator and all repos except these repos would have this collaborator
+- username: thor
+  permission: push
+  include:
+  - actions-demo
+  - another-repo
+# You can include a list of repos for this collaborator and only those repos would have this collaborator
+
+# See https://developer.github.com/v3/teams/#add-or-update-team-repository for available options
+teams:
+  - name: core
+    # The permission to grant the team. Can be one of:
+    # * `pull` - can pull, but not push to or administer this repository.
+    # * `push` - can pull and push, but not administer this repository.
+    # * `admin` - can pull, push and administer this repository.
+    permission: admin
+  - name: docss
+    permission: push
+  - name: docs
+    permission: pull
+
+branches:
+  # If the name of the branch is default, it will create a branch protection for the default branch in the repo
+  - name: default
+    # https://developer.github.com/v3/repos/branches/#update-branch-protection
+    # Branch Protection settings. Set to null to disable
+    protection:
+      # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.
+      required_pull_request_reviews:
+        # The number of approvals required. (1-6)
+        required_approving_review_count: 1
+        # Dismiss approved reviews automatically when a new commit is pushed.
+        dismiss_stale_reviews: true
+        # Blocks merge until code owners have reviewed.
+        require_code_owner_reviews: true
+        # Specify which users and teams can dismiss pull request reviews. Pass an empty dismissal_restrictions object to disable. User and team dismissal_restrictions are only available for organization-owned repositories. Omit this parameter for personal repositories.
+        dismissal_restrictions:
+          users: []
+          teams: []
+      # Required. Require status checks to pass before merging. Set to null to disable
+      required_status_checks:
+        # Required. Require branches to be up to date before merging.
+        strict: true
+        # Required. The list of status checks to require in order to merge into this branch
+        contexts: []
+      # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
+      enforce_admins: true
+      # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
+      restrictions:
+        apps: []
+        users: []
+        teams: []
+        
+validator:
+  #pattern: '[a-zA-Z0-9_-]+_[a-zA-Z0-9_-]+.*' 
+  pattern: '[a-zA-Z0-9_-]+'
+```
+
+### Runtime Settings 
+
+1. Besides the above settings files, the application can be bootstrapped with `runtime` settings.
+2. The `runtime` settings are configured in `deployment-settings.yml` that is in the directory from where the GitHub app is running.
+3. Currently the only setting that is possible are `restrictedRepos: [... ]` which allows you to configure a list of repos within your `org` that are excluded from the settings. If the `deployment-settings.yml` is not present, the following repos are added by default to the `restricted`repos list: `'admin', '.github', 'safe-settings'`
 
 ### Notes
 

--- a/app.yml
+++ b/app.yml
@@ -1,0 +1,140 @@
+# This is a GitHub App Manifest. These settings will be used by default when
+# initially configuring your GitHub App.
+#
+# NOTE: changing this file will not update your GitHub App settings.
+# You must visit github.com/settings/apps/your-app-name to edit them.
+#
+# Read more about configuring your GitHub App:
+# https://probot.github.io/docs/development/#configuring-a-github-app
+#
+# Read more about GitHub App Manifests:
+# https://developer.github.com/apps/building-github-apps/creating-github-apps-from-a-manifest/
+
+# The list of events the GitHub App subscribes to.
+# Uncomment the event names below to enable them.
+default_events:
+  - check_run
+  - check_suite
+  # - commit_comment
+  # - create
+  # - delete
+  # - deployment
+  # - deployment_status
+  # - fork
+  # - gollum
+  # - issue_comment
+  # - issues
+  # - label
+  # - milestone
+  # - member
+  # - membership
+  # - org_block
+  # - organization
+  # - page_build
+  # - project
+  # - project_card
+  # - project_column
+  # - public
+  - pull_request
+  - pull_request_review
+  - pull_request_review_comment
+  - push
+  # - release
+  # - repository
+  # - repository_import
+  # - status
+  # - team
+  # - team_add
+  # - watch
+  
+  # The set of permissions needed by the GitHub App. The format of the object uses
+  # the permission name for the key (for example, issues) and the access type for
+  # the value (for example, write).
+  # Valid values are `read`, `write`, and `none`
+  default_permissions:
+    # Repository creation, deletion, settings, teams, and collaborators.
+    # https://developer.github.com/v3/apps/permissions/#permission-on-administration
+    administration: write
+  
+    # Checks on code.
+    # https://developer.github.com/v3/apps/permissions/#permission-on-checks
+    checks: write
+  
+    # Repository contents, commits, branches, downloads, releases, and merges.
+    # https://developer.github.com/v3/apps/permissions/#permission-on-contents
+    contents: write
+  
+    # Deployments and deployment statuses.
+    # https://developer.github.com/v3/apps/permissions/#permission-on-deployments
+    # deployments: read
+  
+    # Issues and related comments, assignees, labels, and milestones.
+    # https://developer.github.com/v3/apps/permissions/#permission-on-issues
+    issues: write
+  
+    # Search repositories, list collaborators, and access repository metadata.
+    # https://developer.github.com/v3/apps/permissions/#metadata-permissions
+    metadata: read
+  
+    # Retrieve Pages statuses, configuration, and builds, as well as create new builds.
+    # https://developer.github.com/v3/apps/permissions/#permission-on-pages
+    # pages: read
+  
+    # Pull requests and related comments, assignees, labels, milestones, and merges.
+    # https://developer.github.com/v3/apps/permissions/#permission-on-pull-requests
+    pull_requests: write
+  
+    # Manage the post-receive hooks for a repository.
+    # https://developer.github.com/v3/apps/permissions/#permission-on-repository-hooks
+    # repository_hooks: read
+  
+    # Manage repository projects, columns, and cards.
+    # https://developer.github.com/v3/apps/permissions/#permission-on-repository-projects
+    # repository_projects: read
+  
+    # Retrieve security vulnerability alerts.
+    # https://developer.github.com/v4/object/repositoryvulnerabilityalert/
+    # vulnerability_alerts: read
+  
+    # Commit statuses.
+    # https://developer.github.com/v3/apps/permissions/#permission-on-statuses
+    statuses: write
+  
+    # Organization members and teams.
+    # https://developer.github.com/v3/apps/permissions/#permission-on-members
+    members: write
+  
+    # View and manage users blocked by the organization.
+    # https://developer.github.com/v3/apps/permissions/#permission-on-organization-user-blocking
+    # organization_user_blocking: read
+  
+    # Manage organization projects, columns, and cards.
+    # https://developer.github.com/v3/apps/permissions/#permission-on-organization-projects
+    # organization_projects: read
+  
+    # Manage team discussions and related comments.
+    # https://developer.github.com/v3/apps/permissions/#permission-on-team-discussions
+    # team_discussions: read
+  
+    # Manage the post-receive hooks for an organization.
+    # https://developer.github.com/v3/apps/permissions/#permission-on-organization-hooks
+    # organization_hooks: read
+  
+    # Get notified of, and update, content references.
+    # https://developer.github.com/v3/apps/permissions/
+    organization_administration: write
+  
+  
+  # The name of the GitHub App. Defaults to the name specified in package.json
+  name: Safe Settings
+  
+  # The homepage of your GitHub App.
+  url: https://github.com/github/safe-settings
+  
+  # A description of the GitHub App.
+  # description: A description of my awesome app
+  
+  # Set to true when your GitHub App is available to the public or false when it is only accessible to the owner of the app.
+  # Default: true
+  public: false
+  

--- a/app.yml
+++ b/app.yml
@@ -15,6 +15,7 @@
 default_events:
   - check_run
   - check_suite
+  - branch_protection_rule
   # - commit_comment
   # - create
   # - delete
@@ -36,11 +37,9 @@ default_events:
   # - project_column
   # - public
   - pull_request
-  - pull_request_review
-  - pull_request_review_comment
   - push
   # - release
-  # - repository
+  - repository
   # - repository_import
   # - status
   # - team

--- a/app.yml
+++ b/app.yml
@@ -46,11 +46,11 @@ default_events:
   # - team_add
   # - watch
   
-  # The set of permissions needed by the GitHub App. The format of the object uses
-  # the permission name for the key (for example, issues) and the access type for
-  # the value (for example, write).
-  # Valid values are `read`, `write`, and `none`
-  default_permissions:
+# The set of permissions needed by the GitHub App. The format of the object uses
+# the permission name for the key (for example, issues) and the access type for
+# the value (for example, write).
+# Valid values are `read`, `write`, and `none`
+default_permissions:
     # Repository creation, deletion, settings, teams, and collaborators.
     # https://developer.github.com/v3/apps/permissions/#permission-on-administration
     administration: write
@@ -124,16 +124,16 @@ default_events:
     organization_administration: write
   
   
-  # The name of the GitHub App. Defaults to the name specified in package.json
-  name: Safe Settings
+# The name of the GitHub App. Defaults to the name specified in package.json
+name: Safe Settings
   
-  # The homepage of your GitHub App.
-  url: https://github.com/github/safe-settings
+# The homepage of your GitHub App.
+url: https://github.com/github/safe-settings
   
-  # A description of the GitHub App.
-  # description: A description of my awesome app
+# A description of the GitHub App.
+# description: A description of my awesome app
   
-  # Set to true when your GitHub App is available to the public or false when it is only accessible to the owner of the app.
-  # Default: true
-  public: false
+# Set to true when your GitHub App is available to the public or false when it is only accessible to the owner of the app.
+# Default: true
+public: false
   

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,67 +1,37 @@
 # Deployment
 
-**Contents:**
-
-1. [Create the GitHub App](#create-the-github-app)
-1. [Deploy the app](#deploy-the-app)
-   1. [Prepare the source code](#prepare-the-source-code)
-   1. [Docker](#docker)
-   1. [Glitch](#glitch)
-   1. [Heroku](#heroku)
-1. [Share the app](#share-the-app)
-1. [Combining apps](#combining-apps)
-1. [Error tracking](#error-tracking)
-1. [Serverless Deployments](#serverless)
-
-## Create the GitHub App
-
-Every deployment will need an [App](https://developer.github.com/apps/).
-
-1. [Create a new GitHub App](https://github.com/settings/apps/new) with:
-
-   - **Homepage URL**: the URL to the GitHub repository for your app
-   - **Webhook URL**: Use `https://example.com/` for now, we'll come back in a minute to update this with the URL of your deployed app.
-   - **Webhook Secret**: Generate a unique secret with `openssl rand -base64 32` and save it because you'll need it in a minute to configure your deployed app.
-## Permissions & events
-
-1. Set the correct **Permissions & events** for the GitHub Integration:
-
-### Permissions
-
-#### Repository Permissions
-- Administration: **Read & Write**
-- Contents: **Read only**
-- Issues: **Read & Write**
-- Single file: **Read & Write**
-  - Path: `.github/settings.yml`
-
-#### Organization Permissions
-- Members: **Read & Write**
-- Administration: **Read & Write**
-
-### Events
-
-- Push
-- Repository
-1. Download the private key from the app.
-
-1. Make sure that you click the green **Install** button on the top left of the app page. This gives you an option of installing the app on all or a subset of your repositories. __**Important: Install this App for `All` repos in the Org**__
-
 ## Deploy the app
 
 ### Prepare the source code
 You will first need to clone the source code to your local environment that will run the **Docker** container.
 - Clone the codebase
   - `git clone https://github.com/github/safe-settings.git` or `git clone <this repo>`
+  
 - Change directory to inside the code base
   - `cd safe-settings/`
+  
+- Run `npm install` to build the code
+
+- The easiest way to create the Github App is using the [manifest flow](https://docs.github.com/en/developers/apps/building-github-apps/creating-a-github-app-from-a-manifest#using-probot-to-implement-the-github-app-manifest-flow) . To set up the app in an org, provide the `GHE_ORG` env variable in the .env file
+
+- If using the `manifest` flow, create `.env` from `.env.example` and set the `GHE_ORG` variable if installing the app in an org.
+
+- Start the app, `npm run dev` if running locally, or `npm run prod`
+
+- If using the manifest flow, follow the steps [here](https://docs.github.com/en/developers/apps/building-github-apps/creating-a-github-app-from-a-manifest)
+
+- If not using the `manifest flow` then follow the steps in [Create the GitHub App](#Create the GitHub App)
+
 - Create `.env` from `.env.example`
+  
   - `cp .env.example .env`
+  
 - Update the `.env` with the needed fields.
 
-To deploy an app to any cloud provider, you will need 3 environment variables:
+  To deploy an app to any cloud provider, you will need 3 environment variables:
 
 - `APP_ID`: the ID of the app, which you can get from the [app settings page](https://github.com/settings/apps).
+
 - `WEBHOOK_SECRET`: the **Webhook Secret** that you generated when you created the app.
 
 And one of:
@@ -173,6 +143,46 @@ Probot runs like [any other Node app](https://devcenter.heroku.com/articles/depl
          $ heroku config:set LOG_LEVEL=trace
          $ heroku logs --tail
 
+## Create the GitHub App
+
+Every deployment will need an [App](https://developer.github.com/apps/).
+
+1. The easiest way to create the Github App is using the [manifest flow](https://docs.github.com/en/developers/apps/building-github-apps/creating-a-github-app-from-a-manifest#using-probot-to-implement-the-github-app-manifest-flow) . If you set up the app using the `manifest flow`, congrats, you are DONE!
+2. [Create a new GitHub App](https://github.com/settings/apps/new) with:
+   - **Homepage URL**: the URL to the GitHub repository for your app
+   - **Webhook URL**: Use `https://example.com/` for now, we'll come back in a minute to update this with the URL of your deployed app.
+   - **Webhook Secret**: Generate a unique secret with `openssl rand -base64 32` and save it because you'll need it in a minute to configure your deployed app.
+
+## Permissions & events
+
+1. Set the correct **Permissions & events** for the GitHub Integration:
+
+### Permissions
+
+#### Repository Permissions
+
+- Administration: **Read & Write**
+- Contents: **Read only**
+- Issues: **Read & Write**
+- Single file: **Read & Write**
+  - Path: `.github/settings.yml`
+
+#### Organization Permissions
+
+- Members: **Read & Write**
+- Administration: **Read & Write**
+
+### Events
+
+- Push
+- Repository
+
+1. Download the private key from the app.
+
+1. Make sure that you click the green **Install** button on the top left of the app page. This gives you an option of installing the app on all or a subset of your repositories. __**Important: Install this App for `All` repos in the Org**__
+
+
+
 ## Share the app
 
 The Probot website includes a list of [featured apps](https://probot.github.io/apps). Consider [adding your app to the website](https://github.com/probot/probot.github.io/blob/master/CONTRIBUTING.md#adding-your-app) so others can discover and use it.
@@ -197,5 +207,4 @@ To deploy multiple apps in one instance, create a new app that has the existing 
   }
 }
 ```
-
 

--- a/docs/sample-settings/repo.yml
+++ b/docs/sample-settings/repo.yml
@@ -1,0 +1,179 @@
+# This settings can be used to create repo level settings
+#repository: 
+  # Name of the repo
+  #name: test
+ 
+  # Create the repo if it is not existing
+  #force_create: true
+
+  # Use a template when creating the repo
+  #template_repo: template_repo
+
+  # This is the settings that need to be applied to all repositories in the org 
+  # See https://developer.github.com/v3/repos/#edit for all available settings for a repository  
+  # A short description of the repository that will show up on GitHub
+  #description: description of the repo
+  
+  # A URL with more information about the repository
+  #homepage: https://example.github.io/
+    
+  # Keep this as true for most cases
+  # A lot of the policies below cannot be implemented on bare repos
+  # Pass true to create an initial commit with empty README.
+  #auto_init: true
+    
+  # A comma-separated list of topics to set on the repository
+  #topics: github, safe-settings, new-topic, another-topic, topic-12
+  
+  # Either `true` to make the repository private, or `false` to make it public. 
+  # If this value is changed and if Org members cannot change the visibility of repos
+  # it would result in an error when updating a repo
+  #private: false
+  
+  # Can be public or private. If your organization is associated with an enterprise account using 
+  # GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+, visibility can also be internal. 
+  #visibility: private
+  
+  # Either `true` to enable issues for this repository, `false` to disable them.
+  #has_issues: true
+  
+  # Either `true` to enable projects for this repository, or `false` to disable them.
+  # If projects are disabled for the organization, passing `true` will cause an API error.
+  #has_projects: true
+  
+  # Either `true` to enable the wiki for this repository, `false` to disable it.
+  #has_wiki: true
+  
+  # The default branch for this repository.
+  #default_branch: main
+  
+  # Desired language or platform [.gitignore template](https://github.com/github/gitignore) 
+  # to apply. Use the name of the template without the extension. 
+  # For example, "Haskell".
+  #gitignore_template: node
+  
+  # Choose an [open source license template](https://choosealicense.com/) 
+  # that best suits your needs, and then use the 
+  # [license keyword](https://help.github.com/articles/licensing-a-repository/#searching-github-by-license-type) 
+  # as the `license_template` string. For example, "mit" or "mpl-2.0".
+  #license_template: mit
+  
+  # Either `true` to allow squash-merging pull requests, or `false` to prevent
+  # squash-merging.
+  #allow_squash_merge: true
+  
+  # Either `true` to allow merging pull requests with a merge commit, or `false`
+  # to prevent merging pull requests with merge commits.
+  #allow_merge_commit: true
+  
+  # Either `true` to allow rebase-merging pull requests, or `false` to prevent
+  # rebase-merging.
+  #allow_rebase_merge: true
+  
+  # Either `true` to allow auto-merge on pull requests, 
+  # or `false` to disallow auto-merge.
+  # Default: `false`
+  #allow_auto_merge: true
+  
+  # Either `true` to allow automatically deleting head branches 
+  # when pull requests are merged, or `false` to prevent automatic deletion.
+  # Default: `false`
+  #delete_branch_on_merge: true  
+      
+# The following attributes are applied to any repo within the org
+# So if a repo is not listed above is created or edited
+# The app will apply the following settings to it
+#labels:
+  # Labels: define labels for Issues and Pull Requests
+  #- name: bug
+  #  color: CC0000
+  #  description: An issue with the system
+
+  #- name: feature
+    # If including a `#`, make sure to wrap it with quotes!
+  #  color: '#336699'
+  #  description: New functionality.
+
+  #- name: first-timers-only
+    # include the old name to rename an existing label
+  #  oldname: Help Wanted
+  #  color: '#326699'
+
+  #- name: new-label
+    # include the old name to rename an existing label
+  #  oldname: Help Wanted
+  #  color: '#326699'
+
+#collaborators:
+# Collaborators: give specific users access to any repository.
+# See https://developer.github.com/v3/repos/collaborators/#add-user-as-a-collaborator for available options
+
+#- username: drstrange
+#  permission: push
+# The permission to grant the collaborator. Can be one of:
+# * `pull` - can pull, but not push to or administer this repository.
+# * `push` - can pull and push, but not administer this repository.
+# * `admin` - can pull, push and administer this repository.
+#- username: beetlejuice
+#  permission: pull
+#  exclude:
+#  - actions-demo
+# You can exclude a list of repos for this collaborator and all repos except these repos would have this collaborator
+#- username: thor
+#  permission: push
+#  include:
+#  - actions-demo
+#  - another-repo
+# You can include a list of repos for this collaborator and only those repos would have this collaborator
+
+# See https://developer.github.com/v3/teams/#add-or-update-team-repository for available options
+#teams:
+#  - name: core
+    # The permission to grant the team. Can be one of:
+    # * `pull` - can pull, but not push to or administer this repository.
+    # * `push` - can pull and push, but not administer this repository.
+    # * `admin` - can pull, push and administer this repository.
+#    permission: admin
+#  - name: docs
+#    permission: push
+#    exclude:
+#    - actions-demo
+# You can exclude a list of repos for this collaborator and all repos except these repos would have this collaborator
+
+
+#branches:
+  # If the name of the branch value is specified as `default`, then the app will create a branch protection rule to apply against the default branch in the repo
+#  - name: default
+    # https://developer.github.com/v3/repos/branches/#update-branch-protection
+    # Branch Protection settings. Set to null to disable
+#    protection:
+      # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.
+#      required_pull_request_reviews:
+        # The number of approvals required. (1-6)
+#        required_approving_review_count: 1
+        # Dismiss approved reviews automatically when a new commit is pushed.
+#        dismiss_stale_reviews: true
+        # Blocks merge until code owners have reviewed.
+#        require_code_owner_reviews: true
+        # Specify which users and teams can dismiss pull request reviews. Pass an empty dismissal_restrictions object to disable. User and team dismissal_restrictions are only available for organization-owned repositories. Omit this parameter for personal repositories.
+#        dismissal_restrictions:
+#          users: []
+#          teams: []
+      # Required. Require status checks to pass before merging. Set to null to disable
+#      required_status_checks:
+        # Required. Require branches to be up to date before merging.
+#        strict: true
+        # Required. The list of status checks to require in order to merge into this branch
+#        contexts: []
+      # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
+#      enforce_admins: true
+      # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
+#      restrictions:
+#        apps: []
+#        users: []
+#        teams: []
+        
+#validator:
+  #pattern: '[a-zA-Z0-9_-]+_[a-zA-Z0-9_-]+.*' 
+
+

--- a/docs/sample-settings/sample-deployment-settings.yml
+++ b/docs/sample-settings/sample-deployment-settings.yml
@@ -1,0 +1,1 @@
+restrictedRepos: [ 'admin', '.github', 'safe-settings', 'specs', 'lfs', 'actions_test',  'demo', 'dependotest']

--- a/docs/sample-settings/settings.yml
+++ b/docs/sample-settings/settings.yml
@@ -1,0 +1,169 @@
+# This settings can be used to create org level settings
+
+#repository: 
+  # This is the settings that need to be applied to all repositories in the org 
+  # See https://developer.github.com/v3/repos/#edit for all available settings for a repository  
+  # A short description of the repository that will show up on GitHub
+  #description: description of the repo
+  
+  # A URL with more information about the repository
+  #homepage: https://example.github.io/
+    
+  # Keep this as true for most cases
+  # A lot of the policies below cannot be implemented on bare repos
+  # Pass true to create an initial commit with empty README.
+  #auto_init: true
+    
+  # A comma-separated list of topics to set on the repository
+  #topics: github, safe-settings, new-topic, another-topic, topic-12
+  
+  # Either `true` to make the repository private, or `false` to make it public. 
+  # If this value is changed and if Org members cannot change the visibility of repos
+  # it would result in an error when updating a repo
+  #private: false
+  
+  # Can be public or private. If your organization is associated with an enterprise account using 
+  # GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+, visibility can also be internal. 
+  #visibility: private
+  
+  # Either `true` to enable issues for this repository, `false` to disable them.
+  #has_issues: true
+  
+  # Either `true` to enable projects for this repository, or `false` to disable them.
+  # If projects are disabled for the organization, passing `true` will cause an API error.
+  #has_projects: true
+  
+  # Either `true` to enable the wiki for this repository, `false` to disable it.
+  #has_wiki: true
+  
+  # The default branch for this repository.
+  #default_branch: main
+  
+  # Desired language or platform [.gitignore template](https://github.com/github/gitignore) 
+  # to apply. Use the name of the template without the extension. 
+  # For example, "Haskell".
+  #gitignore_template: node
+  
+  # Choose an [open source license template](https://choosealicense.com/) 
+  # that best suits your needs, and then use the 
+  # [license keyword](https://help.github.com/articles/licensing-a-repository/#searching-github-by-license-type) 
+  # as the `license_template` string. For example, "mit" or "mpl-2.0".
+  #license_template: mit
+  
+  # Either `true` to allow squash-merging pull requests, or `false` to prevent
+  # squash-merging.
+  #allow_squash_merge: true
+  
+  # Either `true` to allow merging pull requests with a merge commit, or `false`
+  # to prevent merging pull requests with merge commits.
+  #allow_merge_commit: true
+  
+  # Either `true` to allow rebase-merging pull requests, or `false` to prevent
+  # rebase-merging.
+  #allow_rebase_merge: true
+  
+  # Either `true` to allow auto-merge on pull requests, 
+  # or `false` to disallow auto-merge.
+  # Default: `false`
+  #allow_auto_merge: true
+  
+  # Either `true` to allow automatically deleting head branches 
+  # when pull requests are merged, or `false` to prevent automatic deletion.
+  # Default: `false`
+  #delete_branch_on_merge: true  
+      
+# The following attributes are applied to any repo within the org
+# So if a repo is not listed above is created or edited
+# The app will apply the following settings to it
+#labels:
+  # Labels: define labels for Issues and Pull Requests
+  #- name: bug
+  #  color: CC0000
+  #  description: An issue with the system
+
+  #- name: feature
+    # If including a `#`, make sure to wrap it with quotes!
+  #  color: '#336699'
+  #  description: New functionality.
+
+  #- name: first-timers-only
+    # include the old name to rename an existing label
+  #  oldname: Help Wanted
+  #  color: '#326699'
+
+  #- name: new-label
+    # include the old name to rename an existing label
+  #  oldname: Help Wanted
+  #  color: '#326699'
+
+#collaborators:
+# Collaborators: give specific users access to any repository.
+# See https://developer.github.com/v3/repos/collaborators/#add-user-as-a-collaborator for available options
+
+#- username: drstrange
+#  permission: push
+# The permission to grant the collaborator. Can be one of:
+# * `pull` - can pull, but not push to or administer this repository.
+# * `push` - can pull and push, but not administer this repository.
+# * `admin` - can pull, push and administer this repository.
+#- username: beetlejuice
+#  permission: pull
+#  exclude:
+#  - actions-demo
+# You can exclude a list of repos for this collaborator and all repos except these repos would have this collaborator
+#- username: thor
+#  permission: push
+#  include:
+#  - actions-demo
+#  - another-repo
+# You can include a list of repos for this collaborator and only those repos would have this collaborator
+
+# See https://developer.github.com/v3/teams/#add-or-update-team-repository for available options
+#teams:
+#  - name: core
+    # The permission to grant the team. Can be one of:
+    # * `pull` - can pull, but not push to or administer this repository.
+    # * `push` - can pull and push, but not administer this repository.
+    # * `admin` - can pull, push and administer this repository.
+#    permission: admin
+#  - name: docs
+#    permission: push
+#    exclude:
+#    - actions-demo
+# You can exclude a list of repos for this collaborator and all repos except these repos would have this collaborator
+
+
+#branches:
+  # If the name of the branch value is specified as `default`, then the app will create a branch protection rule to apply against the default branch in the repo
+#  - name: default
+    # https://developer.github.com/v3/repos/branches/#update-branch-protection
+    # Branch Protection settings. Set to null to disable
+#    protection:
+      # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.
+#      required_pull_request_reviews:
+        # The number of approvals required. (1-6)
+#        required_approving_review_count: 1
+        # Dismiss approved reviews automatically when a new commit is pushed.
+#        dismiss_stale_reviews: true
+        # Blocks merge until code owners have reviewed.
+#        require_code_owner_reviews: true
+        # Specify which users and teams can dismiss pull request reviews. Pass an empty dismissal_restrictions object to disable. User and team dismissal_restrictions are only available for organization-owned repositories. Omit this parameter for personal repositories.
+#        dismissal_restrictions:
+#          users: []
+#          teams: []
+      # Required. Require status checks to pass before merging. Set to null to disable
+#      required_status_checks:
+        # Required. Require branches to be up to date before merging.
+#        strict: true
+        # Required. The list of status checks to require in order to merge into this branch
+#        contexts: []
+      # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
+#      enforce_admins: true
+      # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
+#      restrictions:
+#        apps: []
+#        users: []
+#        teams: []
+        
+#validator:
+  #pattern: '[a-zA-Z0-9_-]+_[a-zA-Z0-9_-]+.*' 

--- a/docs/sample-settings/suborg.yml
+++ b/docs/sample-settings/suborg.yml
@@ -1,0 +1,179 @@
+# This settings can be used to create suborg level settings
+
+# List of repos that belong to the suborg
+#suborgrepos:
+#  - test*
+# You can use Glob patterns
+
+#suborgteams:
+#  - core
+
+#repository: 
+  # This is the settings that need to be applied to all repositories in the org 
+  # See https://developer.github.com/v3/repos/#edit for all available settings for a repository  
+  # A short description of the repository that will show up on GitHub
+  #description: description of the repo
+  
+  # A URL with more information about the repository
+  #homepage: https://example.github.io/
+    
+  # Keep this as true for most cases
+  # A lot of the policies below cannot be implemented on bare repos
+  # Pass true to create an initial commit with empty README.
+  #auto_init: true
+    
+  # A comma-separated list of topics to set on the repository
+  #topics: github, safe-settings, new-topic, another-topic, topic-12
+  
+  # Either `true` to make the repository private, or `false` to make it public. 
+  # If this value is changed and if Org members cannot change the visibility of repos
+  # it would result in an error when updating a repo
+  #private: false
+  
+  # Can be public or private. If your organization is associated with an enterprise account using 
+  # GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+, visibility can also be internal. 
+  #visibility: private
+  
+  # Either `true` to enable issues for this repository, `false` to disable them.
+  #has_issues: true
+  
+  # Either `true` to enable projects for this repository, or `false` to disable them.
+  # If projects are disabled for the organization, passing `true` will cause an API error.
+  #has_projects: true
+  
+  # Either `true` to enable the wiki for this repository, `false` to disable it.
+  #has_wiki: true
+  
+  # The default branch for this repository.
+  #default_branch: main
+  
+  # Desired language or platform [.gitignore template](https://github.com/github/gitignore) 
+  # to apply. Use the name of the template without the extension. 
+  # For example, "Haskell".
+  #gitignore_template: node
+  
+  # Choose an [open source license template](https://choosealicense.com/) 
+  # that best suits your needs, and then use the 
+  # [license keyword](https://help.github.com/articles/licensing-a-repository/#searching-github-by-license-type) 
+  # as the `license_template` string. For example, "mit" or "mpl-2.0".
+  #license_template: mit
+  
+  # Either `true` to allow squash-merging pull requests, or `false` to prevent
+  # squash-merging.
+  #allow_squash_merge: true
+  
+  # Either `true` to allow merging pull requests with a merge commit, or `false`
+  # to prevent merging pull requests with merge commits.
+  #allow_merge_commit: true
+  
+  # Either `true` to allow rebase-merging pull requests, or `false` to prevent
+  # rebase-merging.
+  #allow_rebase_merge: true
+  
+  # Either `true` to allow auto-merge on pull requests, 
+  # or `false` to disallow auto-merge.
+  # Default: `false`
+  #allow_auto_merge: true
+  
+  # Either `true` to allow automatically deleting head branches 
+  # when pull requests are merged, or `false` to prevent automatic deletion.
+  # Default: `false`
+  #delete_branch_on_merge: true  
+      
+# The following attributes are applied to any repo within the org
+# So if a repo is not listed above is created or edited
+# The app will apply the following settings to it
+#labels:
+  # Labels: define labels for Issues and Pull Requests
+  #- name: bug
+  #  color: CC0000
+  #  description: An issue with the system
+
+  #- name: feature
+    # If including a `#`, make sure to wrap it with quotes!
+  #  color: '#336699'
+  #  description: New functionality.
+
+  #- name: first-timers-only
+    # include the old name to rename an existing label
+  #  oldname: Help Wanted
+  #  color: '#326699'
+
+  #- name: new-label
+    # include the old name to rename an existing label
+  #  oldname: Help Wanted
+  #  color: '#326699'
+
+#collaborators:
+# Collaborators: give specific users access to any repository.
+# See https://developer.github.com/v3/repos/collaborators/#add-user-as-a-collaborator for available options
+
+#- username: drstrange
+#  permission: push
+# The permission to grant the collaborator. Can be one of:
+# * `pull` - can pull, but not push to or administer this repository.
+# * `push` - can pull and push, but not administer this repository.
+# * `admin` - can pull, push and administer this repository.
+#- username: beetlejuice
+#  permission: pull
+#  exclude:
+#  - actions-demo
+# You can exclude a list of repos for this collaborator and all repos except these repos would have this collaborator
+#- username: thor
+#  permission: push
+#  include:
+#  - actions-demo
+#  - another-repo
+# You can include a list of repos for this collaborator and only those repos would have this collaborator
+
+# See https://developer.github.com/v3/teams/#add-or-update-team-repository for available options
+#teams:
+#  - name: core
+    # The permission to grant the team. Can be one of:
+    # * `pull` - can pull, but not push to or administer this repository.
+    # * `push` - can pull and push, but not administer this repository.
+    # * `admin` - can pull, push and administer this repository.
+#    permission: admin
+#  - name: docs
+#    permission: push
+#    exclude:
+#    - actions-demo
+# You can exclude a list of repos for this collaborator and all repos except these repos would have this collaborator
+
+
+#branches:
+  # If the name of the branch value is specified as `default`, then the app will create a branch protection rule to apply against the default branch in the repo
+#  - name: default
+    # https://developer.github.com/v3/repos/branches/#update-branch-protection
+    # Branch Protection settings. Set to null to disable
+#    protection:
+      # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.
+#      required_pull_request_reviews:
+        # The number of approvals required. (1-6)
+#        required_approving_review_count: 1
+        # Dismiss approved reviews automatically when a new commit is pushed.
+#        dismiss_stale_reviews: true
+        # Blocks merge until code owners have reviewed.
+#        require_code_owner_reviews: true
+        # Specify which users and teams can dismiss pull request reviews. Pass an empty dismissal_restrictions object to disable. User and team dismissal_restrictions are only available for organization-owned repositories. Omit this parameter for personal repositories.
+#        dismissal_restrictions:
+#          users: []
+#          teams: []
+      # Required. Require status checks to pass before merging. Set to null to disable
+#      required_status_checks:
+        # Required. Require branches to be up to date before merging.
+#        strict: true
+        # Required. The list of status checks to require in order to merge into this branch
+#        contexts: []
+      # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
+#      enforce_admins: true
+      # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
+#      restrictions:
+#        apps: []
+#        users: []
+#        teams: []
+        
+#validator:
+  #pattern: '[a-zA-Z0-9_-]+_[a-zA-Z0-9_-]+.*' 
+
+

--- a/index.js
+++ b/index.js
@@ -11,10 +11,10 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
   async function syncAllSettings (nop, context, repo = context.repo(), ref) {
     deploymentConfig = await loadYamlFileSystem()
     robot.log.debug(`deploymentConfig is ${JSON.stringify(deploymentConfig)}`)
-    const configManager = new ConfigManager(context)
+    const configManager = new ConfigManager(context,ref)
     const runtimeConfig = await configManager.loadGlobalSettingsYaml();
     const config = Object.assign({}, deploymentConfig, runtimeConfig)
-    robot.log.debug(`config is ${JSON.stringify(config)}`)
+    robot.log.debug(`config for ref ${ref} is ${JSON.stringify(config)}`)
     if (ref) {
       return Settings.syncAll(nop, context, repo, config, ref)
     } else {
@@ -25,19 +25,21 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
   async function syncSubOrgSettings (nop, context, suborg, repo = context.repo(), ref) {
     deploymentConfig = await loadYamlFileSystem()
     robot.log.debug(`deploymentConfig is ${JSON.stringify(deploymentConfig)}`)
-    const configManager = new ConfigManager(context)
+    const configManager = new ConfigManager(context, ref)
     const runtimeConfig = await configManager.loadGlobalSettingsYaml();
     const config = Object.assign({}, deploymentConfig, runtimeConfig)
-    robot.log.debug(`config is ${JSON.stringify(config)}`)
+    robot.log.debug(`config for ref ${ref} is ${JSON.stringify(config)}`)
     return Settings.syncAll(nop, context, repo, config, ref)
   }
 
   async function syncSettings (nop, context, repo = context.repo(), ref) {
     deploymentConfig = await loadYamlFileSystem()
     robot.log.debug(`deploymentConfig is ${JSON.stringify(deploymentConfig)}`)
-    const runtimeConfig = await loadYaml(context)
+    //const runtimeConfig = await loadYaml(context)
+    const configManager = new ConfigManager(context,ref)
+    const runtimeConfig = await configManager.loadGlobalSettingsYaml();
     const config = Object.assign({}, deploymentConfig, runtimeConfig)
-    robot.log.debug(`config is ${JSON.stringify(config)}`)
+    robot.log.debug(`config for ref ${ref} is ${JSON.stringify(config)}`)
     return Settings.sync(nop, context, repo, config, ref)
   }
 

--- a/index.js
+++ b/index.js
@@ -6,12 +6,10 @@ const ConfigManager = require('./lib/configManager')
 let deploymentConfig
 module.exports = (robot, _, Settings = require('./lib/settings')) => {
   
-
   async function syncAllSettings (nop, context, repo = context.repo(), ref) {
     deploymentConfig = await loadYamlFileSystem()
     robot.log.debug(`deploymentConfig is ${JSON.stringify(deploymentConfig)}`)
     const configManager = new ConfigManager(context)
-    //const runtimeConfig = await loadYaml(context)
     const runtimeConfig = await configManager.loadGlobalSettingsYaml();
     const config = Object.assign({}, deploymentConfig, runtimeConfig)
     robot.log.debug(`config is ${JSON.stringify(config)}`)
@@ -26,13 +24,11 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
     deploymentConfig = await loadYamlFileSystem()
     robot.log.debug(`deploymentConfig is ${JSON.stringify(deploymentConfig)}`)
     const configManager = new ConfigManager(context)
-    //const runtimeConfig = await loadYaml(context)
     const runtimeConfig = await configManager.loadGlobalSettingsYaml();
     const config = Object.assign({}, deploymentConfig, runtimeConfig)
     robot.log.debug(`config is ${JSON.stringify(config)}`)
     return Settings.syncAll(nop, context, repo, config, ref)
   }
-
 
   async function syncSettings (nop, context, repo = context.repo(), ref) {
     deploymentConfig = await loadYamlFileSystem()
@@ -106,7 +102,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
 
     let commit = payload.commits.find(c => {
       return ( c.modified.find(s => {
-        robot.log(JSON.stringify(s))
+        robot.log.debug(JSON.stringify(s))
         return ( s.search(repoSettingPattern)>=0 )
       }) !== undefined )
     })
@@ -163,7 +159,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
 
     let commit = payload.commits.find(c => {
       return ( c.modified.find(s => {
-        robot.log(JSON.stringify(s))
+        robot.log.debug(JSON.stringify(s))
         return ( s.search(repoSettingPattern)>=0 )
       }) !== undefined )
     })
@@ -178,10 +174,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
   }
 
   function getChangedConfigName(glob, files, owner) {
-    //const repoSettingPattern = new Glob(".github/repos/*.yml")
-
     let modifiedFile = files.find(s => {
-        //robot.log.debug(JSON.stringify(s))
         return ( s.search(glob)>=0 )
     })
 
@@ -197,43 +190,14 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
   async function createCheckRun(context, pull_request, head_sha, head_branch) {
     const { payload } = context
     const { repository } = payload
-
-    /*
-    const repo = { owner: context.repo().owner, repo: 'admin' }
-    const CONFIG_PATH = '.github'
-    const params = Object.assign(repo, { path: path.posix.join(CONFIG_PATH, 'settings.yml') })
-    const response = await context.octokit.repos.getContent(params).catch(e => {
-      console.error(e)
-      console.error(`Error getting settings ${e}`)
-    })
-*/
-
-    robot.log(`Check suite was requested! for ${context.repo()} ${pull_request.number} ${head_sha} ${head_branch}`)
+    robot.log.debug(`Check suite was requested! for ${context.repo()} ${pull_request.number} ${head_sha} ${head_branch}`)
     const res = await context.octokit.checks.create({
       owner: payload.repository.owner.login,
       repo: payload.repository.name,
       name: 'Safe-setting validator',
       head_sha: head_sha
     })
-    robot.log(JSON.stringify(res,null))
-
-  /*
-    let params = Object.assign(context.repo(), { pull_number: payload.check_suite.pull_requests[0].number })
-    //robot.log(JSON.stringify(payload.check_suite.head_commit))
-    const commits = await context.octokit.pulls.listCommits(params)
-    robot.log(`${commits.data[0].sha} ${commits.data[0].parents[0].sha}  ${JSON.stringify(commits.data[0], null, 4)}`)
-    params = Object.assign(context.repo(), {  basehead: `${commits.data[0].parents[0].sha}...${commits.data[0].sha}`  })
-    //params = Object.assign(context.repo(), { base: payload.check_suite.pull_requests[0].base.ref, head: payload.check_suite.pull_requests[0].head.ref, basehead: `${payload.check_suite.pull_requests[0].base.ref}...${payload.check_suite.pull_requests[0].head.ref}`  })
-    //robot.log(`${JSON.stringify(params)}`)
-    const changes = await context.octokit.repos.compareCommitsWithBasehead(params)
-    //robot.log(`${JSON.stringify(changes.data.files, null, 4)}`)
-    const files = changes.data.files.map(f => { return f.filename })
-    const repo = getChangedRepoConfigName(files, context.repo().owner)
-    robot.log(`${JSON.stringify(repo, null, 4)}`)
-    if (repo) {
-      return syncSettings(context, repo)
-    }
-    */
+    robot.log.debug(JSON.stringify(res,null))
   }
 
 
@@ -243,18 +207,14 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
 
     const adminRepo = repository.name === 'admin'
     if (!adminRepo) {
-      //robot.log(`received push event ${JSON.stringify(payload)}`)
-      //robot.log('Not working on the Admin repo, returning...')
       return
     }
 
     const defaultBranch = payload.ref === 'refs/heads/' + repository.default_branch
     if (!defaultBranch) {
-      robot.log('Not working on the default branch, returning...')
+      robot.log.debug('Not working on the default branch, returning...')
       return
     }
-
-    //robot.log(`commits ${JSON.stringify(payload.commits)}`)
     const settingsModified = payload.commits.find(commit => {
       return commit.added.includes(Settings.FILE_NAME) ||
         commit.modified.includes(Settings.FILE_NAME)
@@ -281,28 +241,39 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
     }
     
     if (!settingsModified) {
-      robot.log(`No changes in '${Settings.FILE_NAME}' detected, returning...`)
+      robot.log.debug(`No changes in '${Settings.FILE_NAME}' detected, returning...`)
       return
     }
     return syncAllSettings(false, context)
   })
 
+  robot.on('branch_protection_rule', async context => {
+    const { payload } = context
+    const { changes, repository, sender } = payload
+    robot.log.debug('Branch Protection edited by ', JSON.stringify(sender))
+    if (sender.type === 'Bot') {
+      robot.log.debug('Branch Protection edited by Bot')
+      return
+    }
+    console.log('Branch Protection edited by a Human')
+    return syncSettings(false, context)
+  })
+
+
   robot.on('repository.edited', async context => {
     const { payload } = context
     const { changes, repository, sender } = payload
-    robot.log('repository.edited payload from ', JSON.stringify(sender))
+    robot.log.debug('repository.edited payload from ', JSON.stringify(sender))
     if (sender.type === 'Bot') {
-      robot.log('Repository Edited by a Bot')
+      robot.log.debug('Repository Edited by a Bot')
       return
     }
     console.log('Repository Edited by a Human')
     if (!Object.prototype.hasOwnProperty.call(changes, 'default_branch')) {
-      robot.log('Repository configuration was edited but the default branch was not affected, returning...')
+      robot.log.debug('Repository configuration was edited but the default branch was not affected, returning...')
       return
     }
-
-    robot.log(`Default branch changed from '${changes.default_branch.from}' to '${repository.default_branch}'`)
-
+    robot.log.debug(`Default branch changed from '${changes.default_branch.from}' to '${repository.default_branch}'`)
     return syncSettings(false, context)
   })
 
@@ -310,20 +281,18 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
     const { payload } = context
     const { repository } = payload
     const adminRepo = repository.name === 'admin'
-    robot.log(`Is Admin repo event ${adminRepo}`)
+    robot.log.debug(`Is Admin repo event ${adminRepo}`)
     if (!adminRepo) {
-      //robot.log(`received push event ${JSON.stringify(payload)}`)
-      robot.log('Not working on the Admin repo, returning...')
+      robot.log.debug('Not working on the Admin repo, returning...')
       return
     }
     const defaultBranch = payload.check_suite.head_branch ===  repository.default_branch
     if (defaultBranch) {
-      robot.log(' Working on the default branch, returning...')
+      robot.log.debug(' Working on the default branch, returning...')
       return
     }
     if (!payload.check_suite.pull_requests[0]) {
-      //robot.log(`received push event ${JSON.stringify(payload)}`)
-      robot.log('Not working on a PR, returning...')
+      robot.log.debug('Not working on a PR, returning...')
       return
     }
     const pull_request = payload.check_suite.pull_requests[0]
@@ -331,44 +300,41 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
   })
 
   robot.on('pull_request.opened', async context => {
-    robot.log('Pull_request opened !')
+    robot.log.debug('Pull_request opened !')
     const { payload } = context
     const { repository } = payload
     const adminRepo = repository.name === 'admin'
-    robot.log(`Is Admin repo event ${adminRepo}`)
+    robot.log.debug(`Is Admin repo event ${adminRepo}`)
     if (!adminRepo) {
-      //robot.log(`received push event ${JSON.stringify(payload)}`)
-      robot.log('Not working on the Admin repo, returning...')
+      robot.log.debug('Not working on the Admin repo, returning...')
       return
     }
     const defaultBranch = payload.pull_request.head_branch ===  repository.default_branch
     if (defaultBranch) {
-      robot.log(' Working on the default branch, returning...')
+      robot.log.debug(' Working on the default branch, returning...')
       return
     }
-
     const pull_request = payload.pull_request
     console.log(JSON.stringify(pull_request,null,2))
     createCheckRun(context,pull_request, payload.pull_request.head.sha, payload.pull_request.head.ref)
   })
 
   robot.on('pull_request.reopened', async context => {
-    robot.log('Pull_request REopened !')
+    robot.log.debug('Pull_request REopened !')
     const { payload } = context
     const { repository } = payload
     const pull_request = payload.pull_request
     const adminRepo = repository.name === 'admin'
 
-    robot.log(`Is Admin repo event ${adminRepo}`)
+    robot.log.debug(`Is Admin repo event ${adminRepo}`)
     if (!adminRepo) {
-      //robot.log(`received push event ${JSON.stringify(payload)}`)
-      robot.log('Not working on the Admin repo, returning...')
+      robot.log.debug('Not working on the Admin repo, returning...')
       return
     }
 
     const defaultBranch = payload.pull_request.head_branch ===  repository.default_branch
     if (defaultBranch) {
-      robot.log(' Working on the default branch, returning...')
+      robot.log.debug(' Working on the default branch, returning...')
       return
     }
     console.log(JSON.stringify(pull_request,null,2))
@@ -376,18 +342,17 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
   })
 
   robot.on([ 'check_suite.rerequested'], async context => {
-    robot.log('Check suite was rerequested!')
+    robot.log.debug('Check suite was rerequested!')
     createCheckRun(context)
   })
 
   robot.on([ 'check_suite.rerequested'], async context => {
-    robot.log('Check suite was rerequested!')
+    robot.log.debug('Check suite was rerequested!')
     createCheckRun(context)
   })
 
   robot.on([ 'check_run.created'], async context => {
     robot.log.debug(`Check run was created!`)
-    //robot.log.debug(`${JSON.stringify(context,null,2)}`)
     const { payload } = context
     const { repository } = payload
     const { check_run } = payload
@@ -395,21 +360,19 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
     const pull_request = check_suite.pull_requests[0]
     const source = payload.check_run.name ===  "Safe-setting validator"
     if (!source) {
-      robot.log(' Not triggered by Safe-settings...')
+      robot.log.debug(' Not triggered by Safe-settings...')
       return
     }
 
     const adminRepo = repository.name === 'admin'
-    robot.log(`Is Admin repo event ${adminRepo}`)
+    robot.log.debug(`Is Admin repo event ${adminRepo}`)
     if (!adminRepo) {
-      //robot.log(`received push event ${JSON.stringify(payload)}`)
-      robot.log('Not working on the Admin repo, returning...')
+      robot.log.debug('Not working on the Admin repo, returning...')
       return
     }
 
     if (!pull_request) {
-      //robot.log(`received push event ${JSON.stringify(payload)}`)
-      robot.log('Not working on a PR, returning...')
+      robot.log.debug('Not working on a PR, returning...')
       return
     }
 
@@ -421,22 +384,13 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
       started_at: new Date((new Date()).setUTCHours(0, 0, 0, 0)).toISOString(),
       output: { title: "Starting NOP", summary: "initiating..."}
     }
-    robot.log(`Updating check run ${JSON.stringify(params)}`)
+    robot.log.debug(`Updating check run ${JSON.stringify(params)}`)
     let res = await context.octokit.checks.update(params)
-
-    //params = Object.assign(context.repo(), { pull_number: pull_request.number })
-    //robot.log(JSON.stringify(payload.check_suite.head_commit))
-    //const commits = await context.octokit.pulls.listCommits(params)
-    //robot.log(`${commits.data[0].sha} ${commits.data[0].parents[0].sha}  ${JSON.stringify(commits.data[0], null, 4)}`)
-    //params = Object.assign(context.repo(), {  basehead: `${commits.data[0].parents[0].sha}...${commits.data[0].sha}`  })
     params = Object.assign(context.repo(), {  basehead: `${check_suite.before}...${check_suite.after}`  })
-    //params = Object.assign(context.repo(), { base: payload.check_suite.pull_requests[0].base.ref, head: payload.check_suite.pull_requests[0].head.ref, basehead: `${payload.check_suite.pull_requests[0].base.ref}...${payload.check_suite.pull_requests[0].head.ref}`  })
-    //robot.log(`${JSON.stringify(params)}`)
     const changes = await context.octokit.repos.compareCommitsWithBasehead(params)
-    //robot.log(`${JSON.stringify(changes.data.files, null, 4)}`)
     const files = changes.data.files.map(f => { return f.filename })
     const repo = getChangedConfigName(new Glob(".github/repos/*.yml"), files, context.repo().owner)
-    robot.log(`${JSON.stringify(repo, null, 4)}`)
+    robot.log.debug(`${JSON.stringify(repo, null, 4)}`)
     if (repo) {
       return syncSettings(true, context, repo, pull_request.head.ref)
     }
@@ -444,32 +398,18 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
     if (suborg) {
       return syncAllSettings(true, context, suborg, pull_request.head.ref )
     }
-
     return syncAllSettings(true, context, context.repo(), pull_request.head.ref )
-    /*
-    params = {
-      owner: payload.repository.owner.login,
-      repo: payload.repository.name,
-      check_run_id: payload.check_run.id,
-      status: 'completed',
-      conclusion: 'success',
-      completed_at: new Date((new Date()).setUTCHours(0, 0, 0, 0)).toISOString(),
-      output: { title: "Finished with the NOP", summary: "All checks passed"}
-    }
-    robot.log(`Completing check run ${JSON.stringify(params)}`)
-    res = await context.octokit.checks.update(params)
-*/
   })
   
   robot.on('repository.created', async context => {
     const { payload } = context
     const { sender } = payload
-    robot.log('repository.created payload from ', JSON.stringify(sender))
+    robot.log.debug('repository.created payload from ', JSON.stringify(sender))
     if (sender.type === 'Bot') {
-      robot.log('Repository created by a Bot')
+      robot.log.debug('Repository created by a Bot')
       return
     }
-    robot.log('Repository created by a Human')
+    robot.log.debug('Repository created by a Human')
     return syncSettings(false, context)
   })
   

--- a/lib/configManager.js
+++ b/lib/configManager.js
@@ -1,0 +1,46 @@
+const path = require('path')
+const yaml = require('js-yaml')
+const fs = require('fs')
+module.exports = class ConfigManager {
+    constructor(context) {
+        this.context = context
+    }
+
+    /**
+ * Loads a file from GitHub
+ *
+ * @param params Params to fetch the file with
+ * @return The parsed YAML file
+ */
+    async loadGlobalSettingsYaml() {
+        try {
+            const repo = { owner: this.context.repo().owner, repo: 'admin' }
+            const CONFIG_PATH = '.github'
+            const params = Object.assign(repo, { path: path.posix.join(CONFIG_PATH, 'settings.yml') })
+            const response = await this.context.octokit.repos.getContent(params).catch(e => {
+                console.log(e)
+                console.error(`Error getting settings ${e}`)
+            })
+            // Ignore in case path is a folder
+            // - https://developer.github.com/v3/repos/contents/#response-if-content-is-a-directory
+            if (Array.isArray(response.data)) {
+                return null
+            }
+
+            // we don't handle symlinks or submodule
+            // - https://developer.github.com/v3/repos/contents/#response-if-content-is-a-symlink
+            // - https://developer.github.com/v3/repos/contents/#response-if-content-is-a-submodule
+            if (typeof response.data.content !== 'string') {
+                return
+            }
+
+            return yaml.load(Buffer.from(response.data.content, 'base64').toString()) || {}
+        } catch (e) {
+            if (e.status === 404) {
+                return null
+            }
+
+            throw e
+        }
+    }
+}

--- a/lib/configManager.js
+++ b/lib/configManager.js
@@ -2,8 +2,9 @@ const path = require('path')
 const yaml = require('js-yaml')
 const fs = require('fs')
 module.exports = class ConfigManager {
-    constructor(context) {
+    constructor(context, ref) {
         this.context = context
+        this.ref = ref
     }
 
     /**
@@ -16,7 +17,7 @@ module.exports = class ConfigManager {
         try {
             const repo = { owner: this.context.repo().owner, repo: 'admin' }
             const CONFIG_PATH = '.github'
-            const params = Object.assign(repo, { path: path.posix.join(CONFIG_PATH, 'settings.yml') })
+            const params = Object.assign(repo, { path: path.posix.join(CONFIG_PATH, 'settings.yml'), ref: this.ref })
             const response = await this.context.octokit.repos.getContent(params).catch(e => {
                 console.log(e)
                 console.error(`Error getting settings ${e}`)

--- a/lib/glob.js
+++ b/lib/glob.js
@@ -1,0 +1,25 @@
+class Glob {
+    constructor(glob) {
+        this.glob = glob
+        let regexptex = glob.replace(/\//g,"\\/").replace(/\?/g, "([^\\/])").replace(/\./g, "\\.").replace(/\*/g, "([^\\/]*)")
+        this.regexp = new RegExp(`^${regexptex}$`, "u")                       
+    }
+
+    toString() {
+        return this.glob
+    }
+
+    [Symbol.search](s) {
+        return s.search(this.regexp)
+    }
+    [Symbol.match](s) {
+        return s.match(this.regexp)
+    }
+    [Symbol.replace](s, replacement) {
+        return s.replace(this.regexp, replacement)
+    }
+    [Symbol.replaceAll](s, replacement) {
+        return s.replaceAll(this.regexp, replacement)
+    }
+}
+module.exports = Glob

--- a/lib/mergeDeep.js
+++ b/lib/mergeDeep.js
@@ -1,0 +1,140 @@
+class MergeDeep {
+    constructor(log, ignorableFields) {
+        this.log = log
+        this.ignorableFields = ignorableFields
+    }
+
+    isObject(item) {
+        return (item && typeof item === 'object' && !Array.isArray(item));
+    }
+    isEmpty(item) {
+        if (this.isObject(item)) {
+            return Object.keys(item).length === 0
+        } else if (Array.isArray(item)) {
+            return item.length === 0
+        } else {
+            return item == undefined
+        }
+    }
+    compareDeep(t, s, additions = {}, modifications = {}) {
+        const target = Object.assign({}, t)
+        const source = Object.assign({}, s)
+        if (t == undefined) {
+            additions = Object.assign(additions, s)
+        }
+        if (this.isObject(target) && this.isObject(source)) {
+            for (const key in source) {
+                if (key.indexOf("url")>=0 || this.ignorableFields.indexOf(key)>=0) {
+                    continue;
+                }
+                if (this.isObject(source[key]) || Array.isArray(source[key])) {
+                    /*
+                    if (!target[key]) {
+                        if (Array.isArray(source[key])) {
+                            additions = Object.assign({}, {
+                                [key]: []
+                            })
+
+                        } else {
+                            additions = Object.assign({}, {
+                                [key]: {}
+                            })
+                        }
+                    } else {
+                        if (Array.isArray(source[key])) {
+                            modifications = Object.assign({}, {
+                                [key]: []
+                            })
+                        } else {
+                            modifications = Object.assign({}, {
+                                [key]: {}
+                            })
+                        }
+
+                    }
+                    */
+
+                    if (Array.isArray(source[key])) {
+                        additions[key] = []
+                        modifications[key] = []
+                    } else {
+                        additions[key] =  {}
+                        modifications[key] = {}
+                    }
+                    
+                    if (Array.isArray(source[key]) && Array.isArray(target[key])) {
+                        // Deep merge Array so that if the same element is there in source and target, 
+                        // override the target with source otherwise include both source and target elements
+                        const visited = {}
+                        let index = 0
+                        const temp = [...source[key], ...target[key]]
+                        this.log.debug(`merging array ${JSON.stringify(temp)}`)
+                        for (const a of temp) {
+                            if (this.isObject(a)) {
+                                if (visited[a.name]) {
+                                    // Common array in target and source 
+                                    modifications[key].push({})
+                                    additions[key].push({})
+                                    this.compareDeep(a, visited[a.name], additions[key][additions[key].length - 1], modifications[key][modifications[key].length - 1]);
+                                    delete visited[a.name]
+                                    continue
+                                } else if (visited[a.username]) {
+                                    // Common array in target and source 
+                                    modifications[key].push({})
+                                    additions[key].push({})
+                                    this.log.debug(`going deeper in compare array elements objects for ${key}  ${JSON.stringify(visited[a.username])},  ${JSON.stringify(a)}, ${JSON.stringify(additions[key][additions[key].length - 1])}, ${JSON.stringify(modifications[key][modifications[key].length - 1])}`)
+                                    this.compareDeep(visited[a.username], a, additions[key][additions[key].length - 1], modifications[key][modifications[key].length - 1]);
+                                    delete visited[a.username]
+                                    continue
+                                } 
+                                if (a.name) {
+                                    visited[a.name] = a
+                                } else if (a.username) {
+                                    visited[a.username] = a
+                                }
+                            } else {
+                                // If already seen this, it is not a missing field
+                                if (visited[a]) {
+                                    delete visited[a]
+                                    //this.log.debug(`zzz ${a}  ${JSON.stringify(visited)}`)
+                                    continue
+                                }
+                                //this.log.debug(`sssss ${a}`)
+                                visited[a] = a      
+                                //console.log(`yyyy ${JSON.stringify(visited)}`)                          
+                            }
+                        }
+                        const combined = []
+                        for (const fields of Object.keys(visited)) {
+                            combined.push(visited[fields])
+                        }
+                        additions[key] = combined
+
+
+                    } else {
+                        this.log.debug(`going deeper in compare 2 objects for ${key} : ${JSON.stringify(target[key])},  ${JSON.stringify(source[key])}, ${JSON.stringify(additions[key])}, ${JSON.stringify(modifications[key])}`)
+                        this.compareDeep(target[key], source[key], additions[key], modifications[key])  
+                    }
+                } else {
+                    this.log.debug(`Checking for property ${key} ${target[key]} ${source[key]}`)
+                    if (!target[key]) {
+                        additions[key] = source[key]
+                        //delete modifications[key]
+                    } else if (target[key] !== source[key]) {
+                        modifications[key] =  source[key]
+                        //delete additions[key]
+                    }
+                }
+                if (this.isEmpty(modifications[key])) {
+                    delete modifications[key]
+                }
+                if (this.isEmpty(additions[key])) {
+                    delete additions[key]
+                }
+            }
+        }
+        //return ({ target, source, additions, modifications });
+        return ({ additions, modifications });
+    }
+}
+module.exports = MergeDeep

--- a/lib/nopcommand.js
+++ b/lib/nopcommand.js
@@ -1,0 +1,16 @@
+class NopCommand {
+    
+    constructor(pluginName, repo, endpoint, action) {
+        this.plugin = pluginName
+        this.repo = repo.repo
+        this.endpoint = endpoint?endpoint.url:""
+        this.body = endpoint?endpoint.body:""
+        this.action = action                     
+    }
+
+    toString() {
+        return `${this.plugin} plugin will perform ${this.action} using this API ${this.endpoint} passing ${JSON.stringify(this.body, null, 4)}`
+    }
+
+}
+module.exports = NopCommand

--- a/lib/nopcommand.js
+++ b/lib/nopcommand.js
@@ -1,6 +1,7 @@
 class NopCommand {
     
-    constructor(pluginName, repo, endpoint, action) {
+    constructor(pluginName, repo, endpoint, action, type = "INFO") {
+        this.type = type
         this.plugin = pluginName
         this.repo = repo.repo
         this.endpoint = endpoint?endpoint.url:""

--- a/lib/plugins/branches.js
+++ b/lib/plugins/branches.js
@@ -9,6 +9,21 @@ module.exports = class Branches {
     this.log = log
     this.nop = nop
   }
+  static canOverride(target, source) {
+    if (target.protection.required_pull_request_reviews.required_approving_review_count && source.protection.required_pull_request_reviews.required_approving_review_count ) {
+      return source.protection.required_pull_request_reviews.required_approving_review_count >= target.protection.required_pull_request_reviews.required_approving_review_count 
+    }
+    return true
+  }
+
+  static canOverrideStr(target, source) {
+    if (target.protection.required_pull_request_reviews.required_approving_review_count && source.protection.required_pull_request_reviews.required_approving_review_count ) {
+      if (!(source.protection.required_pull_request_reviews.required_approving_review_count >= target.protection.required_pull_request_reviews.required_approving_review_count)) {
+        return `Branch protection required_approving_review_count cannot be overidden to a lower value`
+      }
+    }
+    return ``
+  }
 
   sync () {
     //this.log(`Syncing branches ${JSON.stringify(this.branches)}`)

--- a/lib/plugins/branches.js
+++ b/lib/plugins/branches.js
@@ -1,43 +1,64 @@
+const NopCommand = require('../nopcommand')
 const previewHeaders = { accept: 'application/vnd.github.hellcat-preview+json,application/vnd.github.luke-cage-preview+json,application/vnd.github.zzzax-preview+json' }
 
 module.exports = class Branches {
-  constructor (github, repo, settings, log) {
+  constructor (nop, github, repo, settings, log) {
     this.github = github
     this.repo = repo
     this.branches = settings
     this.log = log
+    this.nop = nop
   }
 
   sync () {
     //this.log(`Syncing branches ${JSON.stringify(this.branches)}`)
-    return Promise.all(
-      this.branches
-        .filter(branch => branch.protection !== undefined)
-        .map(async (branch) => {
-          let params = Object.assign(this.repo, { branch: branch.name })
-          if (this.isEmpty(branch.protection)) {
-            if (branch.name === 'default') {
- //             this.log('calling get repo')
-              const result = await this.github.repos.get(this.repo)
- //             this.log(`after calling ${result}`)
-              params = Object.assign(this.repo, { branch: result.data.default_branch })
-              this.log(`Deleting default branch protection for branch ${result.data.default_branch}`)
+    return this.github.repos.get(this.repo).then(() => { 
+      return Promise.all(
+        this.branches
+          .filter(branch => branch.protection !== undefined)
+          .map(async (branch) => {
+            let params = Object.assign(this.repo, { branch: branch.name })
+            if (this.isEmpty(branch.protection)) {
+              if (branch.name === 'default') {
+   //             this.log('calling get repo')
+                const result = await this.github.repos.get(this.repo)
+   //             this.log(`after calling ${result}`)
+                params = Object.assign(this.repo, { branch: result.data.default_branch })
+                this.log(`Deleting default branch protection for branch ${result.data.default_branch}`)
+              }
+              if (this.nop) {
+                return Promise.resolve([
+                  new NopCommand(this.constructor.name, this.repo, this.github.repos.deleteBranchProtection.endpoint(params), "Delete Branch Protection"),
+                ])
+              }
+              return this.github.repos.deleteBranchProtection(params).catch(e => {return []})
+            } else {
+              if (branch.name === 'default') {
+   //             this.log('calling get repo')
+                const result = await this.github.repos.get(this.repo)
+   //             this.log(`after calling ${result}`)
+                params = Object.assign(this.repo, { branch: result.data.default_branch })
+                this.log(`Setting default branch protection for branch ${result.data.default_branch}`)
+              }
+              Object.assign(params, branch.protection, { headers: previewHeaders })
+              this.log(`Adding branch protection ${JSON.stringify(params)}`)
+              if (this.nop) {
+                return Promise.resolve([
+                  new NopCommand(this.constructor.name, this.repo, this.github.repos.updateBranchProtection.endpoint(params), "Add Branch Protection"),
+                ])
+              }
+              return this.github.repos.updateBranchProtection(params).then(res => this.log(`Branch protection applied successfully ${JSON.stringify(res.url)}`)).catch(e => {return []})      
             }
-            return this.github.repos.deleteBranchProtection(params)
-          } else {
-            if (branch.name === 'default') {
- //             this.log('calling get repo')
-              const result = await this.github.repos.get(this.repo)
- //             this.log(`after calling ${result}`)
-              params = Object.assign(this.repo, { branch: result.data.default_branch })
-              this.log(`Setting default branch protection for branch ${result.data.default_branch}`)
-            }
-            Object.assign(params, branch.protection, { headers: previewHeaders })
-            this.log(`Adding branch protection ${JSON.stringify(params)}`)
-            return this.github.repos.updateBranchProtection(params).then(res => this.log(`Branch protection applied successfully ${JSON.stringify(res.url)}`))      
-          }
-        })
-    )
+          })
+      )
+    })
+    .catch(e => {
+      //this.log.error(` Error ${JSON.stringify(e)}`)
+      if (e.status === 404) {
+        return Promise.resolve([])
+      }
+    })
+
   }
 
   isEmpty (maybeEmpty) {

--- a/lib/plugins/branches.js
+++ b/lib/plugins/branches.js
@@ -9,25 +9,32 @@ module.exports = class Branches {
   }
 
   sync () {
-    this.log(`Syncing branches ${JSON.stringify(this.branches)}`)
+    //this.log(`Syncing branches ${JSON.stringify(this.branches)}`)
     return Promise.all(
       this.branches
         .filter(branch => branch.protection !== undefined)
         .map(async (branch) => {
           let params = Object.assign(this.repo, { branch: branch.name })
           if (this.isEmpty(branch.protection)) {
-            return this.github.repos.removeBranchProtection(params)
+            if (branch.name === 'default') {
+ //             this.log('calling get repo')
+              const result = await this.github.repos.get(this.repo)
+ //             this.log(`after calling ${result}`)
+              params = Object.assign(this.repo, { branch: result.data.default_branch })
+              this.log(`Deleting default branch protection for branch ${result.data.default_branch}`)
+            }
+            return this.github.repos.deleteBranchProtection(params)
           } else {
             if (branch.name === 'default') {
-              this.log('calling get repo')
+ //             this.log('calling get repo')
               const result = await this.github.repos.get(this.repo)
-              this.log(`after calling ${result}`)
+ //             this.log(`after calling ${result}`)
               params = Object.assign(this.repo, { branch: result.data.default_branch })
               this.log(`Setting default branch protection for branch ${result.data.default_branch}`)
             }
             Object.assign(params, branch.protection, { headers: previewHeaders })
             this.log(`Adding branch protection ${JSON.stringify(params)}`)
-            return this.github.repos.updateBranchProtection(params)
+            return this.github.repos.updateBranchProtection(params).then(res => this.log(`Branch protection applied successfully ${JSON.stringify(res.url)}`))      
           }
         })
     )

--- a/lib/plugins/branches.js
+++ b/lib/plugins/branches.js
@@ -1,4 +1,6 @@
 const NopCommand = require('../nopcommand')
+const MergeDeep = require('../mergeDeep')
+const ignorableFields = []
 const previewHeaders = { accept: 'application/vnd.github.hellcat-preview+json,application/vnd.github.luke-cage-preview+json,application/vnd.github.zzzax-preview+json' }
 
 module.exports = class Branches {
@@ -26,6 +28,7 @@ module.exports = class Branches {
   }
 
   sync () {
+    const resArray = []
     //this.log(`Syncing branches ${JSON.stringify(this.branches)}`)
     return this.github.repos.get(this.repo).then(() => { 
       return Promise.all(
@@ -35,32 +38,42 @@ module.exports = class Branches {
             let params = Object.assign(this.repo, { branch: branch.name })
             if (this.isEmpty(branch.protection)) {
               if (branch.name === 'default') {
-   //             this.log('calling get repo')
                 const result = await this.github.repos.get(this.repo)
-   //             this.log(`after calling ${result}`)
                 params = Object.assign(this.repo, { branch: result.data.default_branch })
                 this.log(`Deleting default branch protection for branch ${result.data.default_branch}`)
               }
               if (this.nop) {
-                return Promise.resolve([
+                resArray.concat([
                   new NopCommand(this.constructor.name, this.repo, this.github.repos.deleteBranchProtection.endpoint(params), "Delete Branch Protection"),
                 ])
+                return Promise.resolve(resArray)
               }
               return this.github.repos.deleteBranchProtection(params).catch(e => {return []})
             } else {
               if (branch.name === 'default') {
-   //             this.log('calling get repo')
                 const result = await this.github.repos.get(this.repo)
-   //             this.log(`after calling ${result}`)
                 params = Object.assign(this.repo, { branch: result.data.default_branch })
                 this.log(`Setting default branch protection for branch ${result.data.default_branch}`)
+              }
+              
+              if (this.nop) {
+                try {
+                  const result = await this.github.repos.getBranchProtection(params)
+                  const mergeDeep = new MergeDeep(this.log,ignorableFields)
+                  const results = JSON.stringify(mergeDeep.compareDeep(result.data, branch.protection),null,2)
+                  this.log(`Result of compareDeep = ${results}`)
+                  resArray.push(new NopCommand("Branch Protection", this.repo, null, `Followings changes will be applied to the branch protection for ${params.branch} branch = ${results}`))
+                } catch(e){
+                  this.log.error(e)
+                }
               }
               Object.assign(params, branch.protection, { headers: previewHeaders })
               this.log(`Adding branch protection ${JSON.stringify(params)}`)
               if (this.nop) {
-                return Promise.resolve([
+                resArray.push(
                   new NopCommand(this.constructor.name, this.repo, this.github.repos.updateBranchProtection.endpoint(params), "Add Branch Protection"),
-                ])
+                )
+                return Promise.resolve(resArray)
               }
               return this.github.repos.updateBranchProtection(params).then(res => this.log(`Branch protection applied successfully ${JSON.stringify(res.url)}`)).catch(e => {return []})      
             }

--- a/lib/plugins/collaborators.js
+++ b/lib/plugins/collaborators.js
@@ -11,7 +11,14 @@ module.exports = class Collaborators extends Diffable {
       })
     }
   }
+  
+  static canOverride(target, source) {
+    return true
+  }
 
+  static canOverrideStr(target, source) {
+    return ``
+  }
   find () {
     //this.log.debug(`Finding collaborators for { repo: ${this.repo.repo}, owner: ${this.repo.owner}, affiliation: 'direct', 'outside', and 'pending invites' }`)
     return Promise.all([this.github.repos.listCollaborators({ repo: this.repo.repo, owner: this.repo.owner, affiliation: 'direct' }),

--- a/lib/plugins/collaborators.js
+++ b/lib/plugins/collaborators.js
@@ -13,14 +13,14 @@ module.exports = class Collaborators extends Diffable {
   }
 
   find () {
-    this.log.debug(`Finding collaborators for { repo: ${this.repo.repo}, owner: ${this.repo.owner}, affiliation: 'direct', 'outside', and 'pending invites' }`)
+    //this.log.debug(`Finding collaborators for { repo: ${this.repo.repo}, owner: ${this.repo.owner}, affiliation: 'direct', 'outside', and 'pending invites' }`)
     return Promise.all([this.github.repos.listCollaborators({ repo: this.repo.repo, owner: this.repo.owner, affiliation: 'direct' }),
     this.github.repos.listCollaborators({ repo: this.repo.repo, owner: this.repo.owner, affiliation: 'outside' }),
     this.github.repos.listInvitations({ repo: this.repo.repo, owner: this.repo.owner })])
     .then(res => {
-      this.log.debug('Finding direct collaborators Succeeded ', res[0].data)
-      this.log.debug('Finding outside collaborators Succeeded ', res[1].data)
-      this.log.debug('Finding Invitations Succeeded ', res[2].data)
+      //this.log.debug('Finding direct collaborators Succeeded ', res[0].data)
+      //this.log.debug('Finding outside collaborators Succeeded ', res[1].data)
+      //this.log.debug('Finding Invitations Succeeded ', res[2].data)
       let results0 =  res[0].data.map(user => {
         return {
           // Force all usernames to lowercase to avoid comparison issues.
@@ -52,9 +52,9 @@ module.exports = class Collaborators extends Diffable {
           (invite.permissions === 'write' && 'push')
         }
       })
-      this.log.debug(`direct collaborators ${JSON.stringify(results0)}`)      
-      this.log.debug(`outside collaborators ${JSON.stringify(results1)}`)      
-      this.log.debug(`pending invites ${JSON.stringify(results2)}`)
+      //this.log.debug(`direct collaborators ${JSON.stringify(results0)}`)      
+      //this.log.debug(`outside collaborators ${JSON.stringify(results1)}`)      
+      //this.log.debug(`pending invites ${JSON.stringify(results2)}`)
       return results0.concat(results1).concat(results2)
     })
     .catch(e => {

--- a/lib/plugins/collaborators.js
+++ b/lib/plugins/collaborators.js
@@ -97,6 +97,11 @@ module.exports = class Collaborators extends Diffable {
   add (attrs) {
     const data = Object.assign({}, attrs, this.repo)
     // console.log('Adding collaborator ', data)
+    if (this.nop) {
+      return Promise.resolve([
+        new NopCommand(this.constructor.name, this.repo, this.github.repos.addCollaborator.endpoint(data), "Add Collaborators"),
+      ])
+    }
     return this.github.repos.addCollaborator(data)
   }
 
@@ -106,15 +111,33 @@ module.exports = class Collaborators extends Diffable {
     (permissions === 'pull' && 'read') ||
     (permissions === 'push' && 'write') }, this.repo)
     // console.log('Adding collaborator ', data)
+    if (this.nop) {
+      return Promise.resolve([
+        new NopCommand(this.constructor.name, this.repo, this.github.repos.updateInvitation.endpoint(data), "Update Invitation"),
+      ])
+    }
     return this.github.repos.updateInvitation(data)
   }
 
   remove (existing) {
     if (existing.pendinginvite) {
+      if (this.nop) {
+        return Promise.resolve([
+          new NopCommand(this.constructor.name, this.repo, this.github.repos.deleteInvitation.endpoint(
+            Object.assign(this.repo, { invitation_id: existing.invitation_id })), "Delete Invitation"),
+        ])
+      }
       return this.github.repos.deleteInvitation(
         Object.assign(this.repo, { invitation_id: existing.invitation_id })
       )
     } else {
+      if (this.nop) {
+        return Promise.resolve([
+          new NopCommand(this.constructor.name, this.repo, this.github.repos.removeCollaborator(
+            Object.assign(this.repo, { username: existing.username })
+          ), "Remove Collaborator"),
+        ])
+      }
       return this.github.repos.removeCollaborator(
         Object.assign(this.repo, { username: existing.username })
       )

--- a/lib/plugins/collaborators.js
+++ b/lib/plugins/collaborators.js
@@ -18,9 +18,6 @@ module.exports = class Collaborators extends Diffable {
     this.github.repos.listCollaborators({ repo: this.repo.repo, owner: this.repo.owner, affiliation: 'outside' }),
     this.github.repos.listInvitations({ repo: this.repo.repo, owner: this.repo.owner })])
     .then(res => {
-      //this.log.debug('Finding direct collaborators Succeeded ', res[0].data)
-      //this.log.debug('Finding outside collaborators Succeeded ', res[1].data)
-      //this.log.debug('Finding Invitations Succeeded ', res[2].data)
       let results0 =  res[0].data.map(user => {
         return {
           // Force all usernames to lowercase to avoid comparison issues.
@@ -52,9 +49,6 @@ module.exports = class Collaborators extends Diffable {
           (invite.permissions === 'write' && 'push')
         }
       })
-      //this.log.debug(`direct collaborators ${JSON.stringify(results0)}`)      
-      //this.log.debug(`outside collaborators ${JSON.stringify(results1)}`)      
-      //this.log.debug(`pending invites ${JSON.stringify(results2)}`)
       return results0.concat(results1).concat(results2)
     })
     .catch(e => {
@@ -62,19 +56,6 @@ module.exports = class Collaborators extends Diffable {
       return []
     })
 
-      // this.github.repos.listInvitations({ repo: this.repo.repo, owner: this.repo.owner })
-      // .then(res => {
-      //   this.log.debug('Finding Invitations Succeeded ', res.data)
-      //   return res.data.map(user => {
-      //     return {
-      //       // Force all usernames to lowercase to avoid comparison issues.
-      //       username: user.invitee.login.toLowerCase(),
-      //       permission: (user.permissions.admin && 'admin') ||
-      //         (user.permissions.push && 'push') ||
-      //         (user.permissions.pull && 'pull')
-      //     }
-      //   })
-      // })
   }
 
   comparator (existing, attrs) {

--- a/lib/plugins/diffable.js
+++ b/lib/plugins/diffable.js
@@ -30,32 +30,32 @@ module.exports = class Diffable {
 
   filterEntries () {
     let filteredEntries = Array.from(this.entries)
-    this.log.debug(` entries ${JSON.stringify(filteredEntries)}`)
+    //this.log.debug(` entries ${JSON.stringify(filteredEntries)}`)
     filteredEntries = filteredEntries.filter( attrs => {
       if (Array.isArray(attrs.exclude)) {
         if (!attrs.exclude.includes(this.repo.repo)) {
-          this.log.debug(`returning not excluded entry = ${JSON.stringify(attrs)} for repo ${this.repo.repo}`)
+          //this.log.debug(`returning not excluded entry = ${JSON.stringify(attrs)} for repo ${this.repo.repo}`)
           return true
         } else {
-          this.log.debug(`skipping excluded entry = ${JSON.stringify(attrs)} for repo ${this.repo.repo}`)
+          //this.log.debug(`skipping excluded entry = ${JSON.stringify(attrs)} for repo ${this.repo.repo}`)
           return false
         }
       } else {
-        this.log.debug(`No excludes. Returning unfiltered entries = ${JSON.stringify(attrs)} for repo ${this.repo.repo}`)
+        //this.log.debug(`No excludes. Returning unfiltered entries = ${JSON.stringify(attrs)} for repo ${this.repo.repo}`)
         return true
       }
     })
     filteredEntries = filteredEntries.filter( attrs => {
       if (Array.isArray(attrs.include)) {
         if (attrs.include.includes(this.repo.repo)) {
-          this.log.debug(`returning included entry  = ${JSON.stringify(attrs)} for repo ${this.repo.repo}`)
+          //this.log.debug(`returning included entry  = ${JSON.stringify(attrs)} for repo ${this.repo.repo}`)
           return true
         } else {
-          this.log.debug(`skipping not included entry = ${JSON.stringify(attrs)} for repo ${this.repo.repo}`)
+          //this.log.debug(`skipping not included entry = ${JSON.stringify(attrs)} for repo ${this.repo.repo}`)
           return false
         }
       } else {
-        this.log.debug(`No includes. Returning unfiltered entries = ${JSON.stringify(attrs)} for repo ${this.repo.repo}`)
+        //this.log.debug(`No includes. Returning unfiltered entries = ${JSON.stringify(attrs)} for repo ${this.repo.repo}`)
         return true
       }
     })
@@ -71,7 +71,7 @@ module.exports = class Diffable {
   sync () {
     if (this.entries) {
       let filteredEntries = this.filterEntries()
-      this.log.debug(`filtered entries are ${JSON.stringify(filteredEntries)}`)
+      //this.log.debug(`filtered entries are ${JSON.stringify(filteredEntries)}`)
       return this.find().then(existingRecords => {
         const changes = []
 

--- a/lib/plugins/diffable.js
+++ b/lib/plugins/diffable.js
@@ -60,10 +60,16 @@ module.exports = class Diffable {
       }
     })
     filteredEntries = filteredEntries.map(e => {
+
       let o = new Object();
-      o.username = e.username
-      o.name = e.name
-      o.permission = e.permission
+      for (const key in e) {
+        if (key !== 'include' && key !== 'exclude') {
+          Object.assign(o, {
+            [key]: e[key]
+          })
+        }
+      }
+      
       return o
       })
     return filteredEntries

--- a/lib/plugins/diffable.js
+++ b/lib/plugins/diffable.js
@@ -20,12 +20,12 @@
 //       }
 //     }
 module.exports = class Diffable {
-  constructor (github, repo, entries, log) {
+  constructor (nop, github, repo, entries, log) {
     this.github = github
     this.repo = repo
     this.entries = entries
     this.log = log
-
+    this.nop = nop
   }
 
   filterEntries () {
@@ -92,7 +92,13 @@ module.exports = class Diffable {
             changes.push(this.remove(x))
           }
         })
-
+        if (changes.length === 0) {
+          if (this.nop) {
+            return Promise.resolve([
+              //{plugin: this.constructor.name, repo: this.repo, action: `No changes`},
+            ])
+          }
+        }
         return Promise.all(changes)
       }).catch(e => {
         console.log(`error calling find for ${this.constructor.name} ${e}`)

--- a/lib/plugins/labels.js
+++ b/lib/plugins/labels.js
@@ -20,7 +20,7 @@ module.exports = class Labels extends Diffable {
   }
 
   find () {
-    this.log(`Finding labels for ${JSON.stringify(this.wrapAttrs({ per_page: 100 }))}`)
+    this.log.debug(`Finding labels for ${JSON.stringify(this.wrapAttrs({ per_page: 100 }))}`)
     const options = this.github.issues.listLabelsForRepo.endpoint.merge(this.wrapAttrs({ per_page: 100 }))
     return this.github.repos.get(this.repo).then(() => { 
       return this.github.paginate(options)
@@ -45,6 +45,7 @@ module.exports = class Labels extends Diffable {
     // Our settings file uses oldname for renaming labels,
     // however octokit/rest 16.30.1 uses the current_name attribute.
     // Future versions of octokit/rest will need name and new_name attrs.
+    this.log.debug(`Updating labels for ${JSON.stringify(attrs,null,4)}   ${JSON.stringify(this.repo,null,4)}`)
     attrs.current_name = attrs.oldname || attrs.name
     delete attrs.oldname
     if (this.nop) {
@@ -62,7 +63,7 @@ module.exports = class Labels extends Diffable {
       ])
     }
     this.log.debug(`Creating labels for ${JSON.stringify(attrs,null,4)}`)
-    return this.github.issues.createLabel(this.wrapAttrs(attrs))
+    return this.github.issues.createLabel(this.wrapAttrs(attrs)).catch(e => this.log.error(` ${JSON.stringify(e)}`))
   }
 
   remove (existing) {

--- a/lib/plugins/labels.js
+++ b/lib/plugins/labels.js
@@ -26,7 +26,7 @@ module.exports = class Labels extends Diffable {
       return this.github.paginate(options)
     })
     .catch(e => {
-      //this.log.error(` Error ${JSON.stringify(e)}`)
+      this.log.error(` Error ${JSON.stringify(e)}`)
       if (e.status === 404) {
         return Promise.resolve([])
       }
@@ -61,6 +61,7 @@ module.exports = class Labels extends Diffable {
         new NopCommand(this.constructor.name, this.repo, this.github.issues.createLabel.endpoint(this.wrapAttrs(attrs)),"Create label"),
       ])
     }
+    this.log.debug(`Creating labels for ${JSON.stringify(attrs,null,4)}`)
     return this.github.issues.createLabel(this.wrapAttrs(attrs))
   }
 

--- a/lib/plugins/labels.js
+++ b/lib/plugins/labels.js
@@ -18,6 +18,14 @@ module.exports = class Labels extends Diffable {
       })
     }
   }
+  
+  static canOverride(target, source) {
+    return true
+  }
+
+  static canOverrideStr(target, source) {
+    return ``
+  }
 
   find () {
     this.log.debug(`Finding labels for ${JSON.stringify(this.wrapAttrs({ per_page: 100 }))}`)

--- a/lib/plugins/labels.js
+++ b/lib/plugins/labels.js
@@ -1,4 +1,5 @@
 const Diffable = require('./diffable')
+const NopCommand = require('../nopcommand')
 const previewHeaders = { accept: 'application/vnd.github.symmetra-preview+json' }
 
 module.exports = class Labels extends Diffable {
@@ -21,7 +22,15 @@ module.exports = class Labels extends Diffable {
   find () {
     this.log(`Finding labels for ${JSON.stringify(this.wrapAttrs({ per_page: 100 }))}`)
     const options = this.github.issues.listLabelsForRepo.endpoint.merge(this.wrapAttrs({ per_page: 100 }))
-    return this.github.paginate(options)
+    return this.github.repos.get(this.repo).then(() => { 
+      return this.github.paginate(options)
+    })
+    .catch(e => {
+      //this.log.error(` Error ${JSON.stringify(e)}`)
+      if (e.status === 404) {
+        return Promise.resolve([])
+      }
+    })
   }
 
   comparator (existing, attrs) {
@@ -38,14 +47,29 @@ module.exports = class Labels extends Diffable {
     // Future versions of octokit/rest will need name and new_name attrs.
     attrs.current_name = attrs.oldname || attrs.name
     delete attrs.oldname
+    if (this.nop) {
+      return Promise.resolve([
+        new NopCommand(this.constructor.name, this.repo, this.github.issues.updateLabel.endpoint(this.wrapAttrs(attrs)),"Update label"),
+      ])
+    }
     return this.github.issues.updateLabel(this.wrapAttrs(attrs))
   }
 
   add (attrs) {
+    if (this.nop) {
+      return Promise.resolve([
+        new NopCommand(this.constructor.name, this.repo, this.github.issues.createLabel.endpoint(this.wrapAttrs(attrs)),"Create label"),
+      ])
+    }
     return this.github.issues.createLabel(this.wrapAttrs(attrs))
   }
 
   remove (existing) {
+    if (this.nop) {
+      return Promise.resolve([
+        new NopCommand(this.constructor.name, this.repo, this.github.issues.deleteLabel.endpoint(this.wrapAttrs({ name: existing.name })),"Delete label"),
+      ])
+    }
     return this.github.issues.deleteLabel(this.wrapAttrs({ name: existing.name }))
   }
 

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -2,7 +2,7 @@ module.exports = class Repository {
   constructor (github, repo, settings, installationId, log) {
     this.installationId = installationId
     this.github = github
-    this.settings = Object.assign({ mediaType: { previews: ['baptiste'] } }, settings, repo)
+    this.settings = Object.assign( { mediaType: { previews: ['nebula-preview'] } }, settings, repo)
     this.topics = this.settings.topics
     this.repo = repo
     this.log = log
@@ -10,14 +10,16 @@ module.exports = class Repository {
   }
 
   sync () {
-    this.log('Syncing Repo ', this.settings.name)
+    this.log.debug(`Syncing Repo ${this.settings.name}`)
     this.settings.name = this.settings.name || this.settings.repo
     return this.github.repos.get(this.repo).then(() => {
-      return this.updaterepo()
-    }).catch(e => {
+      return this.updaterepo().then(this.log(`Successfully updated the repo`)).catch(e => {this.log(`Error ${JSON.stringify(e)}`)})
+    })
+    .catch(e => {
+      //this.log.error(` Error ${JSON.stringify(e)}`)
       if (e.status === 404) {
         this.log('Creating repo with settings ', this.settings)
-        return this.github.repos.createInOrg(this.settings).then(newrepo => {
+        return this.github.repos.createInOrg(this.settings).then( () => {
           return this.updaterepo()
         })
       }
@@ -25,7 +27,7 @@ module.exports = class Repository {
   }
 
   updaterepo () {
-    this.log('Updating repo with settings ', this.settings)
+    this.log(`Updating repo with settings ${JSON.stringify(this.settings)}`)
     return this.github.repos.update(this.settings).then(() => {
       if (this.topics) {
         this.log('Updating repo with topics ', this.topics)

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -22,11 +22,21 @@ module.exports = class Repository {
     this.log.debug(`Syncing Repo ${this.settings.name}`)
     this.settings.name = this.settings.name || this.settings.repo
     
-    return this.github.repos.get(this.repo).then(() => {
-      return this.updaterepo().then(this.log(`Successfully updated the repo`)).catch(e => {this.log(`Error ${JSON.stringify(e)}`)})
+    return this.github.repos.get(this.repo)
+    .then( resp => {
+      if (this.settings.default_branch && (resp.data.default_branch !== this.settings.default_branch)) {
+        return this.renameBranch(resp.data.default_branch,this.settings.default_branch)
+      } 
+    })
+    .then(res => {
+      const resArray = [res]
+      // TODO May have to chain the nop results
+      return this.updaterepo().then( res => {
+        this.log(`Successfully updated the repo`)
+        return resArray.concat(res)
+      }).catch(e => {this.log(`Error ${JSON.stringify(e)}`)})
     })
     .catch(e => {
-      //this.log.error(` Error ${JSON.stringify(e)}`)
       if (e.status === 404) {
         if (this.force_create) {
           if (this.template) {
@@ -63,8 +73,26 @@ module.exports = class Repository {
           }
 
         }
+      } else {
+        this.log.error(` Error ${JSON.stringify(e)}`)
       }
     })
+  }
+
+  renameBranch (oldname, newname) {
+    const parms = {
+      owner: this.settings.owner,
+      repo: this.settings.repo,
+      branch: oldname,
+      new_name: newname
+    }
+    this.log.debug(`Rename default branch repo with settings ${JSON.stringify(parms)}`)
+    if (this.nop) {
+      return Promise.resolve([
+        new NopCommand(this.constructor.name, this.repo, this.github.repos.renameBranch.endpoint(parms),"Rename Branch"),
+      ])
+    }
+    return this.github.repos.renameBranch(parms)
   }
 
   updaterepo () {

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -1,33 +1,80 @@
+//const { restEndpointMethods } = require('@octokit/plugin-rest-endpoint-methods')
+//const EndPoints = require('@octokit/plugin-rest-endpoint-methods')
+const NopCommand = require('../nopcommand')
+
 module.exports = class Repository {
-  constructor (github, repo, settings, installationId, log) {
+  constructor (nop, github, repo, settings, installationId, log) {
     this.installationId = installationId
     this.github = github
     this.settings = Object.assign( { mediaType: { previews: ['nebula-preview'] } }, settings, repo)
     this.topics = this.settings.topics
     this.repo = repo
     this.log = log
+    this.nop = nop
+    this.force_create = this.settings.force_create
+    this.template = this.settings.template
     delete this.settings.topics
+    delete this.settings.force
+    delete this.settings.template
   }
 
   sync () {
     this.log.debug(`Syncing Repo ${this.settings.name}`)
     this.settings.name = this.settings.name || this.settings.repo
+    
     return this.github.repos.get(this.repo).then(() => {
       return this.updaterepo().then(this.log(`Successfully updated the repo`)).catch(e => {this.log(`Error ${JSON.stringify(e)}`)})
     })
     .catch(e => {
       //this.log.error(` Error ${JSON.stringify(e)}`)
       if (e.status === 404) {
-        this.log('Creating repo with settings ', this.settings)
-        return this.github.repos.createInOrg(this.settings).then( () => {
-          return this.updaterepo()
-        })
+        if (this.force_create) {
+          if (this.template) {
+            this.log(`Creating repo using template ${this.template}`)
+            const options = {template_owner: this.repo.owner, template_repo: this.template, owner: this.repo.owner, name: this.repo.repo, private: (this.settings.private?this.settings.private:true), description: this.settings.description?this.settings.description:"" }
+
+            if (this.nop) {
+              this.log.debug(`Creating Repo using template ${JSON.stringify(this.github.repos.createInOrg.endpoint(this.settings))}  `)
+              return Promise.resolve([
+                new NopCommand(this.constructor.name, this.repo, this.github.repos.createUsingTemplate.endpoint(options),"Create Repo Using Template"),
+              ])
+            }
+            return this.github.repos.createUsingTemplate(options).then( () => {
+              return this.updaterepo()
+            })
+          } else {
+            this.log('Creating repo with settings ', this.settings)
+            if (this.nop) {
+              this.log.debug(`Creating Repo ${JSON.stringify(this.github.repos.createInOrg.endpoint(this.settings))}  `)
+              return Promise.resolve([
+                new NopCommand(this.constructor.name, this.repo, this.github.repos.createInOrg.endpoint(this.settings),"Create Repo"),
+              ])
+            }
+            return this.github.repos.createInOrg(this.settings).then( () => {
+              return this.updaterepo()
+            })
+          }
+
+        } else {
+          if (this.nop) {
+            return Promise.resolve([
+              new NopCommand(this.constructor.name, this.repo, null,"Force_create is false. Skipping repo creation"),
+            ])
+          }
+
+        }
       }
     })
   }
 
   updaterepo () {
-    this.log(`Updating repo with settings ${JSON.stringify(this.settings)}`)
+    this.log.debug(`Updating repo with settings ${JSON.stringify(this.settings)}`)
+    if (this.nop) {
+
+      return Promise.resolve([
+        new NopCommand(this.constructor.name, this.repo, this.github.repos.update.endpoint(this.settings),"Update Repo"),
+      ])
+    }
     return this.github.repos.update(this.settings).then(() => {
       if (this.topics) {
         this.log('Updating repo with topics ', this.topics)

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -63,6 +63,14 @@ module.exports = class Repository {
     delete this.settings.template
   }
 
+  static canOverride(target, source) {
+    return true
+  }
+
+  static canOverrideStr(target, source) {
+    return ``
+  }
+
   sync () {
     const resArray = []
     this.log.debug(`Syncing Repo ${this.settings.name}`)

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -1,6 +1,51 @@
 //const { restEndpointMethods } = require('@octokit/plugin-rest-endpoint-methods')
 //const EndPoints = require('@octokit/plugin-rest-endpoint-methods')
 const NopCommand = require('../nopcommand')
+const MergeDeep = require('../mergeDeep')
+const ignorableFields = [
+  "id",
+  "node_id",
+  "full_name",
+  "private",
+  "fork",
+  "created_at",
+  "updated_at",
+  "pushed_at",
+  "size",
+  "stargazers_count",
+  "watchers_count",
+  "language",
+  "has_wiki",
+  "has_pages",
+  "forks_count",
+  "archived",
+  "disabled",
+  "open_issues_count",
+  "license",
+  "allow_forking",
+  "is_template",
+ // "topics",
+  "visibility",
+  "forks",
+  "open_issues",
+  "watchers",
+  "permissions",
+  "temp_clone_token",
+  "allow_merge_commit",
+  "allow_rebase_merge",
+  "allow_auto_merge",
+  "delete_branch_on_merge",
+  "organization",
+  "security_and_analysis",
+  "network_count",
+  "subscribers_count",
+  "mediaType",
+  "owner",
+  "org",
+  "force_create",
+  "auto_init",
+  "repo"
+]
 
 module.exports = class Repository {
   constructor (nop, github, repo, settings, installationId, log) {
@@ -13,23 +58,37 @@ module.exports = class Repository {
     this.nop = nop
     this.force_create = this.settings.force_create
     this.template = this.settings.template
-    delete this.settings.topics
+    //delete this.settings.topics
     delete this.settings.force
     delete this.settings.template
   }
 
   sync () {
+    const resArray = []
     this.log.debug(`Syncing Repo ${this.settings.name}`)
     this.settings.name = this.settings.name || this.settings.repo
     
     return this.github.repos.get(this.repo)
     .then( resp => {
+      if (this.nop) {
+        try {
+          const mergeDeep = new MergeDeep(this.log,ignorableFields)
+          const results = JSON.stringify(mergeDeep.compareDeep(resp.data, this.settings),null,2)
+          this.log(`Result of compareDeep = ${results}`)
+          resArray.push(new NopCommand("Repository", this.repo, null, `Followings changes will be applied to the repo settings = ${results}`))
+        } catch(e){
+          this.log.error(e)
+        }
+      }
+
       if (this.settings.default_branch && (resp.data.default_branch !== this.settings.default_branch)) {
-        return this.renameBranch(resp.data.default_branch,this.settings.default_branch)
+        return this.renameBranch(resp.data.default_branch,this.settings.default_branch).then()
       } 
     })
     .then(res => {
-      const resArray = [res]
+      resArray.concat(res)
+      // Remove topics as it would be handled seperately
+      delete this.settings.topics
       // TODO May have to chain the nop results
       return this.updaterepo().then( res => {
         this.log(`Successfully updated the repo`)
@@ -95,26 +154,36 @@ module.exports = class Repository {
     return this.github.repos.renameBranch(parms)
   }
 
-  updaterepo () {
-    this.log.debug(`Updating repo with settings ${JSON.stringify(this.settings)}`)
-    if (this.nop) {
+  updaterepo() {
+    const parms = {
+      owner: this.settings.owner,
+      repo: this.settings.repo,
+      //names: this.topics.split(/\s*,\s*/),
+      names: this.topics,
+      mediaType: {
+        previews: ['mercy']
+      }
+    }
 
-      return Promise.resolve([
+    this.log.debug(`Updating repo with settings ${JSON.stringify(this.topics)} ${JSON.stringify(this.settings)}`)
+    if (this.nop) {
+      let result = [
         new NopCommand(this.constructor.name, this.repo, this.github.repos.update.endpoint(this.settings),"Update Repo"),
-      ])
+      ]
+      if (this.topics) {
+        result.push(new NopCommand(this.constructor.name, this.repo, this.github.repos.replaceAllTopics.endpoint(parms),"Update Topics"))
+      }
+      return Promise.resolve(result)
     }
     return this.github.repos.update(this.settings).then(() => {
-      if (this.topics) {
-        this.log('Updating repo with topics ', this.topics)
-        return this.github.repos.replaceAllTopics({
-          owner: this.settings.owner,
-          repo: this.settings.repo,
-          names: this.topics.split(/\s*,\s*/),
-          mediaType: {
-            previews: ['mercy']
-          }
-        })
-      }
+      this.updatetopics(parms)
     })
+  }
+
+  updatetopics(parms) {
+    if (this.topics) {
+      this.log('Updating repo with topics ', this.topics)
+      return this.github.repos.replaceAllTopics(parms)
+    }
   }
 }

--- a/lib/plugins/teams.js
+++ b/lib/plugins/teams.js
@@ -1,5 +1,5 @@
 const Diffable = require('./diffable')
-
+const NopCommand = require('../nopcommand')
 // it is necessary to use this endpoint until GitHub Enterprise supports
 // the modern version under /orgs
 const teamRepoEndpoint = '/teams/:team_id/repos/:owner/:repo'
@@ -9,7 +9,7 @@ module.exports = class Teams extends Diffable {
   async find () {
     this.log('Finding teams')
     await snooze(2 * 1000)
-    return this.github.repos.listTeams(this.repo).then(res => res.data)
+    return this.github.repos.listTeams(this.repo).then(res => res.data).catch(e => {return []})
   }
 
   comparator (existing, attrs) {
@@ -21,6 +21,11 @@ module.exports = class Teams extends Diffable {
   }
 
   update (existing, attrs) {
+    if (this.nop) {
+      return Promise.resolve([
+        new NopCommand(this.constructor.name, this.repo, this.github.request.endpoint(`PUT ${teamRepoEndpoint}`, this.toParams(existing, attrs)),"Add Teams to Repo"),
+      ])
+    }
     return this.github.request(`PUT ${teamRepoEndpoint}`, this.toParams(existing, attrs))
   }
 
@@ -30,6 +35,11 @@ module.exports = class Teams extends Diffable {
     return this.github.teams.getByName({ org: this.repo.owner, team_slug: attrs.name }).then(res => {
       existing = res.data
       this.log(`adding team ${attrs.name} to repo ${this.repo.repo}`)
+      if (this.nop) {
+        return Promise.resolve([
+          new NopCommand(this.constructor.name, this.repo, this.github.teams.addOrUpdateRepoPermissionsInOrg.endpoint(this.toParams(existing, attrs)), "Add Teams to Repo"),
+        ])
+      }
       return this.github.teams.addOrUpdateRepoPermissionsInOrg(this.toParams(existing, attrs)).then(res => {
         this.log(`team added ${res}`)
       }).catch(e => {
@@ -38,6 +48,11 @@ module.exports = class Teams extends Diffable {
     }).catch(e => {
       if (e.status === 404) {
         this.log(`Creating teams {org: ${this.repo.owner}, name: ${attrs.name}`)
+        if (this.nop) {
+          return Promise.resolve([
+            new NopCommand(this.constructor.name, this.repo, this.github.teams.create.endpoint({ org: this.repo.owner, name: attrs.name }), "Create Team"),
+          ])
+        }
         return this.github.teams.create({ org: this.repo.owner, name: attrs.name }).then(res => {
           this.log('team created')
           existing = res.data
@@ -51,6 +66,14 @@ module.exports = class Teams extends Diffable {
   }
 
   remove (existing) {
+    if (this.nop) {
+      return Promise.resolve([
+        new NopCommand(this.constructor.name, this.repo, this.github.request(
+          `DELETE ${teamRepoEndpoint}`,
+          { team_id: existing.id, ...this.repo, org: this.repo.owner }
+        ), "DELETE Team"),
+      ])
+    }
     return this.github.request(
       `DELETE ${teamRepoEndpoint}`,
       { team_id: existing.id, ...this.repo, org: this.repo.owner }

--- a/lib/plugins/teams.js
+++ b/lib/plugins/teams.js
@@ -12,6 +12,14 @@ module.exports = class Teams extends Diffable {
     return this.github.repos.listTeams(this.repo).then(res => res.data).catch(e => {return []})
   }
 
+  static canOverride(target, source) {
+    return true
+  }
+
+  static canOverrideStr(target, source) {
+    return ``
+  }
+  
   comparator (existing, attrs) {
     return existing.slug === attrs.name
   }

--- a/lib/plugins/validator.js
+++ b/lib/plugins/validator.js
@@ -1,11 +1,13 @@
+const NopCommand = require('../nopcommand')
 module.exports = class Validator {
-  constructor (github, repo, settings, log) {
+  constructor (nop, github, repo, settings, log) {
     this.github = github
     this.pattern = settings.pattern
     //this.regex = /[a-zA-Z0-9_-]+_\w[a-zA-Z0-9_-]+.*/gm
     this.regex = new RegExp(this.pattern,'gm')
     this.repo = repo
     this.log = log
+    this.nop = nop
   }
 
   sync () {
@@ -19,6 +21,11 @@ module.exports = class Validator {
       }).then(res => {
         if (this.repo.repo.search(this.regex) >= 0) {
           this.log(`Repo ${this.repo.repo} Passed Validation for pattern ${this.pattern}`)
+          if (this.nop) {
+            return Promise.resolve([
+              new NopCommand(this.constructor.name, this.repo, null,`Passed Validation for pattern ${this.pattern}`),
+            ])
+          }
           if (res.data.names.find(x => x === 'validation-error')) {
             res.data.names = res.data.names.filter(x => x !== 'validation-error')
             return this.github.repos.replaceAllTopics({
@@ -32,6 +39,11 @@ module.exports = class Validator {
           }
         } else {
           this.log(`Repo ${this.repo.repo} Failed Validation for pattern ${this.pattern}`)
+          if (this.nop) {
+            return Promise.resolve([
+              new NopCommand(this.constructor.name, this.repo, null,`Failed Validation for pattern ${this.pattern}`),
+            ])
+          }
           if (!res.data.names.find(x => x === 'validation-error')) {
             res.data.names.push('validation-error')
             return this.github.repos.replaceAllTopics({
@@ -46,6 +58,7 @@ module.exports = class Validator {
         }
 
       })
+      .catch(() => {return})
       
     } catch (error) {
       this.log(`Error in Validation checking ${error}`)

--- a/lib/plugins/validator.js
+++ b/lib/plugins/validator.js
@@ -18,7 +18,7 @@ module.exports = class Validator {
         }
       }).then(res => {
         if (this.repo.repo.search(this.regex) >= 0) {
-          this.log(`Repo ${this.repo.repo} Passed Validation`)
+          this.log(`Repo ${this.repo.repo} Passed Validation for pattern ${this.pattern}`)
           if (res.data.names.find(x => x === 'validation-error')) {
             res.data.names = res.data.names.filter(x => x !== 'validation-error')
             return this.github.repos.replaceAllTopics({
@@ -31,7 +31,7 @@ module.exports = class Validator {
             })
           }
         } else {
-          this.log(`Repo ${this.repo.repo} Failed Validation`)
+          this.log(`Repo ${this.repo.repo} Failed Validation for pattern ${this.pattern}`)
           if (!res.data.names.find(x => x === 'validation-error')) {
             res.data.names.push('validation-error')
             return this.github.repos.replaceAllTopics({

--- a/lib/plugins/validator.js
+++ b/lib/plugins/validator.js
@@ -1,0 +1,56 @@
+module.exports = class Validator {
+  constructor (github, repo, settings, log) {
+    this.github = github
+    this.pattern = settings.pattern
+    //this.regex = /[a-zA-Z0-9_-]+_\w[a-zA-Z0-9_-]+.*/gm
+    this.regex = new RegExp(this.pattern,'gm')
+    this.repo = repo
+    this.log = log
+  }
+
+  sync () {
+    try {
+      return this.github.repos.getAllTopics({
+        owner: this.repo.owner,
+        repo: this.repo.repo,
+        mediaType: {
+          previews: ['mercy']
+        }
+      }).then(res => {
+        if (this.repo.repo.search(this.regex) >= 0) {
+          this.log(`Repo ${this.repo.repo} Passed Validation`)
+          if (res.data.names.find(x => x === 'validation-error')) {
+            res.data.names = res.data.names.filter(x => x !== 'validation-error')
+            return this.github.repos.replaceAllTopics({
+              owner: this.repo.owner,
+              repo: this.repo.repo,
+              names: res.data.names,
+              mediaType: {
+                previews: ['mercy']
+              }
+            })
+          }
+        } else {
+          this.log(`Repo ${this.repo.repo} Failed Validation`)
+          if (!res.data.names.find(x => x === 'validation-error')) {
+            res.data.names.push('validation-error')
+            return this.github.repos.replaceAllTopics({
+              owner: this.repo.owner,
+              repo: this.repo.repo,
+              names: res.data.names,
+              mediaType: {
+                previews: ['mercy']
+              }
+            })
+          }
+        }
+
+      })
+      
+    } catch (error) {
+      this.log(`Error in Validation checking ${error}`)
+    }
+
+  }
+
+}

--- a/lib/plugins/validator.js
+++ b/lib/plugins/validator.js
@@ -10,6 +10,14 @@ module.exports = class Validator {
     this.nop = nop
   }
 
+  static canOverride(target, source) {
+    return true
+  }
+
+  static canOverrideStr(target, source) {
+    return ``
+  }
+
   sync () {
     try {
       return this.github.repos.getAllTopics({

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -1,6 +1,6 @@
 const path = require('path')
-
 const fs = require('fs')
+const Glob = require('./glob')
 class Settings {
   static syncAll(context, repo, config) {
     const settings = new Settings(context, repo, config)
@@ -112,10 +112,21 @@ class Settings {
     // )
   }
 
+  getSubOrgConfig(repoName) {
+    for (let k of Object.keys(this.subOrgConfigs)) {
+      const repoPattern = new Glob(k)
+      if (repoName.search(repoPattern)>=0) {
+        return this.subOrgConfigs[k]
+      }
+    }
+    return undefined
+  }
+
   childPluginsList(repoName) {
     // Overlay with subOrgConfig
-    this.log.debug(`suborg config for ${repoName}  is ${JSON.stringify(this.subOrgConfigs[repoName])}`)
-    let newConfig = Object.assign({}, this.config, this.subOrgConfigs[repoName])
+    const subOrgConfig = this.getSubOrgConfig(repoName)
+    this.log.debug(`suborg config for ${repoName}  is ${JSON.stringify(subOrgConfig)}`)
+    let newConfig = Object.assign({}, this.config, subOrgConfig)
     this.log.debug(`new config  is ${JSON.stringify(newConfig)}`)
 
     const overrideRepoConfig = this.repoConfigs[`${repoName}.yml`]

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const fs = require('fs')
 const Glob = require('./glob')
+const NopCommand = require('./nopcommand')
 class Settings {
 
   static async syncAll(nop, context, repo, config, ref) {
@@ -36,11 +37,11 @@ class Settings {
       this.log.debug(`Not run in nop`)
       return
     }
-
+    let error = false;
     const pull_request = payload.check_run.check_suite.pull_requests[0]
     const commentmessage = `
-## Safe-Settings no-op summary
-### :white_check_mark: When the changes are merged it will result in the following:
+## Safe-Settings Validator summary
+### :robot: Please expand to see the details:
 ${this.results.reduce((x,y) => {
   if (!y) {
     return x
@@ -48,19 +49,28 @@ ${this.results.reduce((x,y) => {
   if (y.endpoint) {
     return `${x} 
 <details>
-  <summary>${y.plugin} plugin will perform \`${y.action}\` using this API ${y.endpoint}</summary> 
+  <summary>✅ ${y.plugin} plugin will perform \`${y.action}\` using this API ${y.endpoint}</summary> 
   The payload is:  
   ${JSON.stringify(y.body, null, 4)}
 </details>` 
   } else {
-    return `${x} 
+    if (y.type === "ERROR") {
+      error = true
+      return `${x} 
+<details>
+  <summary>❌ ${y.action}</summary> 
+</details>` 
+    } else {
+      return `${x} 
 <details>
   <summary>${y.plugin} plugin will perform \`${y.action}\`</summary> 
 </details>` 
+    }
   }
  
 }, '')}    
 `
+/*
     const newIssueComment = await
         this.github.issues.createComment({ 
           owner: payload.repository.owner.login,
@@ -68,17 +78,17 @@ ${this.results.reduce((x,y) => {
           issue_number: pull_request.number,
           body: commentmessage
         })
-
+*/
     const params = {
       owner: payload.repository.owner.login,
       repo: payload.repository.name,
       check_run_id: payload.check_run.id,
       status: 'completed',
-      conclusion: 'success',
+      conclusion: error?'failure':'success',
       completed_at: new Date((new Date()).setUTCHours(0, 0, 0, 0)).toISOString(),
       output: { 
-        title: "Finished with the NOP", 
-        summary: "All checks passed"
+        title: error?"Finished with error":"Finished with success", 
+        summary: commentmessage
       },
     }
 
@@ -382,7 +392,7 @@ ${this.results.reduce((x,y) => {
       const repo = { owner: this.repo.owner, repo: 'admin' }
       const params = Object.assign(repo, { path: filePath, ref: this.ref })
       const response = await this.github.repos.getContent(params).catch(e => {
-        console.error(`Error getting settings ${e}`)
+        this.log.error(`Error getting settings ${e}`)
       })
 
       // Ignore in case path is a folder
@@ -445,8 +455,39 @@ ${this.results.reduce((x,y) => {
           }
 
           if (Array.isArray(source[key]) && Array.isArray(target[key])) {
+            // Deep merge Array so that if the same element is there in source and target, 
+            // override the target with source otherwise include both source and target elements
+            const visited = {}
+            const combined = []
+            let index = 0
+            const temp = [...source[key],...target[key]]
+            this.log.debug(`merging array ${JSON.stringify(temp)}`)
+            for (const a of temp) {
+              if (visited[a.name]) {
+                if (!Settings.PLUGINS[key].canOverride(a, visited[a.name])) {
+                  if (this.nop) {
+                    const nopcommand = new NopCommand(this.constructor.name, this.repo, null,Settings.PLUGINS[key].canOverrideStr(a, visited[a.name]), "ERROR")
+                    console.error(`NOPCOMMAND ${JSON.stringify(nopcommand)}`)
+                    this.results = this.results.concat(nopcommand)
+                  } else {
+                    throw new Error(`Cannot override ${JSON.stringify(a)} with ${JSON.stringify(visited[a.name])}`)
+                  }
+                }
+                continue
+              } else if (visited[a.username]) {
+                continue
+              }
+              if (a.name) {
+                visited[a.name] = a
+              } else if (a.username) {
+                visited[a.username] = a
+              }
+              combined[index++] = a
+            }
+
+            this.log.debug(`merged array ${JSON.stringify(combined)}`)
             Object.assign(target, {
-              [key]: [...target[key],...source[key]]
+             [key]: combined
             })
           } else {
             this.mergeDeep(target[key], source[key]);

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -345,11 +345,15 @@ ${this.results.reduce((x,y) => {
       for (let override of overridePaths) {
         const data = await this.loadYaml(override.path)
         this.log.debug(`data = ${JSON.stringify(data)}`)
-        subOrgConfigs[override.name] = data
-        data.suborgrepos.forEach(repository => {
-          subOrgConfigs[repository]=data
-        })
+        
+        if (!data) {return subOrgConfigs}
 
+        subOrgConfigs[override.name] = data
+        if (data.suborgrepos) {
+          data.suborgrepos.forEach(repository => {
+            subOrgConfigs[repository]=data
+          })
+        }
         if (data.suborgteams) {
           const promises = data.suborgteams.map(  (teamslug) => {
             return this.getReposForTeam(teamslug)

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -114,10 +114,13 @@ class Settings {
 
   childPluginsList(repoName) {
     // Overlay with subOrgConfig
+    this.log.debug(`suborg config for ${repoName}  is ${JSON.stringify(this.subOrgConfigs[repoName])}`)
     let newConfig = Object.assign({}, this.config, this.subOrgConfigs[repoName])
+    this.log.debug(`new config  is ${JSON.stringify(newConfig)}`)
+
     const overrideRepoConfig = this.repoConfigs[`${repoName}.yml`]
     if (overrideRepoConfig) {
-      newConfig = Object.assign({}, this.config, overrideRepoConfig)
+      newConfig = Object.assign({}, newConfig, overrideRepoConfig)
     }
     this.log.debug(`consolidated config is ${JSON.stringify(newConfig)}`)
     const childPlugins = []

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -1,58 +1,131 @@
+const path = require('path')
+
+const fs = require('fs')
 class Settings {
-  static syncAll (context, repo, config) {
-    return new Settings(context, repo, config).updateAll()
+  static syncAll(context, repo, config) {
+    const settings = new Settings(context, repo, config)
+    settings.loadConfigs()
+    return settings.updateAll()
   }
 
-  static sync (context, repo, config) {
-    return new Settings(context, repo, config).update()
+  static sync(context, repo, config) {
+    const settings = new Settings(context, repo, config)
+    settings.loadConfigs()
+    return settings.update()
   }
 
-  constructor (context, repo, config) {
+  constructor(context, repo, config) {
     this.context = context
     this.installation_id = context.payload.installation.id
     this.github = context.octokit
     this.repo = repo
-    this.org = repo.org
+    //this.org = repo.owner
     this.config = config
     this.log = context.log
+    //this.overridePaths =  getRepoConfigMap(this.github, this.repo, this.log)
+
   }
 
-  update () {
-    const childPlugins = this.childPluginsList()
-    return Promise.all(childPlugins.map(([Plugin, config]) => {
-      new Plugin(this.github, this.repo, config, this.log).sync()
-    }))
+  async loadConfigs() {    
+    this.repoConfigs = await this.getRepoConfigs(this.github, this.repo, this.log)
+    this.subOrgConfigs = await this.getSubOrgConfigs(this.github, this.repo, this.log)
   }
 
-  updateAll () {
-    const childPlugins = this.childPluginsList()
+  async update() {
+    this.subOrgConfigs = await this.getSubOrgConfigs(this.github, this.repo, this.log)
+    let repoConfig = this.config.repositories.find(config => {
+      //this.log.debug(`In update ${this.repo.owner}, ${config.org}, ${JSON.stringify(this.repo)}, ${config.name}`)
+      return this.repo.repo === config.name
+    })
+
+    // Overlay repo config
+    this.repoConfigs = await this.getRepoConfigs(this.github, this.repo, this.log)
+    const overrideRepoConfig = this.repoConfigs[`${this.repo.repo}.yml`]?.repository
+    //this.log.debug(`overrideRepoConfig =  ${JSON.stringify(overrideRepoConfig)}`)
+    if (overrideRepoConfig) {
+      repoConfig = Object.assign({}, repoConfig, overrideRepoConfig)
+    }
+    if (repoConfig) {
+      this.log.debug(`found a matching repoconfig for this repo ${JSON.stringify(repoConfig)}`)
+      const childPlugins = this.childPluginsList(this.repo.repo)
+      const RepoPlugin = Settings.PLUGINS.repository
+      return new RepoPlugin(this.github, this.repo, repoConfig, this.installation_id, this.log).sync().then( () => {
+        return Promise.all(
+          childPlugins.map(([Plugin, config]) => {
+            new Plugin(this.github, this.repo, config, this.log).sync()
+          }))
+        })
+    } else {
+      this.log.debug(`Didnt find any a matching repoconfig for this repo ${JSON.stringify(this.repo)} in ${JSON.stringify(this.repoConfigs)}`)
+      const childPlugins = this.childPluginsList(this.repo.repo)
+      return Promise.all(childPlugins.map(([Plugin, config]) => {
+        new Plugin(this.github, this.repo, config, this.log).sync()
+      }))
+    }
+  }
+
+  async updateAll() {
+    this.subOrgConfigs = await this.getSubOrgConfigs(this.github, this.repo, this.log)
+    this.repoConfigs = await this.getRepoConfigs(this.github, this.repo, this.log)
     return Promise.all(
       this.config.repositories.map(repoconfig => {
         const RepoPlugin = Settings.PLUGINS.repository
         const repo = Object.assign({ owner: repoconfig.org, repo: repoconfig.name })
         return new RepoPlugin(this.github, repo, repoconfig, this.installation_id, this.log).sync()
-      }),
-      eachRepository(childPlugins, this.github, this.config.restrictedRepos, this.log)
-    )
-  //   return new RepoPlugin(this.github, repo, repoconfig, this.installation_id, this.log).sync().then(() => {
-  //     return Promise.all(
-  //       childPlugins.map(
-  //         ([Plugin, config]) => { return new Plugin(this.github, repo, config, this.log).sync() }
-  //       )
-  //     )
-  //   })
-  // }),
-  // eachRepository(childPlugins,this.github, this.log)
-  // )
+      })).then(() => { 
+        return this.eachRepository(this.github, this.config.restrictedRepos, this.log)
+      })
+    
+    //   return new RepoPlugin(this.github, repo, repoconfig, this.installation_id, this.log).sync().then(() => {
+    //     return Promise.all(
+    //       childPlugins.map(
+    //         ([Plugin, config]) => { return new Plugin(this.github, repo, config, this.log).sync() }
+    //       )
+    //     )
+    //   })
+    // }),
+    // eachRepository(childPlugins,this.github, this.log)
+    // )
   }
 
-  childPluginsList () {
+  async updateSubOrg() {
+    this.repoConfigs = await this.getRepoConfigs(this.github, this.repo, this.log)
+    this.subOrgConfigs = await this.getSubOrgConfigs(this.github, this.repo, this.log)
+    return Promise.all(
+      this.config.repositories.map(repoconfig => {
+        const RepoPlugin = Settings.PLUGINS.repository
+        const repo = Object.assign({ owner: repoconfig.org, repo: repoconfig.name })
+        return new RepoPlugin(this.github, repo, repoconfig, this.installation_id, this.log).sync()
+      })).then(() => { 
+        return this.eachRepository(this.github, this.config.restrictedRepos, this.log)
+      })
+    
+    //   return new RepoPlugin(this.github, repo, repoconfig, this.installation_id, this.log).sync().then(() => {
+    //     return Promise.all(
+    //       childPlugins.map(
+    //         ([Plugin, config]) => { return new Plugin(this.github, repo, config, this.log).sync() }
+    //       )
+    //     )
+    //   })
+    // }),
+    // eachRepository(childPlugins,this.github, this.log)
+    // )
+  }
+
+  childPluginsList(repoName) {
+    // Overlay with subOrgConfig
+    let newConfig = Object.assign({}, this.config, this.subOrgConfigs[repoName])
+    const overrideRepoConfig = this.repoConfigs[`${repoName}.yml`]
+    if (overrideRepoConfig) {
+      newConfig = Object.assign({}, this.config, overrideRepoConfig)
+    }
+    this.log.debug(`consolidated config is ${JSON.stringify(newConfig)}`)
     const childPlugins = []
-    for (const [section, config] of Object.entries(this.config)) {
-      if (section !== 'repositories') {
-        this.log(`Found section ${section} in the config. Creating plugin...`)
+    for (const [section, config] of Object.entries(newConfig)) {
+      if (section !== 'repositories' && section !== 'repository') {
         // Ignore any config that is not a plugin
         if (section in Settings.PLUGINS) {
+          this.log.debug(`Found section ${section} in the config. Creating plugin...`)
           const Plugin = Settings.PLUGINS[section]
           childPlugins.push([Plugin, config])
         }
@@ -60,30 +133,205 @@ class Settings {
     }
     return childPlugins
   }
-}
 
-function eachRepository (childPlugins, github, restrictedRepos, log) {
-  log('Fetching repositories')
-  github.paginate('GET /installation/repositories').then(repositories => {
-    // Debating if we should put a Promise.all in the return
-    return repositories.forEach(repository => {
-      // Skip configuring any restricted repos
-      if (restrictedRepos.includes(repository.name)) {
-        log.debug(`Skipping retricted repo ${repository.name}`)
-        return
-      } else {
-        log.debug(`${repository.name} not in restricted repos ${restrictedRepos}`)
-      }
-      const { owner, name } = repository
-      return Promise.all(
-        childPlugins.map(
-          ([Plugin, config]) => { return new Plugin(github, { owner: owner.login, repo: name }, config, log).sync() }
+  eachRepository(github, restrictedRepos, log) {
+    log('Fetching repositories')
+    //let childPluginsList = this.childPluginsList
+    github.paginate('GET /installation/repositories').then(repositories => {
+      // Debating if we should put a Promise.all in the return
+      return repositories.forEach(repository => {
+        // Skip configuring any restricted repos
+        if (restrictedRepos.includes(repository.name)) {
+          log.debug(`Skipping retricted repo ${repository.name}`)
+          return
+        } else {
+          log.debug(`${repository.name} not in restricted repos ${restrictedRepos}`)
+        }
+        const { owner, name } = repository
+        const childPlugins = this.childPluginsList(name)
+        return Promise.all(
+          childPlugins.map(
+            ([Plugin, config]) => { return new Plugin(github, { owner: owner.login, repo: name }, config, log).sync() }
+          )
         )
-      )
+      })
     })
-  })
-}
+  }
 
+  /**
+   * Loads a file from GitHub
+   *
+   * @param params Params to fetch the file with
+   * @return The parsed YAML file
+   */
+  async loadConfigMap(params) {
+    try {
+      this.log.debug(` In loadConfigMap ${JSON.stringify(params)}`)
+      const response = await this.github.repos.getContent(params).catch(e => {
+        this.log.error(e)
+        this.log.error(`Error getting settings ${e}`)
+      })
+
+      if (!response) {
+        return
+      }
+      // Ignore in case path is a folder
+      // - https://developer.github.com/v3/repos/contents/#response-if-content-is-a-directory
+      if (Array.isArray(response.data)) {
+        //const overrides = new Map()
+        const overrides = response.data.map(d => { return { name: d.name, path: d.path } })
+        //response.data.forEach(d =>  overrides.set(d.name, d.path))
+        return overrides
+      }
+      // we don't handle symlinks or submodule
+      // - https://developer.github.com/v3/repos/contents/#response-if-content-is-a-symlink
+      // - https://developer.github.com/v3/repos/contents/#response-if-content-is-a-submodule
+      if (typeof response.data.content !== 'string') {
+        return
+      }
+      const yaml = require('js-yaml')
+      return yaml.load(Buffer.from(response.data.content, 'base64').toString()) || {}
+    } catch (e) {
+      if (e.status === 404) {
+        return null
+      }
+      throw e
+    }
+  }  
+
+  /**
+   * Loads a file from GitHub
+   *
+   * @param params Params to fetch the file with
+   * @return The parsed YAML file
+   */
+  async getRepoConfigMap() {
+    try {
+      this.log.debug(` In getRepoConfigMap ${JSON.stringify(this.repo)}`)
+      const repo = { owner: this.repo.owner, repo: 'admin' }
+      const CONFIG_PATH = '.github'
+      const params = Object.assign(repo, { path: path.posix.join(CONFIG_PATH, 'repos') })
+
+      const response = await this.loadConfigMap(params)
+      return response
+    } catch (e) {
+      throw e
+    }
+  }
+
+    /**
+   * Loads a file from GitHub
+   *
+   * @param params Params to fetch the file with
+   * @return The parsed YAML file
+   */
+  async getSubOrgConfigMap() {
+    try {
+      this.log.debug(` In getRepoConfigMap ${JSON.stringify(this.repo)}`)
+      const repo = { owner: this.repo.owner, repo: 'admin' }
+      const CONFIG_PATH = '.github'
+      const params = Object.assign(repo, { path: path.posix.join(CONFIG_PATH, 'suborgs') })
+
+      const response = await this.loadConfigMap(params)
+      return response
+    } catch (e) {
+      throw e
+    }
+  }
+
+  /**
+   * Loads a file from GitHub
+   *
+   * @param params Params to fetch the file with
+   * @return The parsed YAML file
+   */
+  async getRepoConfigs() {
+    try {
+      const overridePaths = await this.getRepoConfigMap()
+      //log.debug(`XXXXXXX overridePaths = ${JSON.stringify(overridePaths)}`)
+      const repoConfigs = {}
+      //const overrideConfigs = []
+
+      for (let override of overridePaths) {
+        const data = await this.loadYaml(override.path)
+        this.log.debug(`data = ${JSON.stringify(data)}`)
+        //overrideConfigs.push({ name: override.name, path: override.path, data: data})
+        repoConfigs[override.name] = data
+      }
+      //log.debug(`override configs = ${JSON.stringify(overrideConfigs)}`)
+      this.log.debug(`repo configs = ${JSON.stringify(repoConfigs)}`)
+      return repoConfigs
+    } catch (e) {
+      throw e
+    }
+  }
+
+  /**
+   * Loads a file from GitHub
+   *
+   * @param params Params to fetch the file with
+   * @return The parsed YAML file
+   */
+  async getSubOrgConfigs() {
+    try {
+      const overridePaths = await this.getSubOrgConfigMap()
+      //log.debug(`XXXXXXX overridePaths = ${JSON.stringify(overridePaths)}`)
+      const subOrgConfigs = {}
+      //const overrideConfigs = []
+
+      for (let override of overridePaths) {
+        const data = await this.loadYaml(override.path)
+        this.log.debug(`data = ${JSON.stringify(data)}`)
+        //overrideConfigs.push({ name: override.name, path: override.path, data: data})
+        subOrgConfigs[override.name] = data
+        data.suborgrepos.forEach(repository => {
+          subOrgConfigs[repository]=data
+        })
+      }
+      //log.debug(`override configs = ${JSON.stringify(overrideConfigs)}`)
+      this.log.debug(`suborg configs = ${JSON.stringify(subOrgConfigs)}`)
+      return subOrgConfigs
+    } catch (e) {
+      throw e
+    }
+  }
+  /**
+   * Loads a file from GitHub
+   *
+   * @param params Params to fetch the file with
+   * @return The parsed YAML file
+   */
+  async loadYaml(filePath) {
+    try {
+      const repo = { owner: this.repo.owner, repo: 'admin' }
+      const params = Object.assign(repo, { path: filePath })
+      const response = await this.github.repos.getContent(params).catch(e => {
+        console.log(e)
+        console.error(`Error getting settings ${e}`)
+      })
+      //log.debug(`In loadYAML ${JSON.stringify(response.data)}`)
+      // Ignore in case path is a folder
+      // - https://developer.github.com/v3/repos/contents/#response-if-content-is-a-directory
+      if (Array.isArray(response.data)) {
+        return null
+      }
+      // we don't handle symlinks or submodule
+      // - https://developer.github.com/v3/repos/contents/#response-if-content-is-a-symlink
+      // - https://developer.github.com/v3/repos/contents/#response-if-content-is-a-submodule
+      if (typeof response.data.content !== 'string') {
+        return
+      }
+      const yaml = require('js-yaml')
+      return yaml.load(Buffer.from(response.data.content, 'base64').toString()) || {}
+    } catch (e) {
+      if (e.status === 404) {
+        return null
+      }
+      throw e
+    }
+  }
+
+}
 // async function eachRepository (context, config) {
 //   this.log('Fetching repositories')
 //   const github = context.github
@@ -98,13 +346,16 @@ function eachRepository (childPlugins, github, restrictedRepos, log) {
 
 Settings.FILE_NAME = '.github/settings.yml'
 
+
+
 Settings.PLUGINS = {
   repository: require('./plugins/repository'),
   labels: require('./plugins/labels'),
   collaborators: require('./plugins/collaborators'),
   teams: require('./plugins/teams'),
   milestones: require('./plugins/milestones'),
-  branches: require('./plugins/branches')
+  branches: require('./plugins/branches'),
+  validator: require('./plugins/validator')
 }
 
 module.exports = Settings

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -14,7 +14,7 @@ class Settings {
     const { payload } = context
     const settings = new Settings(nop, context, repo, config, ref)
     await settings.loadConfigs()
-    await settings.update()
+    await settings.updateRepos(repo)
     await settings.handleResults()
   }
 
@@ -36,6 +36,7 @@ class Settings {
       this.log.debug(`Not run in nop`)
       return
     }
+
     const pull_request = payload.check_run.check_suite.pull_requests[0]
     const commentmessage = `
 ## Safe-Settings no-op summary
@@ -91,36 +92,49 @@ ${this.results.reduce((x,y) => {
     this.subOrgConfigs = await this.getSubOrgConfigs(this.github, this.repo, this.log)
   }
 
-  async update() {
-    this.subOrgConfigs = await this.getSubOrgConfigs(this.github, this.repo, this.log)
-    let repoConfig = this.config.repositories.find(config => {
-      return this.repo.repo === config.name
-    })
+  async updateRepos(repo) {
+    this.subOrgConfigs = await this.getSubOrgConfigs(this.github, repo, this.log)
+    this.repoConfigs = await this.getRepoConfigs(this.github, repo, this.log)
+    let repoConfig = this.config.repository
+    if (repoConfig) {
+      repoConfig = Object.assign(repoConfig, {name: repo.repo, org: repo.owner})
+    }
+
+    const subOrgConfig = this.getSubOrgConfig(repo.repo)
+
+    if (subOrgConfig) {
+      let suborgRepoConfig = subOrgConfig.repository
+      if (suborgRepoConfig) {
+        suborgRepoConfig = Object.assign(suborgRepoConfig, {name: repo.repo, org: repo.owner})
+        repoConfig = this.mergeDeep({}, repoConfig, suborgRepoConfig)
+      }
+    }
+
     // Overlay repo config
-    this.repoConfigs = await this.getRepoConfigs(this.github, this.repo, this.log)
-    const overrideRepoConfig = this.repoConfigs[`${this.repo.repo}.yml`]?.repository
+    const overrideRepoConfig = this.repoConfigs[`${repo.repo}.yml`]?.repository
     if (overrideRepoConfig) {
-      //repoConfig = Object.assign({}, repoConfig, overrideRepoConfig)
       repoConfig = this.mergeDeep({}, repoConfig, overrideRepoConfig)
     }
     if (repoConfig) {
       this.log.debug(`found a matching repoconfig for this repo ${JSON.stringify(repoConfig)}`)
-      const childPlugins = this.childPluginsList(this.repo.repo)
+      const childPlugins = this.childPluginsList(repo.repo)
       const RepoPlugin = Settings.PLUGINS.repository
-      return new RepoPlugin(this.nop, this.github, this.repo, repoConfig, this.installation_id, this.log).sync().then( res => {
+      return new RepoPlugin(this.nop, this.github, repo, repoConfig, this.installation_id, this.log).sync().then( res => {
         this.appendToResults(res)
         return Promise.all(
           childPlugins.map(([Plugin, config]) => {
-            return new Plugin(this.nop, this.github, this.repo, config, this.log).sync()
+            return new Plugin(this.nop, this.github, repo, config, this.log).sync()
           }))
         }).then( res => {
           this.appendToResults(res)
         })
     } else {
-      this.log.debug(`Didnt find any a matching repoconfig for this repo ${JSON.stringify(this.repo)} in ${JSON.stringify(this.repoConfigs)}`)
-      const childPlugins = this.childPluginsList(this.repo.repo)
+      this.log.debug(`Didnt find any a matching repoconfig for this repo ${JSON.stringify(repo)} in ${JSON.stringify(this.repoConfigs)}`)
+      const childPlugins = this.childPluginsList(repo.repo)
       return Promise.all(childPlugins.map(([Plugin, config]) => {
-        return new Plugin(this.nop, this.github, this.repo, config, this.log).sync()
+        return new Plugin(this.nop, this.github, repo, config, this.log).sync().then( res => {
+           this.appendToResults(res)
+         })
       }))
     }
   }
@@ -128,36 +142,10 @@ ${this.results.reduce((x,y) => {
   async updateAll() {
     this.subOrgConfigs = await this.getSubOrgConfigs(this.github, this.repo, this.log)
     this.repoConfigs = await this.getRepoConfigs(this.github, this.repo, this.log)
-    if (this.config.repositories.length > 0 ) {
-      return Promise.all(
-        this.config.repositories.map(repoconfig => {
-          const RepoPlugin = Settings.PLUGINS.repository
-          const repo = Object.assign({ owner: repoconfig.org, repo: repoconfig.name })
-          return new RepoPlugin(this.nop, this.github, repo, repoconfig, this.installation_id, this.log).sync()
-        })).then( res => { 
-          this.appendToResults(res)
-          return this.eachRepository(this.github, this.config.restrictedRepos, this.log)
-        }).then( res => { 
-          this.appendToResults(res)
-        })
-    } else {
-      return this.eachRepository(this.github, this.config.restrictedRepos, this.log).then( res => {
-        this.appendToResults(res)
-      })
-    }
-  }
+    return this.eachRepositoryRepos(this.github, this.config.restrictedRepos, this.log).then( res => {
+      this.appendToResults(res)
+    })
 
-  async updateSubOrg() {
-    this.repoConfigs = await this.getRepoConfigs(this.github, this.repo, this.log)
-    this.subOrgConfigs = await this.getSubOrgConfigs(this.github, this.repo, this.log)
-    return Promise.all(
-      this.config.repositories.map(repoconfig => {
-        const RepoPlugin = Settings.PLUGINS.repository
-        const repo = Object.assign({ owner: repoconfig.org, repo: repoconfig.name })
-        return new RepoPlugin(this.nop, this.github, repo, repoconfig, this.installation_id, this.log).sync()
-      })).then(() => { 
-        return this.eachRepository(this.github, this.config.restrictedRepos, this.log)
-      })
   }
 
   getSubOrgConfig(repoName) {
@@ -174,13 +162,11 @@ ${this.results.reduce((x,y) => {
     // Overlay with subOrgConfig
     const subOrgConfig = this.getSubOrgConfig(repoName)
     this.log.debug(`suborg config for ${repoName}  is ${JSON.stringify(subOrgConfig)}`)
-    //let newConfig = Object.assign({}, this.config, subOrgConfig)
     let newConfig = this.mergeDeep({}, this.config, subOrgConfig)
     this.log.debug(`new config  is ${JSON.stringify(newConfig)}`)
 
     const overrideRepoConfig = this.repoConfigs[`${repoName}.yml`]
     if (overrideRepoConfig) {
-      //newConfig = Object.assign({}, newConfig, overrideRepoConfig)
       newConfig = this.mergeDeep({}, newConfig, overrideRepoConfig)
     }
     this.log.debug(`consolidated config is ${JSON.stringify(newConfig)}`)
@@ -198,7 +184,7 @@ ${this.results.reduce((x,y) => {
     return childPlugins
   }
 
-  async eachRepository(github, restrictedRepos, log) {
+  async eachRepositoryChildPlugins(github, restrictedRepos, log) {
     log.debug('Fetching repositories')
     return github.paginate('GET /installation/repositories').then(repositories => {
       return Promise.all(repositories.map(repository => {
@@ -218,6 +204,24 @@ ${this.results.reduce((x,y) => {
         ).then( res => {
           return res
         })
+      })
+      )
+    })
+  }
+
+  async eachRepositoryRepos(github, restrictedRepos, log) {
+    log.debug('Fetching repositories')
+    return github.paginate('GET /installation/repositories').then(repositories => {
+      return Promise.all(repositories.map(repository => {
+        // Skip configuring any restricted repos
+        if (restrictedRepos.includes(repository.name)) {
+          log.debug(`Skipping retricted repo ${repository.name}`)
+          return 
+        } else {
+          log.debug(`${repository.name} not in restricted repos ${restrictedRepos}`)
+        }
+        const { owner, name } = repository
+        return this.updateRepos({ owner: owner.login, repo: name })
       })
       )
     })
@@ -350,7 +354,6 @@ ${this.results.reduce((x,y) => {
           const promises = data.suborgteams.map(  (teamslug) => {
             return this.getReposForTeam(teamslug)
           })
-  
           await Promise.all(promises).then(res => {
             res.forEach(r => {
               r.forEach(e => {
@@ -358,9 +361,7 @@ ${this.results.reduce((x,y) => {
               })
             })
           })        
-        }
-
-        
+        }   
       }
       return subOrgConfigs
     } catch (e) {
@@ -410,7 +411,6 @@ ${this.results.reduce((x,y) => {
   }
 
   async getReposForTeam(teamslug) {
-
     const options = this.github.rest.teams.listReposInOrg.endpoint.merge({
       org: this.repo.owner,
       team_slug: teamslug,
@@ -426,7 +426,6 @@ ${this.results.reduce((x,y) => {
   mergeDeep(target, ...sources) {
     if (!sources.length) return target;
     const source = sources.shift();
-
     if (this.isObject(target) && this.isObject(source)) {
       for (const key in source) {
         if (this.isObject(source[key]) || Array.isArray(source[key])) {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -63,7 +63,7 @@ ${this.results.reduce((x,y) => {
     } else {
       return `${x} 
 <details>
-  <summary>${y.plugin} plugin will perform \`${y.action}\`</summary> 
+  <summary>ℹ️ ${y.plugin} : ${y.repo} : ${y.action}</summary> 
 </details>` 
     }
   }
@@ -126,18 +126,30 @@ ${this.results.reduce((x,y) => {
       repoConfig = this.mergeDeep({}, repoConfig, overrideRepoConfig)
     }
     if (repoConfig) {
-      this.log.debug(`found a matching repoconfig for this repo ${JSON.stringify(repoConfig)}`)
-      const childPlugins = this.childPluginsList(repo.repo)
-      const RepoPlugin = Settings.PLUGINS.repository
-      return new RepoPlugin(this.nop, this.github, repo, repoConfig, this.installation_id, this.log).sync().then( res => {
-        this.appendToResults(res)
-        return Promise.all(
-          childPlugins.map(([Plugin, config]) => {
-            return new Plugin(this.nop, this.github, repo, config, this.log).sync()
-          }))
-        }).then( res => {
+      try {
+        this.log.debug(`found a matching repoconfig for this repo ${JSON.stringify(repoConfig)}`)
+        const childPlugins = this.childPluginsList(repo.repo)
+        const RepoPlugin = Settings.PLUGINS.repository
+        return new RepoPlugin(this.nop, this.github, repo, repoConfig, this.installation_id, this.log).sync().then( res => {
           this.appendToResults(res)
-        })
+          return Promise.all(
+            childPlugins.map(([Plugin, config]) => {
+              return new Plugin(this.nop, this.github, repo, config, this.log).sync()
+            }))
+          }).then( res => {
+            this.appendToResults(res)
+          })
+      } catch(e) {
+        if (this.nop) {
+          const nopcommand = new NopCommand(this.constructor.name, this.repo, null,e, "ERROR")
+          console.error(`NOPCOMMAND ${JSON.stringify(nopcommand)}`)
+          this.appendToResults([nopcommand])
+          //throw e
+        } else {
+          throw e
+        }
+      }
+
     } else {
       this.log.debug(`Didnt find any a matching repoconfig for this repo ${JSON.stringify(repo)} in ${JSON.stringify(this.repoConfigs)}`)
       const childPlugins = this.childPluginsList(repo.repo)
@@ -465,13 +477,7 @@ ${this.results.reduce((x,y) => {
             for (const a of temp) {
               if (visited[a.name]) {
                 if (!Settings.PLUGINS[key].canOverride(a, visited[a.name])) {
-                  if (this.nop) {
-                    const nopcommand = new NopCommand(this.constructor.name, this.repo, null,Settings.PLUGINS[key].canOverrideStr(a, visited[a.name]), "ERROR")
-                    console.error(`NOPCOMMAND ${JSON.stringify(nopcommand)}`)
-                    this.results = this.results.concat(nopcommand)
-                  } else {
-                    throw new Error(`Cannot override ${JSON.stringify(a)} with ${JSON.stringify(visited[a.name])}`)
-                  }
+                  throw new Error(Settings.PLUGINS[key].canOverrideStr(a, visited[a.name]))
                 }
                 continue
               } else if (visited[a.username]) {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -2,27 +2,87 @@ const path = require('path')
 const fs = require('fs')
 const Glob = require('./glob')
 class Settings {
-  static syncAll(context, repo, config) {
-    const settings = new Settings(context, repo, config)
-    settings.loadConfigs()
-    return settings.updateAll()
+
+  static async syncAll(nop, context, repo, config, ref) {
+    const settings = new Settings(nop, context, repo, config, ref)
+    await settings.loadConfigs()
+    await settings.updateAll()
+    await settings.handleResults()
   }
 
-  static sync(context, repo, config) {
-    const settings = new Settings(context, repo, config)
-    settings.loadConfigs()
-    return settings.update()
+  static async sync(nop, context, repo, config, ref) {
+    const { payload } = context
+    const settings = new Settings(nop, context, repo, config, ref)
+    await settings.loadConfigs()
+    await settings.update()
+    await settings.handleResults()
   }
 
-  constructor(context, repo, config) {
+  constructor(nop, context, repo, config, ref) {
+    this.ref = ref
     this.context = context
     this.installation_id = context.payload.installation.id
     this.github = context.octokit
     this.repo = repo
-    //this.org = repo.owner
     this.config = config
+    this.nop = nop
     this.log = context.log
-    //this.overridePaths =  getRepoConfigMap(this.github, this.repo, this.log)
+    this.results = []
+  }
+
+  async handleResults() {
+    const { payload } = this.context
+    if (!this.nop) {
+      this.log.debug(`Not run in nop`)
+      return
+    }
+    const pull_request = payload.check_run.check_suite.pull_requests[0]
+    const commentmessage = `
+## Safe-Settings no-op summary
+### :white_check_mark: When the changes are merged it will result in the following:
+${this.results.reduce((x,y) => {
+  if (!y) {
+    return x
+  }
+  if (y.endpoint) {
+    return `${x} 
+<details>
+  <summary>${y.plugin} plugin will perform \`${y.action}\` using this API ${y.endpoint}</summary> 
+  The payload is:  
+  ${JSON.stringify(y.body, null, 4)}
+</details>` 
+  } else {
+    return `${x} 
+<details>
+  <summary>${y.plugin} plugin will perform \`${y.action}\`</summary> 
+</details>` 
+  }
+ 
+}, '')}    
+`
+    const newIssueComment = await
+        this.github.issues.createComment({ 
+          owner: payload.repository.owner.login,
+          repo: payload.repository.name,
+          issue_number: pull_request.number,
+          body: commentmessage
+        })
+
+    const params = {
+      owner: payload.repository.owner.login,
+      repo: payload.repository.name,
+      check_run_id: payload.check_run.id,
+      status: 'completed',
+      conclusion: 'success',
+      completed_at: new Date((new Date()).setUTCHours(0, 0, 0, 0)).toISOString(),
+      output: { 
+        title: "Finished with the NOP", 
+        summary: "All checks passed"
+      },
+    }
+
+    this.log.debug(`Completing check run ${JSON.stringify(params)}`)
+    await this.github.checks.update(params)
 
   }
 
@@ -34,32 +94,33 @@ class Settings {
   async update() {
     this.subOrgConfigs = await this.getSubOrgConfigs(this.github, this.repo, this.log)
     let repoConfig = this.config.repositories.find(config => {
-      //this.log.debug(`In update ${this.repo.owner}, ${config.org}, ${JSON.stringify(this.repo)}, ${config.name}`)
       return this.repo.repo === config.name
     })
-
     // Overlay repo config
     this.repoConfigs = await this.getRepoConfigs(this.github, this.repo, this.log)
     const overrideRepoConfig = this.repoConfigs[`${this.repo.repo}.yml`]?.repository
-    //this.log.debug(`overrideRepoConfig =  ${JSON.stringify(overrideRepoConfig)}`)
     if (overrideRepoConfig) {
-      repoConfig = Object.assign({}, repoConfig, overrideRepoConfig)
+      //repoConfig = Object.assign({}, repoConfig, overrideRepoConfig)
+      repoConfig = this.mergeDeep({}, repoConfig, overrideRepoConfig)
     }
     if (repoConfig) {
       this.log.debug(`found a matching repoconfig for this repo ${JSON.stringify(repoConfig)}`)
       const childPlugins = this.childPluginsList(this.repo.repo)
       const RepoPlugin = Settings.PLUGINS.repository
-      return new RepoPlugin(this.github, this.repo, repoConfig, this.installation_id, this.log).sync().then( () => {
+      return new RepoPlugin(this.nop, this.github, this.repo, repoConfig, this.installation_id, this.log).sync().then( res => {
+        this.appendToResults(res)
         return Promise.all(
           childPlugins.map(([Plugin, config]) => {
-            new Plugin(this.github, this.repo, config, this.log).sync()
+            return new Plugin(this.nop, this.github, this.repo, config, this.log).sync()
           }))
+        }).then( res => {
+          this.appendToResults(res)
         })
     } else {
       this.log.debug(`Didnt find any a matching repoconfig for this repo ${JSON.stringify(this.repo)} in ${JSON.stringify(this.repoConfigs)}`)
       const childPlugins = this.childPluginsList(this.repo.repo)
       return Promise.all(childPlugins.map(([Plugin, config]) => {
-        new Plugin(this.github, this.repo, config, this.log).sync()
+        return new Plugin(this.nop, this.github, this.repo, config, this.log).sync()
       }))
     }
   }
@@ -67,25 +128,23 @@ class Settings {
   async updateAll() {
     this.subOrgConfigs = await this.getSubOrgConfigs(this.github, this.repo, this.log)
     this.repoConfigs = await this.getRepoConfigs(this.github, this.repo, this.log)
-    return Promise.all(
-      this.config.repositories.map(repoconfig => {
-        const RepoPlugin = Settings.PLUGINS.repository
-        const repo = Object.assign({ owner: repoconfig.org, repo: repoconfig.name })
-        return new RepoPlugin(this.github, repo, repoconfig, this.installation_id, this.log).sync()
-      })).then(() => { 
-        return this.eachRepository(this.github, this.config.restrictedRepos, this.log)
+    if (this.config.repositories.length > 0 ) {
+      return Promise.all(
+        this.config.repositories.map(repoconfig => {
+          const RepoPlugin = Settings.PLUGINS.repository
+          const repo = Object.assign({ owner: repoconfig.org, repo: repoconfig.name })
+          return new RepoPlugin(this.nop, this.github, repo, repoconfig, this.installation_id, this.log).sync()
+        })).then( res => { 
+          this.appendToResults(res)
+          return this.eachRepository(this.github, this.config.restrictedRepos, this.log)
+        }).then( res => { 
+          this.appendToResults(res)
+        })
+    } else {
+      return this.eachRepository(this.github, this.config.restrictedRepos, this.log).then( res => {
+        this.appendToResults(res)
       })
-    
-    //   return new RepoPlugin(this.github, repo, repoconfig, this.installation_id, this.log).sync().then(() => {
-    //     return Promise.all(
-    //       childPlugins.map(
-    //         ([Plugin, config]) => { return new Plugin(this.github, repo, config, this.log).sync() }
-    //       )
-    //     )
-    //   })
-    // }),
-    // eachRepository(childPlugins,this.github, this.log)
-    // )
+    }
   }
 
   async updateSubOrg() {
@@ -95,21 +154,10 @@ class Settings {
       this.config.repositories.map(repoconfig => {
         const RepoPlugin = Settings.PLUGINS.repository
         const repo = Object.assign({ owner: repoconfig.org, repo: repoconfig.name })
-        return new RepoPlugin(this.github, repo, repoconfig, this.installation_id, this.log).sync()
+        return new RepoPlugin(this.nop, this.github, repo, repoconfig, this.installation_id, this.log).sync()
       })).then(() => { 
         return this.eachRepository(this.github, this.config.restrictedRepos, this.log)
       })
-    
-    //   return new RepoPlugin(this.github, repo, repoconfig, this.installation_id, this.log).sync().then(() => {
-    //     return Promise.all(
-    //       childPlugins.map(
-    //         ([Plugin, config]) => { return new Plugin(this.github, repo, config, this.log).sync() }
-    //       )
-    //     )
-    //   })
-    // }),
-    // eachRepository(childPlugins,this.github, this.log)
-    // )
   }
 
   getSubOrgConfig(repoName) {
@@ -126,12 +174,14 @@ class Settings {
     // Overlay with subOrgConfig
     const subOrgConfig = this.getSubOrgConfig(repoName)
     this.log.debug(`suborg config for ${repoName}  is ${JSON.stringify(subOrgConfig)}`)
-    let newConfig = Object.assign({}, this.config, subOrgConfig)
+    //let newConfig = Object.assign({}, this.config, subOrgConfig)
+    let newConfig = this.mergeDeep({}, this.config, subOrgConfig)
     this.log.debug(`new config  is ${JSON.stringify(newConfig)}`)
 
     const overrideRepoConfig = this.repoConfigs[`${repoName}.yml`]
     if (overrideRepoConfig) {
-      newConfig = Object.assign({}, newConfig, overrideRepoConfig)
+      //newConfig = Object.assign({}, newConfig, overrideRepoConfig)
+      newConfig = this.mergeDeep({}, newConfig, overrideRepoConfig)
     }
     this.log.debug(`consolidated config is ${JSON.stringify(newConfig)}`)
     const childPlugins = []
@@ -148,16 +198,14 @@ class Settings {
     return childPlugins
   }
 
-  eachRepository(github, restrictedRepos, log) {
-    log('Fetching repositories')
-    //let childPluginsList = this.childPluginsList
-    github.paginate('GET /installation/repositories').then(repositories => {
-      // Debating if we should put a Promise.all in the return
-      return repositories.forEach(repository => {
+  async eachRepository(github, restrictedRepos, log) {
+    log.debug('Fetching repositories')
+    return github.paginate('GET /installation/repositories').then(repositories => {
+      return Promise.all(repositories.map(repository => {
         // Skip configuring any restricted repos
         if (restrictedRepos.includes(repository.name)) {
           log.debug(`Skipping retricted repo ${repository.name}`)
-          return
+          return 
         } else {
           log.debug(`${repository.name} not in restricted repos ${restrictedRepos}`)
         }
@@ -165,10 +213,13 @@ class Settings {
         const childPlugins = this.childPluginsList(name)
         return Promise.all(
           childPlugins.map(
-            ([Plugin, config]) => { return new Plugin(github, { owner: owner.login, repo: name }, config, log).sync() }
+            ([Plugin, config]) => { return new Plugin(this.nop, github, { owner: owner.login, repo: name }, config, log).sync() }
           )
-        )
+        ).then( res => {
+          return res
+        })
       })
+      )
     })
   }
 
@@ -224,7 +275,7 @@ class Settings {
       this.log.debug(` In getRepoConfigMap ${JSON.stringify(this.repo)}`)
       const repo = { owner: this.repo.owner, repo: 'admin' }
       const CONFIG_PATH = '.github'
-      const params = Object.assign(repo, { path: path.posix.join(CONFIG_PATH, 'repos') })
+      const params = Object.assign(repo, { path: path.posix.join(CONFIG_PATH, 'repos'), ref: this.ref })
 
       const response = await this.loadConfigMap(params)
       return response
@@ -244,7 +295,7 @@ class Settings {
       this.log.debug(` In getRepoConfigMap ${JSON.stringify(this.repo)}`)
       const repo = { owner: this.repo.owner, repo: 'admin' }
       const CONFIG_PATH = '.github'
-      const params = Object.assign(repo, { path: path.posix.join(CONFIG_PATH, 'suborgs') })
+      const params = Object.assign(repo, { path: path.posix.join(CONFIG_PATH, 'suborgs'), ref: this.ref })
 
       const response = await this.loadConfigMap(params)
       return response
@@ -262,17 +313,13 @@ class Settings {
   async getRepoConfigs() {
     try {
       const overridePaths = await this.getRepoConfigMap()
-      //log.debug(`XXXXXXX overridePaths = ${JSON.stringify(overridePaths)}`)
       const repoConfigs = {}
-      //const overrideConfigs = []
 
       for (let override of overridePaths) {
         const data = await this.loadYaml(override.path)
         this.log.debug(`data = ${JSON.stringify(data)}`)
-        //overrideConfigs.push({ name: override.name, path: override.path, data: data})
         repoConfigs[override.name] = data
       }
-      //log.debug(`override configs = ${JSON.stringify(overrideConfigs)}`)
       this.log.debug(`repo configs = ${JSON.stringify(repoConfigs)}`)
       return repoConfigs
     } catch (e) {
@@ -289,21 +336,32 @@ class Settings {
   async getSubOrgConfigs() {
     try {
       const overridePaths = await this.getSubOrgConfigMap()
-      //log.debug(`XXXXXXX overridePaths = ${JSON.stringify(overridePaths)}`)
       const subOrgConfigs = {}
-      //const overrideConfigs = []
 
       for (let override of overridePaths) {
         const data = await this.loadYaml(override.path)
         this.log.debug(`data = ${JSON.stringify(data)}`)
-        //overrideConfigs.push({ name: override.name, path: override.path, data: data})
         subOrgConfigs[override.name] = data
         data.suborgrepos.forEach(repository => {
           subOrgConfigs[repository]=data
         })
+
+        if (data.suborgteams) {
+          const promises = data.suborgteams.map(  (teamslug) => {
+            return this.getReposForTeam(teamslug)
+          })
+  
+          await Promise.all(promises).then(res => {
+            res.forEach(r => {
+              r.forEach(e => {
+                subOrgConfigs[e.name]=data
+              })
+            })
+          })        
+        }
+
+        
       }
-      //log.debug(`override configs = ${JSON.stringify(overrideConfigs)}`)
-      this.log.debug(`suborg configs = ${JSON.stringify(subOrgConfigs)}`)
       return subOrgConfigs
     } catch (e) {
       throw e
@@ -318,17 +376,17 @@ class Settings {
   async loadYaml(filePath) {
     try {
       const repo = { owner: this.repo.owner, repo: 'admin' }
-      const params = Object.assign(repo, { path: filePath })
+      const params = Object.assign(repo, { path: filePath, ref: this.ref })
       const response = await this.github.repos.getContent(params).catch(e => {
-        console.log(e)
         console.error(`Error getting settings ${e}`)
       })
-      //log.debug(`In loadYAML ${JSON.stringify(response.data)}`)
+
       // Ignore in case path is a folder
       // - https://developer.github.com/v3/repos/contents/#response-if-content-is-a-directory
       if (Array.isArray(response.data)) {
         return null
       }
+
       // we don't handle symlinks or submodule
       // - https://developer.github.com/v3/repos/contents/#response-if-content-is-a-symlink
       // - https://developer.github.com/v3/repos/contents/#response-if-content-is-a-submodule
@@ -345,22 +403,65 @@ class Settings {
     }
   }
 
+  appendToResults(res) {
+    if (this.nop) {
+      this.results = this.results.concat(res.flat(3))
+    }    
+  }
+
+  async getReposForTeam(teamslug) {
+
+    const options = this.github.rest.teams.listReposInOrg.endpoint.merge({
+      org: this.repo.owner,
+      team_slug: teamslug,
+      per_page: 100,
+    })
+    return this.github.paginate(options)
+  }
+
+  isObject(item) {
+    return (item && typeof item === 'object' && !Array.isArray(item));
+  }
+
+  mergeDeep(target, ...sources) {
+    if (!sources.length) return target;
+    const source = sources.shift();
+
+    if (this.isObject(target) && this.isObject(source)) {
+      for (const key in source) {
+        if (this.isObject(source[key]) || Array.isArray(source[key])) {
+          if (!target[key]) {
+            if (Array.isArray(source[key])) {
+              Object.assign(target, {
+                [key]: []
+              })
+            } else {
+              Object.assign(target, {
+                [key]: {}
+              })
+            }
+          }
+
+          if (Array.isArray(source[key]) && Array.isArray(target[key])) {
+            Object.assign(target, {
+              [key]: [...target[key],...source[key]]
+            })
+          } else {
+            this.mergeDeep(target[key], source[key]);
+          }      
+        } else {
+          Object.assign(target, {
+            [key]: source[key]
+          })
+        }
+      }
+    }
+    return this.mergeDeep(target, ...sources);
+  }
+
 }
-// async function eachRepository (context, config) {
-//   this.log('Fetching repositories')
-//   const github = context.github
-//   const repositories = await github.paginate(
-//     github.apps.listRepos.endpoint.merge({ per_page: 100 }),
-//     response => {
-//       return response.data.repositories
-//     }
-//   )
-//   return repositories.forEach(repo => { return Settings.sync(context, { owner: repo.owner.login, repo: repo.name }, config) })
-// }
 
 Settings.FILE_NAME = '.github/settings.yml'
-
-
 
 Settings.PLUGINS = {
   repository: require('./plugins/repository'),

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -242,7 +242,7 @@ ${this.results.reduce((x,y) => {
       })
 
       if (!response) {
-        return
+        return []
       }
       // Ignore in case path is a folder
       // - https://developer.github.com/v3/repos/contents/#response-if-content-is-a-directory

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -237,8 +237,7 @@ ${this.results.reduce((x,y) => {
     try {
       this.log.debug(` In loadConfigMap ${JSON.stringify(params)}`)
       const response = await this.github.repos.getContent(params).catch(e => {
-        this.log.error(e)
-        this.log.error(`Error getting settings ${e}`)
+        this.log.error(`Error getting settings ${JSON.stringify(params)} ${e}`)
       })
 
       if (!response) {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,0 +1,56 @@
+module.exports = class Validator {
+  constructor (github, repo, settings, log) {
+    this.github = github
+    this.pattern = settings.pattern
+    //this.regex = /[a-zA-Z0-9_-]+_\w[a-zA-Z0-9_-]+.*/gm
+    this.regex = new RegExp(this.pattern,'gm')
+    this.repo = repo
+    this.log = log
+  }
+
+  sync () {
+    try {
+      return this.github.repos.getAllTopics({
+        owner: this.repo.owner,
+        repo: this.repo.repo,
+        mediaType: {
+          previews: ['mercy']
+        }
+      }).then(res => {
+        if (this.repo.repo.search(this.regex) >= 0) {
+          this.log(`Repo ${this.repo.repo} Passed Validation for pattern ${this.pattern}`)
+          if (res.data.names.find(x => x === 'validation-error')) {
+            res.data.names = res.data.names.filter(x => x !== 'validation-error')
+            return this.github.repos.replaceAllTopics({
+              owner: this.repo.owner,
+              repo: this.repo.repo,
+              names: res.data.names,
+              mediaType: {
+                previews: ['mercy']
+              }
+            })
+          }
+        } else {
+          this.log(`Repo ${this.repo.repo} Failed Validation for pattern ${this.pattern}`)
+          if (!res.data.names.find(x => x === 'validation-error')) {
+            res.data.names.push('validation-error')
+            return this.github.repos.replaceAllTopics({
+              owner: this.repo.owner,
+              repo: this.repo.repo,
+              names: res.data.names,
+              mediaType: {
+                previews: ['mercy']
+              }
+            })
+          }
+        }
+
+      })
+      
+    } catch (error) {
+      this.log(`Error in Validation checking ${error}`)
+    }
+
+  }
+
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "deepmerge": "^4.2.2",
     "js-yaml": "^4.0.0",
+    "node-cron": "^3.0.0",
     "probot": "12.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Overview
I have made a lot of changes to the v1 release of safe-settings. Initially, safe-settings was based on `probot/settings` app. However, in this release, I have made changes that moves it away from the original probot settings app in several important ways:

1. `safe-settings` now supports 3 levels at which the settings could be managed:
   1. `Org-level` settings are defined in `.github/settings.yml` 
   1. `SubOrg-level` settings. The org-level settings could be overridden at a  `suborg` level. These would be a collection of repos belonging to a project or a business unit, or a team. The `suborg`settings reside in the `.github/suborgs`folder.
   1. `Repo-level` settings. Lastly, we could override settings for individual repos by creating a repo specific yaml in `.github/repos`folder
1. New `validator` plugin to support Validation of repo names
1. `Glob` support for specifying suborg repo names.
2. Several bug fixes

## TODO
1. Add support for `noop` mode for pull requests validations for settings showing the impact of the change.
2. Add support for specifying templates in the settings for repo creation
3. Add support for cron expression support for setting up timers for periodic full syncs
4. Add support for querying audit logs for identifying config drifts and converging the repo settings to the known state
3. Code cleanup and restructuring for better maintainability
4. Write tests