### PR TITLE
Only load configs if not previously fetched on the same operation

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -130,8 +130,8 @@ ${this.results.reduce((x,y) => {
   }
 
   async updateRepos(repo) {
-    this.subOrgConfigs = await this.getSubOrgConfigs(this.github, repo, this.log)
-    this.repoConfigs = await this.getRepoConfigs(this.github, repo, this.log)
+    this.subOrgConfigs = this.subOrgConfigs || await this.getSubOrgConfigs(this.github, repo, this.log)
+    this.repoConfigs = this.repoConfigs || await this.getRepoConfigs(this.github, repo, this.log)
     let repoConfig = this.config.repository
     if (repoConfig) {
       repoConfig = Object.assign(repoConfig, {name: repo.repo, org: repo.owner})
@@ -189,12 +189,11 @@ ${this.results.reduce((x,y) => {
   }
 
   async updateAll() {
-    this.subOrgConfigs = await this.getSubOrgConfigs(this.github, this.repo, this.log)
-    this.repoConfigs = await this.getRepoConfigs(this.github, this.repo, this.log)
+    this.subOrgConfigs = this.subOrgConfigs || await this.getSubOrgConfigs(this.github, this.repo, this.log)
+    this.repoConfigs = this.repoConfigs || await this.getRepoConfigs(this.github, this.repo, this.log)
     return this.eachRepositoryRepos(this.github, this.config.restrictedRepos, this.log).then( res => {
       this.appendToResults(res)
     })
-
   }
 
   getSubOrgConfig(repoName) {


### PR DESCRIPTION
loading configs (repos,suborgs) was being loaded even when they had been loaded in the same instance.

This meant that on a synch all, configs were being loaded for each repo.

On an org with a moderate number of repos the decrease in calls is 10x

In some situations this would also trigger abuse limiting measures on GitHub