### PR TITLE
Fix: repo creation failed when template was not defined.

### DIFF
--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -132,6 +132,9 @@ module.exports = class Repository {
               return this.github.repos.createUsingTemplate(options)
             } else {
               this.log('Creating repo with settings ', this.settings)
+              // https://docs.github.com/en/rest/repos/repos#create-an-organization-repository uses org instead of owner like
+              // the API to create a repo with a template
+              this.settings.org = this.settings.owner
               if (this.nop) {
                 this.log.debug(`Creating Repo ${JSON.stringify(this.github.repos.createInOrg.endpoint(this.settings))}  `)
                 return Promise.resolve([

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -131,10 +131,10 @@ module.exports = class Repository {
               }
               return this.github.repos.createUsingTemplate(options)
             } else {
-              this.log('Creating repo with settings ', this.settings)
               // https://docs.github.com/en/rest/repos/repos#create-an-organization-repository uses org instead of owner like
               // the API to create a repo with a template
               this.settings.org = this.settings.owner
+              this.log('Creating repo with settings ', this.settings)
               if (this.nop) {
                 this.log.debug(`Creating Repo ${JSON.stringify(this.github.repos.createInOrg.endpoint(this.settings))}  `)
                 return Promise.resolve([


### PR DESCRIPTION
Repo creation with [template uses ](https://docs.github.com/en/rest/repos/repos#create-a-repository-using-a-template) owner to define owner of repo but Creating a repo with should be org  https://docs.github.com/en/rest/repos/repos#create-an-organization-repository uses org to define the owner


