### PR TITLE
Allow removing teams from override config

### DIFF
--- a/lib/mergeDeep.js
+++ b/lib/mergeDeep.js
@@ -1,4 +1,5 @@
 const mergeBy = require('./mergeArrayBy')
+const NAME_FIELDS = ['name', 'username']
 class MergeDeep {
   constructor (log, ignorableFields, configvalidators = {}, overridevalidators = {}) {
     this.log = log
@@ -205,7 +206,7 @@ class MergeDeep {
           // Deep merge Array so that if the same element is there in source and target,
           // override the target with source otherwise include both source and target elements
           if (Array.isArray(source[key]) && Array.isArray(target[key])) {
-            const combined = mergeBy(key, this.configvalidators[key], this.overridevalidators[key], ['name', 'username'], target[key], source[key])
+            const combined = mergeBy(key, this.configvalidators[key], this.overridevalidators[key], NAME_FIELDS, target[key], source[key])
             Object.assign(target, {
               [key]: combined
             })
@@ -247,4 +248,5 @@ class MergeDeep {
     return modifications
   }
 }
+MergeDeep.NAME_FIELDS = NAME_FIELDS;
 module.exports = MergeDeep

--- a/lib/plugins/diffable.js
+++ b/lib/plugins/diffable.js
@@ -37,7 +37,7 @@ module.exports = class Diffable {
     // Filter out all empty entries (usually from repo override)
     for(const entry of filteredEntries) {
       for(const key of Object.keys(entry)) {
-        if(entry[key] === null || entry[key === undefined]) {
+        if(entry[key] === null || entry[key] === undefined) {
           delete entry[key]
         }
       }

--- a/lib/plugins/diffable.js
+++ b/lib/plugins/diffable.js
@@ -33,6 +33,17 @@ module.exports = class Diffable {
 
   filterEntries () {
     let filteredEntries = Array.from(this.entries)
+
+    // Filter out all empty entries (usually from repo override)
+    for(const entry of filteredEntries) {
+      for(const key of Object.keys(entry)) {
+        if(entry[key] === null || entry[key === undefined]) {
+          delete entry[key]
+        }
+      }
+    }
+    filteredEntries = filteredEntries.filter(entry => Object.keys(entry).filter(key => !MergeDeep.NAME_FIELDS.includes(key)).length !== 0)
+
     // this.log.debug(` entries ${JSON.stringify(filteredEntries)}`)
     filteredEntries = filteredEntries.filter(attrs => {
       if (Array.isArray(attrs.exclude)) {

--- a/lib/plugins/diffable.js
+++ b/lib/plugins/diffable.js
@@ -34,16 +34,6 @@ module.exports = class Diffable {
   filterEntries () {
     let filteredEntries = Array.from(this.entries)
 
-    // Filter out all empty entries (usually from repo override)
-    for(const entry of filteredEntries) {
-      for(const key of Object.keys(entry)) {
-        if(entry[key] === null || entry[key] === undefined) {
-          delete entry[key]
-        }
-      }
-    }
-    filteredEntries = filteredEntries.filter(entry => Object.keys(entry).filter(key => !MergeDeep.NAME_FIELDS.includes(key)).length !== 0)
-
     // this.log.debug(` entries ${JSON.stringify(filteredEntries)}`)
     filteredEntries = filteredEntries.filter(attrs => {
       if (Array.isArray(attrs.exclude)) {
@@ -90,7 +80,7 @@ module.exports = class Diffable {
 
   sync () {
     if (this.entries) {
-      const filteredEntries = this.filterEntries()
+      let filteredEntries = this.filterEntries()
       // this.log.debug(`filtered entries are ${JSON.stringify(filteredEntries)}`)
       return this.find().then(existingRecords => {
         const mergeDeep = new MergeDeep(this.log, ignorableFields)
@@ -104,6 +94,16 @@ module.exports = class Diffable {
           }
           return Promise.resolve()
         }
+
+        // Filter out all empty entries (usually from repo override)
+        for (const entry of filteredEntries) {
+          for (const key of Object.keys(entry)) {
+            if (entry[key] === null || entry[key] === undefined) {
+              delete entry[key]
+            }
+          }
+        }
+        filteredEntries = filteredEntries.filter(entry => Object.keys(entry).filter(key => !MergeDeep.NAME_FIELDS.includes(key)).length !== 0)
 
         const changes = []
 

--- a/lib/plugins/teams.js
+++ b/lib/plugins/teams.js
@@ -23,6 +23,9 @@ module.exports = class Teams extends Diffable {
         new NopCommand(this.constructor.name, this.repo, this.github.request.endpoint(`PUT ${teamRepoEndpoint}`, this.toParams(existing, attrs)), 'Add Teams to Repo')
       ])
     }
+    if(!attrs.permission) {
+      return this.remove(existing)
+    }
     return this.github.request(`PUT ${teamRepoEndpoint}`, this.toParams(existing, attrs))
   }
 

--- a/lib/plugins/teams.js
+++ b/lib/plugins/teams.js
@@ -18,9 +18,6 @@ module.exports = class Teams extends Diffable {
   }
 
   update (existing, attrs) {
-    if(!attrs.permission) {
-      return this.remove(existing)
-    }
     if (this.nop) {
       return Promise.resolve([
         new NopCommand(this.constructor.name, this.repo, this.github.request.endpoint(`PUT ${teamRepoEndpoint}`, this.toParams(existing, attrs)), 'Add Teams to Repo')
@@ -30,10 +27,6 @@ module.exports = class Teams extends Diffable {
   }
 
   add (attrs) {
-    if(!attrs.permission) {
-      this.log(`Not adding team, because permissions were explicitely cleared ${JSON.stringify(attrs)}`)
-      return Promise.resolve()
-    }
     let existing = { team_id: 1 }
     this.log(`Getting team with the parms ${JSON.stringify(attrs)}`)
     return this.github.teams.getByName({ org: this.repo.owner, team_slug: attrs.name }).then(res => {

--- a/lib/plugins/teams.js
+++ b/lib/plugins/teams.js
@@ -18,13 +18,13 @@ module.exports = class Teams extends Diffable {
   }
 
   update (existing, attrs) {
+    if(!attrs.permission) {
+      return this.remove(existing)
+    }
     if (this.nop) {
       return Promise.resolve([
         new NopCommand(this.constructor.name, this.repo, this.github.request.endpoint(`PUT ${teamRepoEndpoint}`, this.toParams(existing, attrs)), 'Add Teams to Repo')
       ])
-    }
-    if(!attrs.permission) {
-      return this.remove(existing)
     }
     return this.github.request(`PUT ${teamRepoEndpoint}`, this.toParams(existing, attrs))
   }

--- a/lib/plugins/teams.js
+++ b/lib/plugins/teams.js
@@ -30,6 +30,10 @@ module.exports = class Teams extends Diffable {
   }
 
   add (attrs) {
+    if(!attrs.permission) {
+      this.log(`Not adding team, because permissions were explicitely cleared ${JSON.stringify(attrs)}`)
+      return Promise.resolve()
+    }
     let existing = { team_id: 1 }
     this.log(`Getting team with the parms ${JSON.stringify(attrs)}`)
     return this.github.teams.getByName({ org: this.repo.owner, team_slug: attrs.name }).then(res => {


### PR DESCRIPTION
Consider the below scenario: I want to have a global team (say engineering), but want to exclude this team specifically from one repo (`<repo>`). Right now there is no way to do this, because omitting `permission` from the override will cause it to be merged from the base config.

With this change, specifying null permissions will remove the team, instead of unsuccessfully trying to add the team with an unknown permission.

`.github/settings.yml`:
```
teams:
  - name: engineering
    permission: push
```

`.github/repos/<repo>.yml`:
```
teams:
  - name: engineering
    permission:
```

The above configuration will cause `engineering` to have write access to all teams except `<repo>`