### PR TITLE
Refactor Dockerfiles to be non root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ LABEL version="1.0" \
       description="Probot app which is a modified version of Settings Probot GitHub App" \
       maintainer="GitHub Professional Services <services@github.com>"
 
+USER node
 ## Set our working directory
 WORKDIR /opt/safe-settings
 
@@ -25,12 +26,14 @@ COPY  lib /opt/safe-settings/lib
 ## using this in their enterprise environments
 #COPY --chown=node:node .ssh/safe-settings.pem /opt/safe-settings/.ssh/
 
-## Best practice, don't run as `root`
-#USER node
-
-## We need Python for Probot
+# We need Python for Probot
+USER root
 RUN apk add --no-cache make python
 
+## Best practice, don't run as `root`
+USER node
+
+#
 ## Not strictly necessary, but set permissions to 400
 #RUN chmod 400 /opt/safe-settings/.ssh/safe-settings.pem /opt/safe-settings/.env
 

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -6,6 +6,13 @@ services:
     build: .
     environment:
       NODE_ENV: development
+      APP_ID: ${APP_ID}
+      GH_ORG: ${GH_ORG}
+      WEBHOOK_PROXY_URL: ${WEBHOOK_PROXY_URL}
+      PRIVATE_KEY: ${PRIVATE_KEY}
+      WEBHOOK_SECRET: ${WEBHOOK_SECRET}
+      GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID}
+      GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET}
     ports:
       - 3000:3000
       - 9229:9229

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,12 @@ services:
     build: .
     environment:
       NODE_ENV: production
+      APP_ID: ${APP_ID}
+      GH_ORG: ${GH_ORG}
+      WEBHOOK_PROXY_URL: ${WEBHOOK_PROXY_URL}
+      PRIVATE_KEY: ${PRIVATE_KEY}
+      WEBHOOK_SECRET: ${WEBHOOK_SECRET}
+      GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID}
+      GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET}
     ports:
       - 3000:3000

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -58,7 +58,7 @@ Once you have configured the **GitHub App** and updated the source code, you sho
 - Change directory to inside the code base
   - `cd safe-settings/`
 - Build the container
-  - `sudo docker build -t safe-settings .`
+  - `docker build -t safe-settings .`
 - This process should complete successfully and you will then have a **Docker** container ready for deployment
 
 #### Run the Docker container
@@ -66,24 +66,24 @@ Once the container has been successfully built, you can deploy it and start util
 
 #### Start the container with docker-compose
 If you have docker-compose installed, you can simply start and stop the **Docker** container with:
-- `cd safe-settings/; docker-compose up -d`
+- `cd safe-settings/; docker-compose --env-file .env up -d`
 This will start the container in the background and detached.
 
 #### Start Docker container Detached in background
 - Start the container detached with port assigned (*Assuming port 3000 for the webhook*)
-  - `sudo docker run -d -p 3000:3000 safe-settings`
+  - `docker run -d -p 3000:3000 safe-settings`
 - You should now have the container running in the background and can validate it running with the command:
-  - `sudo docker ps`
+  - `docker ps`
 - This should show the `safe-settings` alive and running
 
 #### Start Docker container attached in forground (Debug)
 - If you need to run the container in interactive mode to validate connectivity and functionality:
-  - `sudo docker run -it -p 3000:3000 safe-settings`
+  - `docker run -it -p 3000:3000 safe-settings`
 - You will now have the log of the container showing to your terminal, and can validate connectivity and functionality.
 
 #### Connect to running Docker container (Debug)
 - If you need to connect to the container thats already running, you can run the following command:
-  - `sudo docker exec -it safe-settings /bin/sh`
+  - `docker exec -it safe-settings /bin/sh`
 - You will now be inside the running **Docker** container and can perform any troubleshooting needed
 
 ### Deploy the app to AWS Lambda


### PR DESCRIPTION
Updated the build definitions to remove running as root when building the container.

Change the settings to inject the environment variables rather than hard coding them into the compose files or passing as individual env vars on the CLI.