### PR TITLE
Limit the number of requests to .github/repos/*

### DIFF
--- a/index.js
+++ b/index.js
@@ -324,7 +324,6 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
   robot.on('branch_protection_rule', async context => {
     const { payload } = context
     const { changes, repository, sender } = payload
-    robot.log.debug('Branch Protection edited by ', JSON.stringify(sender))
     if (sender.type === 'Bot') {
       robot.log.debug('Branch Protection edited by Bot')
       return

--- a/lib/mergeDeep.js
+++ b/lib/mergeDeep.js
@@ -68,7 +68,6 @@ class MergeDeep {
                         const visited = {}
                         let index = 0
                         const temp = [...source[key], ...target[key]]
-                        this.log.debug(`merging array ${JSON.stringify(temp)}`)
                         for (const a of temp) {
                             if (this.isObject(a)) {
                                 if (visited[a.name]) {

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -66,8 +66,7 @@ module.exports = class Repository {
 
   sync () {
     const resArray = []
-    this.log.debug(`Syncing Repo ${this.settings.name}`)
-    this.settings.name = this.settings.name || this.settings.repo
+    this.log.debug(`Syncing Repo ${this.repo.repo}`)
 
     return this.github.repos.get(this.repo)
       .then(resp => {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -124,7 +124,7 @@ ${this.results.reduce((x,y) => {
 
   async updateRepo(repo) {
     const subOrgConfig = await this.getSubOrgConfig(repo.repo)
-    const repoConfig = await this.getRepoConfig(repo)[`${repo.repo}.yml`]
+    const repoConfig = (await this.getRepoConfig(repo))[`${repo.repo}.yml`]
     const assembledConfig = this.mergeDeep({}, repo, this.config, subOrgConfig, repoConfig)
 
     try {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -121,41 +121,24 @@ ${this.results.reduce((x,y) => {
 
   }
 
+
   async updateRepo(repo) {
-    this.subOrgConfigs = this.subOrgConfigs || await this.getSubOrgConfigs()
-    const repoConfigs = await this.getRepoConfig(repo)
-    let repoConfig = this.config.repository
-    if (repoConfig) {
-      repoConfig = Object.assign(repoConfig, {name: repo.repo, org: repo.owner})
-    }
+    const subOrgConfig = await this.getSubOrgConfig(repo.repo)
+    const repoConfig = await this.getRepoConfig(repo)[`${repo.repo}.yml`]
+    const assembledConfig = this.mergeDeep({}, repo, this.config, subOrgConfig, repoConfig)
 
-    const subOrgConfig = this.getSubOrgConfig(this.subOrgConfigs, repo.repo)
-
-    if (subOrgConfig) {
-      let suborgRepoConfig = subOrgConfig.repository
-      if (suborgRepoConfig) {
-        suborgRepoConfig = Object.assign(suborgRepoConfig, {name: repo.repo, org: repo.owner})
-        repoConfig = this.mergeDeep({}, repoConfig, suborgRepoConfig)
-      }
-    }
-
-    // Overlay repo config
-    const overrideRepoConfig = repoConfigs[`${repo.repo}.yml`]?.repository
-    if (overrideRepoConfig) {
-      repoConfig = this.mergeDeep({}, repoConfig, overrideRepoConfig)
-    }
     try {
-      const childPlugins = this.childPluginsList(repoConfig)
-      const RepoPlugin = Settings.PLUGINS.repository
-      return new RepoPlugin(this.nop, this.github, repo, repoConfig, this.installation_id, this.log).sync().then( res => {
-        this.appendToResults(res)
-        return Promise.all(
-          childPlugins.map(([Plugin, config]) => {
+      if(assembledConfig.repository) {
+        const RepoPlugin = Settings.PLUGINS.repository;
+        const results = await new RepoPlugin(this.nop, this.github, repo, assembledConfig.repository, this.installation_id, this.log).sync();
+        this.appendToResults(results)
+      }
+      
+      const childPlugins = this.childPluginsList(assembledConfig)
+      return Promise.all(childPlugins.map(([Plugin, config]) => {
             return new Plugin(this.nop, this.github, repo, config, this.log).sync()
-          }))
-        }).then( res => {
-          this.appendToResults(res)
-        })
+          })).then(res => { this.appendToResults(res) })
+
     } catch(e) {
       if (this.nop) {
         const nopcommand = new NopCommand(this.constructor.name, this.repo, null,e, "ERROR")
@@ -169,14 +152,14 @@ ${this.results.reduce((x,y) => {
   }
 
   async updateAll() {
-    this.subOrgConfigs = this.subOrgConfigs || await this.getSubOrgConfigs()
     return this.eachRepositoryRepos(this.github, this.config.restrictedRepos, this.log).then( res => {
       this.appendToResults(res)
     })
   }
 
-  getSubOrgConfig(subOrgConfigs, repoName) {
-    for (let k of Object.keys(subOrgConfigs)) {
+  async getSubOrgConfig(repoName) {
+    this.subOrgConfigs = this.subOrgConfigs || await this.getSubOrgConfigs()
+    for (let k of Object.keys(this.subOrgConfigs)) {
       const repoPattern = new Glob(k)
       if (repoName.search(repoPattern)>=0) {
         return subOrgConfigs[k]

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -500,7 +500,6 @@ ${this.results.reduce((x,y) => {
             const combined = []
             let index = 0
             const temp = [...source[key],...target[key]]
-            this.log.debug(`merging array ${JSON.stringify(temp)}`)
             for (const a of temp) {
               if (visited[a.name]) {
                 continue

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -2,22 +2,22 @@ const path = require('path')
 const Glob = require('./glob')
 const NopCommand = require('./nopcommand')
 
+const CONFIG_PATH = '.github'
+
 class Settings {
 
   static async syncAll(nop, context, repo, config, ref) {
     const settings = new Settings(nop, context, repo, config, ref)
-    await settings.loadConfigs()
     await settings.updateAll()
     await settings.handleResults()
   }
 
   static async sync(nop, context, repo, config, ref) {
     const settings = new Settings(nop, context, repo, config, ref)
-    await settings.loadConfigs()
     if(settings.isRestricted(repo.repo)) {
       return;
     }
-    await settings.updateRepos(repo)
+    await settings.updateRepo(repo)
     await settings.handleResults()
   }
 
@@ -121,20 +121,15 @@ ${this.results.reduce((x,y) => {
 
   }
 
-  async loadConfigs() {
-    this.repoConfigs = await this.getRepoConfigs(this.github, this.repo, this.log)
-    this.subOrgConfigs = await this.getSubOrgConfigs(this.github, this.repo, this.log)
-  }
-
-  async updateRepos(repo) {
-    this.subOrgConfigs = this.subOrgConfigs || await this.getSubOrgConfigs(this.github, repo, this.log)
-    this.repoConfigs = this.repoConfigs || await this.getRepoConfigs(this.github, repo, this.log)
+  async updateRepo(repo) {
+    this.subOrgConfigs = this.subOrgConfigs || await this.getSubOrgConfigs()
+    const repoConfigs = await this.getRepoConfig(repo)
     let repoConfig = this.config.repository
     if (repoConfig) {
       repoConfig = Object.assign(repoConfig, {name: repo.repo, org: repo.owner})
     }
 
-    const subOrgConfig = this.getSubOrgConfig(repo.repo)
+    const subOrgConfig = this.getSubOrgConfig(this.subOrgConfigs, repo.repo)
 
     if (subOrgConfig) {
       let suborgRepoConfig = subOrgConfig.repository
@@ -145,74 +140,54 @@ ${this.results.reduce((x,y) => {
     }
 
     // Overlay repo config
-    const overrideRepoConfig = this.repoConfigs[`${repo.repo}.yml`]?.repository
+    const overrideRepoConfig = repoConfigs[`${repo.repo}.yml`]?.repository
     if (overrideRepoConfig) {
       repoConfig = this.mergeDeep({}, repoConfig, overrideRepoConfig)
     }
-    if (repoConfig) {
-      try {
-        this.log.debug(`found a matching repoconfig for this repo ${JSON.stringify(repoConfig)}`)
-        const childPlugins = this.childPluginsList(repo)
-        const RepoPlugin = Settings.PLUGINS.repository
-        return new RepoPlugin(this.nop, this.github, repo, repoConfig, this.installation_id, this.log).sync().then( res => {
+    try {
+      const childPlugins = this.childPluginsList(repoConfig)
+      const RepoPlugin = Settings.PLUGINS.repository
+      return new RepoPlugin(this.nop, this.github, repo, repoConfig, this.installation_id, this.log).sync().then( res => {
+        this.appendToResults(res)
+        return Promise.all(
+          childPlugins.map(([Plugin, config]) => {
+            return new Plugin(this.nop, this.github, repo, config, this.log).sync()
+          }))
+        }).then( res => {
           this.appendToResults(res)
-          return Promise.all(
-            childPlugins.map(([Plugin, config]) => {
-              return new Plugin(this.nop, this.github, repo, config, this.log).sync()
-            }))
-          }).then( res => {
-            this.appendToResults(res)
-          })
-      } catch(e) {
-        if (this.nop) {
-          const nopcommand = new NopCommand(this.constructor.name, this.repo, null,e, "ERROR")
-          console.error(`NOPCOMMAND ${JSON.stringify(nopcommand)}`)
-          this.appendToResults([nopcommand])
-          //throw e
-        } else {
-          throw e
-        }
+        })
+    } catch(e) {
+      if (this.nop) {
+        const nopcommand = new NopCommand(this.constructor.name, this.repo, null,e, "ERROR")
+        console.error(`NOPCOMMAND ${JSON.stringify(nopcommand)}`)
+        this.appendToResults([nopcommand])
+        //throw e
+      } else {
+        throw e
       }
-
-    } else {
-      this.log.debug(`Didnt find any a matching repoconfig for this repo ${JSON.stringify(repo)} in ${JSON.stringify(this.repoConfigs)}`)
-      const childPlugins = this.childPluginsList(repo)
-      return Promise.all(childPlugins.map(([Plugin, config]) => {
-        return new Plugin(this.nop, this.github, repo, config, this.log).sync().then( res => {
-           this.appendToResults(res)
-         })
-      }))
     }
   }
 
   async updateAll() {
-    this.subOrgConfigs = this.subOrgConfigs || await this.getSubOrgConfigs(this.github, this.repo, this.log)
-    this.repoConfigs = this.repoConfigs || await this.getRepoConfigs(this.github, this.repo, this.log)
+    this.subOrgConfigs = this.subOrgConfigs || await this.getSubOrgConfigs()
     return this.eachRepositoryRepos(this.github, this.config.restrictedRepos, this.log).then( res => {
       this.appendToResults(res)
     })
   }
 
-  getSubOrgConfig(repoName) {
-    for (let k of Object.keys(this.subOrgConfigs)) {
+  getSubOrgConfig(subOrgConfigs, repoName) {
+    for (let k of Object.keys(subOrgConfigs)) {
       const repoPattern = new Glob(k)
       if (repoName.search(repoPattern)>=0) {
-        return this.subOrgConfigs[k]
+        return subOrgConfigs[k]
       }
     }
     return undefined
   }
 
-  childPluginsList(repo) {
-    const repoName = repo.repo
-    const subOrgOverrideConfig = this.getSubOrgConfig(repoName)
-    this.log.debug(`suborg config for ${repoName}  is ${JSON.stringify(subOrgOverrideConfig)}`)
-    const repoOverrideConfig = this.repoConfigs[`${repoName}.yml`] || {};
-    const overrideConfig = this.mergeDeep({}, this.config, subOrgOverrideConfig, repoOverrideConfig);
-
-    this.log.debug(`consolidated config is ${JSON.stringify(overrideConfig)}`)
+  childPluginsList(repoConfig) {
     const childPlugins = []
-    for (const [section, config] of Object.entries(overrideConfig)) {
+    for (const [section, config] of Object.entries(repoConfig)) {
       const baseConfig = this.config[section];
       if(Array.isArray(baseConfig) && Array.isArray(config)) {
           for(let baseEntry of baseConfig) {
@@ -296,7 +271,7 @@ ${this.results.reduce((x,y) => {
         }
 
         const { owner, name } = repository
-        return this.updateRepos({ owner: owner.login, repo: name })
+        return this.updateRepo({ owner: owner.login, repo: name })
       })
       )
     })
@@ -349,33 +324,6 @@ ${this.results.reduce((x,y) => {
     }
   }
 
-  /**
-   * Loads a file from GitHub
-   *
-   * @param params Params to fetch the file with
-   * @return The parsed YAML file
-   */
-  async getRepoConfigMap() {
-    try {
-      this.log.debug(` In getRepoConfigMap ${JSON.stringify(this.repo)}`)
-      const repo = { owner: this.repo.owner, repo: 'admin' }
-      const CONFIG_PATH = '.github'
-      const params = Object.assign(repo, { path: path.posix.join(CONFIG_PATH, 'repos'), ref: this.ref })
-
-      const response = await this.loadConfigMap(params)
-      return response
-    } catch (e) {
-      if (this.nop) {
-        const nopcommand = new NopCommand("getRepoConfigMap", this.repo, null,e, "ERROR")
-        console.error(`NOPCOMMAND ${JSON.stringify(nopcommand)}`)
-        this.appendToResults([nopcommand])
-        //throw e
-      } else {
-        throw e
-      }
-    }
-  }
-
     /**
    * Loads a file from GitHub
    *
@@ -384,9 +332,8 @@ ${this.results.reduce((x,y) => {
    */
   async getSubOrgConfigMap() {
     try {
-      this.log.debug(` In getRepoConfigMap ${JSON.stringify(this.repo)}`)
+      this.log.debug(` In getSubOrgConfigMap ${JSON.stringify(this.repo)}`)
       const repo = { owner: this.repo.owner, repo: 'admin' }
-      const CONFIG_PATH = '.github'
       const params = Object.assign(repo, { path: path.posix.join(CONFIG_PATH, 'suborgs'), ref: this.ref })
 
       const response = await this.loadConfigMap(params)
@@ -406,24 +353,21 @@ ${this.results.reduce((x,y) => {
   /**
    * Loads a file from GitHub
    *
-   * @param params Params to fetch the file with
+   * @param repo Repository whos config we want to fetch
    * @return The parsed YAML file
    */
-  async getRepoConfigs() {
+  async getRepoConfig(repo) {
     try {
-      const overridePaths = await this.getRepoConfigMap()
-      const repoConfigs = {}
-
-      for (let override of overridePaths) {
-        const data = await this.loadYaml(override.path)
-        this.log.debug(`data = ${JSON.stringify(data)}`)
-        repoConfigs[override.name] = data
-      }
-      this.log.debug(`repo configs = ${JSON.stringify(repoConfigs)}`)
-      return repoConfigs
+      const repoConfig = {}
+      const name = `${repo.repo}.yml`
+      const data = await this.loadYaml(path.posix.join(CONFIG_PATH, 'repos', name))
+      this.log.debug(`data = ${JSON.stringify(data)}`)
+      repoConfig[name] = data || {}
+      this.log.debug(`repo configs = ${JSON.stringify(repoConfig)}`)
+      return repoConfig
     } catch (e) {
       if (this.nop) {
-        const nopcommand = new NopCommand("getRepoConfigs", this.repo, null,e, "ERROR")
+        const nopcommand = new NopCommand("getRepoConfig", this.repo, null,e, "ERROR")
         console.error(`NOPCOMMAND ${JSON.stringify(nopcommand)}`)
         this.appendToResults([nopcommand])
         //throw e
@@ -491,9 +435,7 @@ ${this.results.reduce((x,y) => {
     try {
       const repo = { owner: this.repo.owner, repo: 'admin' }
       const params = Object.assign(repo, { path: filePath, ref: this.ref })
-      const response = await this.github.repos.getContent(params).catch(e => {
-        this.log.error(`Error getting settings ${e}`)
-      })
+      const response = await this.github.repos.getContent(params)
 
       // Ignore in case path is a folder
       // - https://developer.github.com/v3/repos/contents/#response-if-content-is-a-directory


### PR DESCRIPTION
Currently, we build the entire config object for every request. This requires essentially reading the whole admin repo, which can be a lot of requests for orgs with lots of repos. I have changed it so that we pull (1) all suborg files and (2) one repo-specific file. Now instead of requesting pulling every `repos` file, we usually request one (still max request all of them in case of installation sync).

also removed some really noisy logs which made this hard to debug