### PR TITLE
Allow running validators against arbitrary config objects, not just ones with names

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -1,8 +1,7 @@
 const path = require('path')
-const fs = require('fs')
 const Glob = require('./glob')
 const NopCommand = require('./nopcommand')
-const { throws } = require('assert')
+
 class Settings {
 
   static async syncAll(nop, context, repo, config, ref) {
@@ -13,7 +12,6 @@ class Settings {
   }
 
   static async sync(nop, context, repo, config, ref) {
-    const { payload } = context
     const settings = new Settings(nop, context, repo, config, ref)
     await settings.loadConfigs()
     if(settings.isRestricted(repo.repo)) {
@@ -24,7 +22,6 @@ class Settings {
   }
 
   static async handleError(nop, context, repo, config, ref, nopcommand ) {
-    const { payload } = context
     const settings = new Settings(nop, context, repo, config, ref)
     settings.appendToResults([nopcommand])
     await settings.handleResults()
@@ -216,18 +213,14 @@ ${this.results.reduce((x,y) => {
     this.log.debug(`consolidated config is ${JSON.stringify(overrideConfig)}`)
     const childPlugins = []
     for (const [section, config] of Object.entries(overrideConfig)) {
-      if(this.overridevalidators[section]) {
-          if (!this.overridevalidators[section].canOverride(this.config[section], overrideConfig[section])) {
-            this.log.error(`Error in calling overridevalidator for key ${section} ${this.overridevalidators[section].error}`)
-            throw new Error(this.overridevalidators[section].error)
+      const baseConfig = this.config[section];
+      if(Array.isArray(baseConfig) && Array.isArray(config)) {
+          for(let baseEntry of baseConfig) {
+              const newEntry = config.find(e => e.name === baseEntry.name);
+              this.validate(section, baseEntry, newEntry)
           }
-        }
-      if (this.configvalidators[section]) {
-        this.log.debug(`Calling configvalidator for key ${section} `)
-        if (!this.configvalidators[section].isValid(config)) {
-          this.log.error(`Error in calling configvalidator for key ${section} ${this.configvalidators[section].error}`)
-          throw new Error(this.configvalidators[section].error)
-        }
+      } else {
+        this.validate(section, baseConfig, config);
       }
 
       if (section !== 'repositories' && section !== 'repository') {
@@ -240,6 +233,26 @@ ${this.results.reduce((x,y) => {
       }
     }
     return childPlugins
+  }
+
+  validate(section, baseConfig, overrideConfig) {
+    const configValidator = this.configvalidators[section];
+    if (configValidator) {
+        this.log.debug(`Calling configvalidator for key ${section} `)
+        if (!configValidator.isValid(baseConfig)) {
+          this.log.error(`Error in calling configvalidator for key ${section} ${configValidator.error}`)
+          throw new Error(configValidator.error)
+        }
+      }
+
+    const overridevalidator = this.overridevalidators[section];
+    if (overridevalidator) {
+        this.log.debug(`Calling overridevalidator for key ${section} `)
+        if (!overridevalidator.canOverride(baseConfig, overrideConfig)) {
+            this.log.error(`Error in calling overridevalidator for key ${section} ${overridevalidator.error}`)
+            throw new Error(overridevalidator.error)
+        }
+    }
   }
 
   isRestricted(repoName) {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -155,7 +155,7 @@ ${this.results.reduce((x,y) => {
     if (repoConfig) {
       try {
         this.log.debug(`found a matching repoconfig for this repo ${JSON.stringify(repoConfig)}`)
-        const childPlugins = this.childPluginsList(repo.repo)
+        const childPlugins = this.childPluginsList(repo)
         const RepoPlugin = Settings.PLUGINS.repository
         return new RepoPlugin(this.nop, this.github, repo, repoConfig, this.installation_id, this.log).sync().then( res => {
           this.appendToResults(res)
@@ -179,7 +179,7 @@ ${this.results.reduce((x,y) => {
 
     } else {
       this.log.debug(`Didnt find any a matching repoconfig for this repo ${JSON.stringify(repo)} in ${JSON.stringify(this.repoConfigs)}`)
-      const childPlugins = this.childPluginsList(repo.repo)
+      const childPlugins = this.childPluginsList(repo)
       return Promise.all(childPlugins.map(([Plugin, config]) => {
         return new Plugin(this.nop, this.github, repo, config, this.log).sync().then( res => {
            this.appendToResults(res)
@@ -206,20 +206,30 @@ ${this.results.reduce((x,y) => {
     return undefined
   }
 
-  childPluginsList(repoName) {
-    // Overlay with subOrgConfig
-    const subOrgConfig = this.getSubOrgConfig(repoName)
-    this.log.debug(`suborg config for ${repoName}  is ${JSON.stringify(subOrgConfig)}`)
-    let newConfig = this.mergeDeep({}, this.config, subOrgConfig)
-    this.log.debug(`new config  is ${JSON.stringify(newConfig)}`)
+  childPluginsList(repo) {
+    const repoName = repo.repo
+    const subOrgOverrideConfig = this.getSubOrgConfig(repoName)
+    this.log.debug(`suborg config for ${repoName}  is ${JSON.stringify(subOrgOverrideConfig)}`)
+    const repoOverrideConfig = this.repoConfigs[`${repoName}.yml`] || {};
+    const overrideConfig = this.mergeDeep({}, this.config, subOrgOverrideConfig, repoOverrideConfig);
 
-    const overrideRepoConfig = this.repoConfigs[`${repoName}.yml`]
-    if (overrideRepoConfig) {
-      newConfig = this.mergeDeep({}, newConfig, overrideRepoConfig)
-    }
-    this.log.debug(`consolidated config is ${JSON.stringify(newConfig)}`)
+    this.log.debug(`consolidated config is ${JSON.stringify(overrideConfig)}`)
     const childPlugins = []
-    for (const [section, config] of Object.entries(newConfig)) {
+    for (const [section, config] of Object.entries(overrideConfig)) {
+      if(this.overridevalidators[section]) {
+          if (!this.overridevalidators[section].canOverride(this.config[section], overrideConfig[section])) {
+            this.log.error(`Error in calling overridevalidator for key ${section} ${this.overridevalidators[section].error}`)
+            throw new Error(this.overridevalidators[section].error)
+          }
+        }
+      if (this.configvalidators[section]) {
+        this.log.debug(`Calling configvalidator for key ${section} `)
+        if (!this.configvalidators[section].isValid(config)) {
+          this.log.error(`Error in calling configvalidator for key ${section} ${this.configvalidators[section].error}`)
+          throw new Error(this.configvalidators[section].error)
+        }
+      }
+
       if (section !== 'repositories' && section !== 'repository') {
         // Ignore any config that is not a plugin
         if (section in Settings.PLUGINS) {
@@ -262,27 +272,6 @@ ${this.results.reduce((x,y) => {
       }
     }
     return false
-  }
-
-  async eachRepositoryChildPlugins(github, restrictedRepos, log) {
-    log.debug('Fetching repositories')
-    return github.paginate('GET /installation/repositories').then(repositories => {
-      return Promise.all(repositories.map(repository => {
-        if (this.isRestricted(repository.name)) {
-          return
-        }
-        const { owner, name } = repository
-        const childPlugins = this.childPluginsList(name)
-        return Promise.all(
-          childPlugins.map(
-            ([Plugin, config]) => { return new Plugin(this.nop, github, { owner: owner.login, repo: name }, config, log).sync() }
-          )
-        ).then( res => {
-          return res
-        })
-      })
-      )
-    })
   }
 
   async eachRepositoryRepos(github, restrictedRepos, log) {
@@ -576,35 +565,14 @@ ${this.results.reduce((x,y) => {
             this.log.debug(`merging array ${JSON.stringify(temp)}`)
             for (const a of temp) {
               if (visited[a.name]) {
-                this.log.debug(`Calling canOverride for key ${key} `)
-                if (this.overridevalidators[key]) {
-                  if (!this.overridevalidators[key].canOverride(a, visited[a.name])) {
-                    this.log.error(`Error in calling overridevalidator for key ${key} ${this.overridevalidators[key].error}`)
-                    throw new Error(this.overridevalidators[key].error)
-                  }
-                }
                 continue
               } else if (visited[a.username]) {
-                this.log.debug(`Calling canOverride for key ${key} `)
-                if (this.overridevalidators[key]) {
-                  if (!this.overridevalidators[key].canOverride(a, visited[a.username])) {
-                    this.log.error(`Error in calling overridevalidator for key ${key} ${this.overridevalidators[key].error}`)
-                    throw new Error(this.overridevalidators[key].error)
-                  }
-                }
                 continue
               }
               if (a.name) {
                 visited[a.name] = a
               } else if (a.username) {
                 visited[a.username] = a
-              }
-              if (this.configvalidators[key]) {
-                this.log.debug(`Calling configvalidator for key ${key} `)
-                if (!this.configvalidators[key].isValid(a)) {
-                  this.log.error(`Error in calling configvalidator for key ${key} ${this.configvalidators[key].error}`)
-                  throw new Error(this.configvalidators[key].error)
-                }
               }
               combined[index++] = a
             }


### PR DESCRIPTION
Because the validation was happening during array merging, we could only validate entries in arrays. However, some plugins (like `repositories`) do not accept an array, and others (like `autolinks`) do not have a `name` property. So here I am hoisting the logic into `childPluginsList`

IMO, ideally we could run a validator on the entier plugin config object, but that would break backwards compatibility, so I have added "back" the logic to run on a per array entry basis. If we are OK breaking that compat, then we may want to remove the isArray special case