### PR TITLE
Remove allow_auto_merge from ignored fields

### DIFF
--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -28,7 +28,6 @@ const ignorableFields = [
   'temp_clone_token',
   'allow_merge_commit',
   'allow_rebase_merge',
-  'allow_auto_merge',
   'delete_branch_on_merge',
   'organization',
   'security_and_analysis',


### PR DESCRIPTION
I tried applying `allow_auto_merge` using safe-settings though nothing happened. I then issue https://github.com/github/safe-settings/issues/318 and tried to change the code myself.

Removing it from `ignoredFields` make the `allow_auto_merge` setting to be applied properly.

I have to admit that I don't understand how the code works, but this change solves our issue. It is also possible that more things should be removed from the ignored list.