### PR TITLE
Log full JSON result when adding a team

### DIFF
--- a/lib/plugins/teams.js
+++ b/lib/plugins/teams.js
@@ -31,7 +31,7 @@ module.exports = class Teams extends Diffable {
       existing = res.data
       this.log(`adding team ${attrs.name} to repo ${this.repo.repo}`)
       return this.github.teams.addOrUpdateRepoPermissionsInOrg(this.toParams(existing, attrs)).then(res => {
-        this.log(`team added ${res}`)
+        this.log(`team added ${JSON.stringify(res)}`)
       }).catch(e => {
         this.log(`Error adding team to repo ${JSON.stringify(e)} with parms ${JSON.stringify(this.toParams(existing, attrs))}`)
       })


### PR DESCRIPTION
When a team was added to a repo It was showing the result as [object object]

This dumps the full result as JSON on the logs