### PR TITLE
Update create-pre-release.yml

### DIFF
--- a/.github/workflows/create-pre-release.yml
+++ b/.github/workflows/create-pre-release.yml
@@ -8,8 +8,6 @@ jobs:
   build:
     if: ${{ github.actor != 'dependabot'}}
     runs-on: ubuntu-latest
-    outputs:
-      release: ${{ steps.rcrelease.outputs.release }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup node
@@ -32,6 +30,12 @@ jobs:
             npm-${{ env.cache-name }}-
             npm-
       - run: npm install
+  tag-rc:
+    if: ${{github.event.pull_request.head.repo.full_name == 'github/safe-settings' }}
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.rcrelease.outputs.release }}
+    steps: 
       - name: Tag a rc release 
         id: rcrelease
         uses: actionsdesk/semver@0.6.0-rc.8

--- a/.github/workflows/create-pre-release.yml
+++ b/.github/workflows/create-pre-release.yml
@@ -31,6 +31,7 @@ jobs:
             npm-
       - run: npm install
   tag-rc:
+    needs: [build]
     if: ${{github.event.pull_request.head.repo.full_name == 'github/safe-settings' }}
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
Make changes to the `Create pre-release` workflow to not create a release for forks. Otherwise, this results in error because of `read-only` access to the GITHUB_TOKEN