### PR TITLE
fix: typo in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -272,7 +272,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
       }
       return syncAllSettings(false, context)
     }
-    retrun
+    return
   }
 
   robot.on('push', async context => {


### PR DESCRIPTION
There is a small typo in `index.js`, it should be `return` not `retrun`