### PR TITLE
Change expected log to debug

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -310,7 +310,7 @@ ${this.results.reduce((x,y) => {
     try {
       this.log.debug(` In loadConfigMap ${JSON.stringify(params)}`)
       const response = await this.github.repos.getContent(params).catch(e => {
-        this.log.error(`Error getting settings ${JSON.stringify(params)} ${e}`)
+        this.log.debug(`Error getting settings ${JSON.stringify(params)} ${e}`)
       })
 
       if (!response) {


### PR DESCRIPTION
This log triggers (expectedly) whenever a repo or suborg doesnt have an associated settings file (which is allowed). Lets demote this log line from anything critical