### PR TITLE
Add compliance report function

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -74,12 +74,13 @@ jobs:
           docker run --env APP_ID=${{ secrets.APP_ID }} --env PRIVATE_KEY=${{ secrets.PRIVATE_KEY }} --env WEBHOOK_SECRET=${{ secrets.WEBHOOK_SECRET }} -d -p 3000:3000 yadhav/safe-settings:main-enterprise
           sleep 5
           curl http://localhost:3000
-      - name: Tag a rc release 
+      - name: Tag a release 
         id: rcrelease
         uses: actionsdesk/semver@0.6.0-rc.8
         with:
+          bump: patch
           prerelease: withBuildNumber
-          prelabel: rc
+          prelabel: alpha
       - name: Push Docker Image
         if: ${{ success() }}
         uses: docker/build-push-action@v2

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
    1. `Suborg` level settings. A `suborg` is an arbitrary collection of repos belonging to projects, business units, or teams. The `suborg`settings reside in a yaml file for each `suborg` in the `.github/suborgs`folder.
    1. `Repo` level settings. They reside in a repo specific yaml in `.github/repos`folder
 1. It is recommended to break the settings into org-level, suborg-level, and repo-level units. This will allow different teams to be define and manage policies for their specific projects or business units.With `CODEOWNERS`, this will allow different people to be responsible for approving changes in different projects.
+2. `safe-settings` can create a compliance report of all repositories in the org
 
 **Note:** The settings file must have a `.yml`extension only. `.yaml` extension is ignored, for now.
 
@@ -36,6 +37,10 @@ The App listens to the following webhook events:
 The App can be configured to apply the settings on a schedule. This could a way to address configuration drift since webhooks have not always guaranteed to be delivered.
 
  To set periodically converge the settings to the configuration, set the `CRON` environment variable. This is based on [node-cron](https://www.npmjs.com/package/node-cron) and details on the possible values can be found [here](#Env variables).
+
+### Report
+
+If you go to <safe-settings-url>/admin/report, it will create a report of all the repositories in the org and what changes would be applied to them. This could be used to identify repositories that are non-compliant.
 
 ### Pull Request Workflow
 `Safe-settings` explicitly looks in the `admin` repo in the organization for the settings files. The `admin` repo could be a restricted repository with `branch protections` and `codeowners`  

--- a/lib/plugins/branches.js
+++ b/lib/plugins/branches.js
@@ -1,6 +1,6 @@
 const NopCommand = require('../nopcommand')
 const MergeDeep = require('../mergeDeep')
-const ignorableFields = []
+const ignorableFields = ['enforce_admins']
 const previewHeaders = { accept: 'application/vnd.github.hellcat-preview+json,application/vnd.github.luke-cage-preview+json,application/vnd.github.zzzax-preview+json' }
 
 module.exports = class Branches {
@@ -62,7 +62,7 @@ module.exports = class Branches {
                   const mergeDeep = new MergeDeep(this.log,ignorableFields)
                   const results = JSON.stringify(mergeDeep.compareDeep(result.data, branch.protection),null,2)
                   this.log(`Result of compareDeep = ${results}`)
-                  resArray.push(new NopCommand("Branch Protection", this.repo, null, `Followings changes will be applied to the branch protection for ${params.branch} branch = ${results}`))
+                  resArray.push(new NopCommand("Branch Protection", this.repo, null, `Branch protection changes \`${params.branch}\` branch = ${results}`))
                 } catch(e){
                   this.log.error(e)
                 }

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -1,5 +1,3 @@
-//const { restEndpointMethods } = require('@octokit/plugin-rest-endpoint-methods')
-//const EndPoints = require('@octokit/plugin-rest-endpoint-methods')
 const NopCommand = require('../nopcommand')
 const MergeDeep = require('../mergeDeep')
 const ignorableFields = [
@@ -83,7 +81,7 @@ module.exports = class Repository {
           const mergeDeep = new MergeDeep(this.log,ignorableFields)
           const results = JSON.stringify(mergeDeep.compareDeep(resp.data, this.settings),null,2)
           this.log(`Result of compareDeep = ${results}`)
-          resArray.push(new NopCommand("Repository", this.repo, null, `Followings changes will be applied to the repo settings = ${results}`))
+          resArray.push(new NopCommand("Repository", this.repo, null, `Repository changes = ${results}`))
         } catch(e){
           this.log.error(e)
         }

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -11,6 +11,13 @@ class Settings {
     await settings.handleResults()
   }
 
+  static async reportAll(nop, context, repo, config) {
+    const settings = new Settings(nop, context, repo, config)
+    await settings.loadConfigs()
+    await settings.updateAll()
+    return await settings.reportResults()
+  }
+
   static async sync(nop, context, repo, config, ref) {
     const { payload } = context
     const settings = new Settings(nop, context, repo, config, ref)
@@ -29,6 +36,50 @@ class Settings {
     this.nop = nop
     this.log = context.log
     this.results = []
+  }
+
+  async reportResults() {
+    if (!this.nop) {
+      this.log.debug(`Not run in nop`)
+      return
+    }
+    
+    this.results.sort((s,t) => {
+      if (s.repo < t.repo) return -1
+      if (s.repo > t.repo) return 1
+      return 0
+    })
+
+    let error = false;
+
+    const commentmessage = `
+<h1> 🤖 Safe-Settings Repository Report </h1>
+${this.results.reduce((x,y) => {
+  if (!y) {
+    return x
+  }
+  if (y.endpoint) {
+    // ignore this
+    return x
+  } else {
+    if (y.type === "ERROR") {
+      error = true
+      return `${x} 
+<details>
+  <summary>❌ ${y.action}</summary> 
+</details>` 
+    } else {
+       return `${x} 
+ <p>
+ - ℹ️ ${y.repo} : ${y.action}
+ </p>` 
+ 
+    }
+  }
+ 
+}, '')}    
+`
+    return commentmessage
   }
 
   async handleResults() {


### PR DESCRIPTION
## Overview
When safe-settings has been set up, it is helpful to initially see which repositories are not complying with the policies and conduct some impact analysis. 
In the future, we could implement a functionality where where safe-settings is run in a passive mode where it will only monitor and generate reports.

## How it would work
Going to <deployment URL>/admin/report will create a HTML report

## Caveat
The report is pretty basic