### PR TITLE
Update sample documentation suborg.yml

### DIFF
--- a/docs/sample-settings/suborg.yml
+++ b/docs/sample-settings/suborg.yml
@@ -23,7 +23,12 @@ suborgteams:
   #auto_init: true
     
   # A comma-separated list of topics to set on the repository
-  #topics: github, safe-settings, new-topic, another-topic, topic-12
+  #topics:
+  #- github
+  #- safe-settings
+  #- new-topic
+  #- another-topic
+  #- topic-12
   
   # Either `true` to make the repository private, or `false` to make it public. 
   # If this value is changed and if Org members cannot change the visibility of repos


### PR DESCRIPTION
While testing out this app I discovered that the sample documentation in `suborg.yml` was incorrect.

It took me some time to figure out since I started with trying to set some topics on a few of our repos.

I checked the other sample documentation files and they are correct.