### PR TITLE
Does fix bug inside of the Repository plugin related to updateRepo function ambiguity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules/
 private-key.pem
 .env
 *.pem
+
+.vscode

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -110,7 +110,7 @@ module.exports = class Repository {
               return this.updateSecurity(resp.data, resArray)
             }
 
-            return this.updateSecurity(await this.github.repos.update(this.settings).resArray)
+            return this.updateSecurity(await this.github.repos.update(this.settings), resArray)
           })
         }
         if (topicChanges.hasChanges) {

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -43,7 +43,7 @@ const ignorableFields = [
 ]
 
 module.exports = class Repository {
-  constructor (nop, github, repo, settings, installationId, log) {
+  constructor(nop, github, repo, settings, installationId, log) {
     this.installationId = installationId
     this.github = github
     this.settings = Object.assign({ mediaType: { previews: ['nebula-preview'] } }, settings, repo)
@@ -59,7 +59,7 @@ module.exports = class Repository {
     delete this.settings.template
   }
 
-  sync () {
+  sync() {
     const resArray = []
     this.log.debug(`Syncing Repo ${this.settings.name}`)
     this.settings.name = this.settings.name || this.settings.repo
@@ -100,9 +100,18 @@ module.exports = class Repository {
           }
           // Remove topics as it would be handled seperately
           delete this.settings.topics
-          promises.push(this.updaterepo(resArray).then((resp) => {
-            return this.updateSecurity(resp.data, resArray)
-          }))
+
+          promises.push(async () => {
+
+            this.log.debug(`Updating repo with settings ${JSON.stringify(this.topics)} ${JSON.stringify(this.settings)}`)
+
+            if (this.nop) {
+              resArray.push(new NopCommand(this.constructor.name, this.repo, this.github.repos.update.endpoint(this.settings), 'Update Repo'))
+              return this.updateSecurity(resp.data, resArray)
+            }
+
+            return this.updateSecurity(await this.github.repos.update(this.settings).resArray)
+          })
         }
         if (topicChanges.hasChanges) {
           promises.push(this.updatetopics(resp.data, resArray))
@@ -156,7 +165,7 @@ module.exports = class Repository {
       })
   }
 
-  renameBranch (oldname, newname) {
+  renameBranch(oldname, newname) {
     const parms = {
       owner: this.settings.owner,
       repo: this.settings.repo,
@@ -172,16 +181,7 @@ module.exports = class Repository {
     return this.github.repos.renameBranch(parms)
   }
 
-  updaterepo (resArray) {
-    this.log.debug(`Updating repo with settings ${JSON.stringify(this.topics)} ${JSON.stringify(this.settings)}`)
-    if (this.nop) {
-      resArray.push(new NopCommand(this.constructor.name, this.repo, this.github.repos.update.endpoint(this.settings), 'Update Repo'))
-      return Promise.resolve(resArray)
-    }
-    return this.github.repos.update(this.settings)
-  }
-
-  updatetopics (repoData, resArray) {
+  updatetopics(repoData, resArray) {
     const parms = {
       owner: this.settings.owner,
       repo: this.settings.repo,
@@ -212,7 +212,7 @@ module.exports = class Repository {
   }
 
   // Added support for Code Security and Analysis
-  updateSecurity (repoData, resArray) {
+  updateSecurity(repoData, resArray) {
     if (this.security) {
       this.log(`Found repo with security settings ${JSON.stringify(this.security)}`)
       if (this.security?.enableVulnerabilityAlerts === true || this.security?.enableVulnerabilityAlerts === false) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/github/safe-settings.git",
   "main": "index.js",
   "scripts": {
-    "dev": "nodemon",
+    "dev": "nodemon --inspect",
     "start": "probot run ./index.js",
     "test": "npm-run-all --print-label --parallel lint:* --parallel test:*",
     "lint:es": "eslint .",


### PR DESCRIPTION
## What's the purpose of this PR?

Fixes a bug on the repository plugin when we need a security update


### Context

Inside of the repository class, we have an ambiguous return to `updaterepo` function that makes a bug when this function is called with `nop` variable true.

When the nop var is true, the function `updaterepo` returns an array of operations and when the nop var is false, the function returns one object with the repository data. Assuming that the expected response when the function is called is one array and the function update security expects one object with the repository data, we have a bug in this place.

---

Error caused by this ambiguity problem cited above:

```
/Users/nicaciooliveira/vtex/safe-settings/lib/plugins/repository.js:220
          this.log(`Enabling Dependabot alerts for owner: ${repoData.data.owner.login} and repo ${repoData.data.name}`)
                                                                     ^
TypeError: Cannot read properties of undefined (reading 'data')
    at Repository.updateSecurity (/Users/nicaciooliveira/vtex/safe-settings/lib/plugins/repository.js:220:70)
    at /Users/nicaciooliveira/vtex/safe-settings/lib/plugins/repository.js:104:25
```
Ambiguous points:

![image](https://user-images.githubusercontent.com/18489627/190873597-c258f48e-3ab9-4788-8c67-d69685f9d603.png)

![image](https://user-images.githubusercontent.com/18489627/190873611-ec77dc35-0b2b-42f0-b3f5-ebe96666f5b9.png)


