### PR TITLE
When no changes detected, send success to the check run

### DIFF
--- a/index.js
+++ b/index.js
@@ -420,6 +420,19 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
         return syncSubOrgSettings(true, context, suborg, context.repo(), pull_request.head.ref)
       }))
     }
+
+    // if no safe-settings changes detected, send a success to the check run
+    params = {
+      owner: payload.repository.owner.login,
+      repo: payload.repository.name,
+      check_run_id: payload.check_run.id,
+      status: 'completed',
+      completed_at: new Date().toISOString(),
+      conclusion: 'success',
+      output: { title: 'No Safe-settings changes detected', summary: 'No changes detected' }
+    }
+    robot.log.debug(`Completing check run ${JSON.stringify(params)}`)
+    await context.octokit.checks.update(params)
   })
 
   robot.on('repository.created', async context => {


### PR DESCRIPTION
This PR tries to fix #307

Test cases:

- [x] PR with safe-setting file modified from beginning.
  - [x] Force push a NO safe-settings file to this PR, like `README.md`
- [x] PR with a NO safe-setting file modified.
  - [x] Modified a safe-setting file and added to this PR.
- [x] PR with a not safe-setting file modified.
  - [x] Force push a safe-settings file to this PR.

