### PR TITLE
Don't get repo twice when handling default branch protection

### DIFF
--- a/lib/plugins/branches.js
+++ b/lib/plugins/branches.js
@@ -14,7 +14,7 @@ module.exports = class Branches {
   sync () {
     const resArray = []
     //this.log(`Syncing branches ${JSON.stringify(this.branches)}`)
-    return this.github.repos.get(this.repo).then(() => { 
+    return this.github.repos.get(this.repo).then((currentRepo) => { 
       return Promise.all(
         this.branches
           .filter(branch => branch.protection !== undefined)
@@ -22,9 +22,8 @@ module.exports = class Branches {
             let params = Object.assign(this.repo, { branch: branch.name })
             if (this.isEmpty(branch.protection)) {
               if (branch.name === 'default') {
-                const result = await this.github.repos.get(this.repo)
-                params = Object.assign(this.repo, { branch: result.data.default_branch })
-                this.log(`Deleting default branch protection for branch ${result.data.default_branch}`)
+                params = Object.assign(this.repo, { branch: currentRepo.data.default_branch })
+                this.log(`Deleting default branch protection for branch ${currentRepo.data.default_branch}`)
               }
               if (this.nop) {
                 resArray.concat([
@@ -35,9 +34,8 @@ module.exports = class Branches {
               return this.github.repos.deleteBranchProtection(params).catch(e => {return []})
             } else {
               if (branch.name === 'default') {
-                const result = await this.github.repos.get(this.repo)
-                params = Object.assign(this.repo, { branch: result.data.default_branch })
-                this.log(`Setting default branch protection for branch ${result.data.default_branch}`)
+                params = Object.assign(this.repo, { branch: currentRepo.data.default_branch })
+                this.log(`Setting default branch protection for branch ${currentRepo.data.default_branch}`)
               }
               
               if (this.nop) {


### PR DESCRIPTION
When dealing with the default branch in branches plugin, the repo was read even though it had already been fetched.

This reduces the number of calls in a synch, it could be further optimized by only getting it if the default branch is reference. But not defining the default repo is highly likely an edge case.