### PR TITLE
Fix messaging for cron log line

### DIFF
--- a/index.js
+++ b/index.js
@@ -500,7 +500,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
     # * * * * * *
     */
     cron.schedule(process.env.CRON, () => {
-      console.log('running a task every minute');
+      console.log(`running a reconciliation according to ${process.env.CRON}`);
       syncInstallation()
     });
   }


### PR DESCRIPTION
The current log line that gets emitted every cron evaluation is

```
running a task every minute
```

This is misleading as it's probably... not... running every minute. You'd probably run out of rate limit if you tried that.

This PR changes the log line to just output the cron line, for lack of another idea on what to output easily.

Please note that I made this PR in the github `/edit/` page, and have not executed this at all. Will try to patch our instance to test this change later today.