### PR TITLE
Fix: repo creation failed when template was not defined

### DIFF
--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -144,6 +144,10 @@ module.exports = class Repository {
                 return this.updaterepo(resArray)
               })
             } else {
+              // https://docs.github.com/en/rest/repos/repos#create-an-organization-repository uses org instead of owner like
+              // the API to create a repo with a template
+              this.settings.org = this.settings.owner
+              
               this.log('Creating repo with settings ', this.settings)
               if (this.nop) {
                 this.log.debug(`Creating Repo ${JSON.stringify(this.github.repos.createInOrg.endpoint(this.settings))}  `)


### PR DESCRIPTION
Repo [creation with template uses ](https://docs.github.com/en/rest/repos/repos#create-a-repository-using-a-template)owner to define owner of repo but creating a [repo without template](https://docs.github.com/en/rest/repos/repos#create-an-organization-repository) should be org