### PR TITLE
Support team visibility (team creation only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,11 @@ teams:
     permission: push
   - name: docs
     permission: pull
+  # Visibility is only honored when the team is created not for existing teams.
+  # It can be either secret (default) or closed (visible to all members of the org)
+  - name: globalteam
+    permission: push
+    visibility: closed
 
 branches:
   # If the name of the branch value is specified as `default`, then the app will create a branch protection rule to apply against the default branch in the repo

--- a/lib/plugins/teams.js
+++ b/lib/plugins/teams.js
@@ -47,14 +47,21 @@ module.exports = class Teams extends Diffable {
       })
     }).catch(e => {
       if (e.status === 404) {
-        this.log(`Creating teams {org: ${this.repo.owner}, name: ${attrs.name}`)
+        let createParam = {
+          org: this.repo.owner,
+          name: attrs.name
+        }
+        if(attrs.privacy) {
+          createParam.privacy = attrs.privacy
+        }
+        this.log(`Creating teams ${JSON.stringify(createParam)}`)
         if (this.nop) {
           return Promise.resolve([
-            new NopCommand(this.constructor.name, this.repo, this.github.teams.create.endpoint({ org: this.repo.owner, name: attrs.name }), "Create Team"),
+            new NopCommand(this.constructor.name, this.repo, this.github.teams.create.endpoint(createParam), "Create Team"),
           ])
         }
-        return this.github.teams.create({ org: this.repo.owner, name: attrs.name }).then(res => {
-          this.log('team created')
+        return this.github.teams.create(createParam).then(res => {
+          this.log(`team ${createParam.name} created`)
           existing = res.data
           this.log(`adding team ${attrs.name} to repo ${this.repo.repo}`)
           return this.github.teams.addOrUpdateRepoPermissionsInOrg(this.toParams(existing, attrs))


### PR DESCRIPTION
Allow team's visibility to be set (closed or secret) when a team is created

If the team already exists it doesn't change it's visibility, this only applies for teams that are created. 