### PR TITLE
Wrong 'topics' variable value in repository plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ private-key.pem
 *.pem
 
 .vscode
+yarn.lock

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -47,7 +47,7 @@ module.exports = class Repository {
     this.installationId = installationId
     this.github = github
     this.settings = Object.assign({ mediaType: { previews: ['nebula-preview'] } }, settings, repo)
-    this.topics = this.settings.topics
+    this.topics = settings && settings.topics && typeof settings.topics === 'string' ? this.settings.topics.split(',').map(t => t.trim()) : []
     this.security = this.settings.security
     this.repo = repo
     this.log = log
@@ -185,7 +185,6 @@ module.exports = class Repository {
     const parms = {
       owner: this.settings.owner,
       repo: this.settings.repo,
-      // names: this.topics.split(/\s*,\s*/),
       names: this.topics,
       mediaType: {
         previews: ['mercy']


### PR DESCRIPTION
When the repository plugin will process repository topics, we needs a array of topics and not a string of topics.

The error occurs in the moment of the Repository instanciation when the topics is passed to this.topics like a string.
This is not handled error and the GitHub check run maintains an eternal loading state.

Example:

```javascript

'this.topics.join is not a function'
Stack:
'TypeError: this.topics.join is not a function\n    at Repository.updatetopics (/Users/nicaciooliveira/vtex/safe-settings/lib/plugins/repository.js:198:59)\n    
at /Users/nicaciooliveira/vtex/safe-settings/lib/plugins/repository.js:117:30\n    
at async Promise.all (index 284)\n    
at async Function.syncSubOrgs (/Users/nicaciooliveira/vtex/safe-settings/lib/settings.js:20:5)\n   
at async Promise.all (index 0)\n    at async Promise.all (index 0)\n    at async middleware (/Users/nicaciooliveira/vtex/safe-settings/node_modules/@octokit/webhooks/dist-node/index.js:355:5)'
```

Debugger:
![image](https://user-images.githubusercontent.com/18489627/191836290-43a37714-1ec9-494d-9689-a14fbd46f866.png)

the function join not works with a string, and this validations on this code not works