### PR TITLE
Add support for autolinks in safe-settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Using the settings, the following things could be configured:
 - `Collaborators and permissions`
 - `Issue labels`
 - `Branch protections`. If the name of the branch is `default` in the settings, it is applied to the `default` branch of the repo.
+- `Autolinks`
 - `repository name validation` using regex pattern
 
 It is possible to provide an `include` or `exclude` settings to restrict the `collaborators`, `teams`, `labels` to a list of repos or exclude a set of repos for a collaborator.
@@ -298,6 +299,13 @@ branches:
         apps: []
         users: []
         teams: []
+
+# See the docs (https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources) for a description of autolinks and replacement values.
+autolinks:
+  - key_prefix: 'JIRA-'
+    url_template: 'https://jira.github.com/browse/JIRA-<num>'
+  - key_prefix: 'MYLINK-'
+    url_template: 'https://mywebsite.com/<num>'
         
 validator:
   #pattern: '[a-zA-Z0-9_-]+_[a-zA-Z0-9_-]+.*' 

--- a/lib/plugins/autolinks.js
+++ b/lib/plugins/autolinks.js
@@ -54,7 +54,7 @@ module.exports = class Autolinks extends Diffable {
   async remove({ id }) {
     const attrs = {
       ...this.repo,
-      id,
+      autolink_id: id,
     };
     if (this.nop) {
       return new NopCommand(

--- a/lib/plugins/autolinks.js
+++ b/lib/plugins/autolinks.js
@@ -44,7 +44,8 @@ module.exports = class Autolinks extends Diffable {
       return this.github.repos.createAutolink(attrs);
     } catch (e) {
       if (e?.response?.data?.errors?.[0]?.code === 'already_exists') {
-        this.log.debug(`Did not update ${key}, as it already exists`);
+        this.log.debug(`Did not update ${key_prefix}, as it already exists`);
+        return;
       }
       throw e;
     }

--- a/lib/plugins/autolinks.js
+++ b/lib/plugins/autolinks.js
@@ -1,0 +1,68 @@
+const Diffable = require('./diffable');
+const NopCommand = require('../nopcommand');
+
+module.exports = class Autolinks extends Diffable {
+  constructor(...args) {
+    super(...args);
+  }
+
+  async find() {
+    const { data } = await this.github.repos.listAutolinks(this.repo);
+    return data;
+  }
+
+  comparator(existing, attr) {
+    return existing.key_prefix === attr.key_prefix && existing.url_template === attr.url_template;
+  }
+
+  changed(existing, attr) {
+    return existing.key_prefix === attr.key_prefix && existing.url_template !== attr.url_template;
+  }
+
+  async update(existing, attr) {
+    await this.remove(existing);
+    return this.add(attr);
+  }
+
+  async add({ key_prefix, url_template }) {
+    const attrs = {
+      ...this.repo,
+      key_prefix,
+      url_template,
+    };
+
+    if (this.nop) {
+      return new NopCommand(
+        this.constructor.name,
+        this.repo,
+        this.github.repos.createAutolink.endpoint(attrs),
+        'Add autolink',
+      );
+    }
+
+    try {
+      return this.github.repos.createAutolink(attrs);
+    } catch (e) {
+      if (e?.response?.data?.errors?.[0]?.code === 'already_exists') {
+        this.log.debug(`Did not update ${key}, as it already exists`);
+      }
+      throw e;
+    }
+  }
+
+  async remove({ id }) {
+    const attrs = {
+      ...this.repo,
+      id,
+    };
+    if (this.nop) {
+      return new NopCommand(
+        this.constructor.name,
+        this.repo,
+        this.github.repos.deleteAutolink.endpoint(attrs),
+        'Remove autolink',
+      );
+    }
+    return this.github.repos.deleteAutolink(attrs);
+  }
+};

--- a/lib/plugins/diffable.js
+++ b/lib/plugins/diffable.js
@@ -81,6 +81,12 @@ module.exports = class Diffable {
       return this.find().then(existingRecords => {
         const changes = []
 
+        existingRecords.forEach(x => {
+          if (!filteredEntries.find(y => this.comparator(x, y))) {
+            changes.push(this.remove(x))
+          }
+        })
+        
         filteredEntries.forEach(attrs => {
           const existing = existingRecords.find(record => {
             return this.comparator(record, attrs)
@@ -93,11 +99,6 @@ module.exports = class Diffable {
           }
         })
 
-        existingRecords.forEach(x => {
-          if (!filteredEntries.find(y => this.comparator(x, y))) {
-            changes.push(this.remove(x))
-          }
-        })
         if (changes.length === 0) {
           if (this.nop) {
             return Promise.resolve([

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -637,6 +637,7 @@ Settings.PLUGINS = {
   teams: require('./plugins/teams'),
   milestones: require('./plugins/milestones'),
   branches: require('./plugins/branches'),
+  autolinks: require('./plugins/autolinks'),
   validator: require('./plugins/validator')
 }
 


### PR DESCRIPTION
Includes autolinks as a setting the app can handle and manage. If the `autolinks` field is not populated, this is a no-op. 

Docs about autolinks here https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources

Follows defined "diffable" pattern, so no change really.

Also moved removals of diffs before additions due to bugs with the previous ordering (if you reach max number of autolinks/labels/etc, then adding before removing will cause issues) - removing before adding will "make space" when needed. Not a common issue, but I ran int it while testing