### PR TITLE
Respond to repository.created event instead of doing it ourselves

### DIFF
--- a/index.js
+++ b/index.js
@@ -486,11 +486,6 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
     const { payload } = context
     const { sender } = payload
     robot.log.debug('repository.created payload from ', JSON.stringify(sender))
-    if (sender.type === 'Bot') {
-      robot.log.debug('Repository created by a Bot')
-      return
-    }
-    robot.log.debug('Repository created by a Human')
     return syncSettings(false, context)
   })
 

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -109,9 +109,7 @@ module.exports = class Repository {
                   new NopCommand(this.constructor.name, this.repo, this.github.repos.createUsingTemplate.endpoint(options), 'Create Repo Using Template')
                 ])
               }
-              return this.github.repos.createUsingTemplate(options).then(() => {
-                return this.updaterepo()
-              })
+              return this.github.repos.createUsingTemplate(options)
             } else {
               this.log(`Creating ${this.repo.owner}/${this.repo.repo} with settings `, this.settings)
               if (this.nop) {
@@ -120,9 +118,7 @@ module.exports = class Repository {
                   new NopCommand(this.constructor.name, this.repo, this.github.repos.createInOrg.endpoint(this.settings), 'Create Repo')
                 ])
               }
-              return this.github.repos.createInOrg(this.settings).then(() => {
-                return this.updaterepo()
-              })
+              return this.github.repos.createInOrg(this.settings)
             }
           } else {
             if (this.nop) {


### PR DESCRIPTION
This is functionally the same as before, but now we can support repositories created from other bots