### PR TITLE
feat: allow different admin repo by env variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,128 @@
+# Created by https://www.gitignore.io/api/go,vim,osx,emacs,visualstudiocode
+# Edit at https://www.gitignore.io/?templates=go,vim,osx,emacs,visualstudiocode
+
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+
+### Go ###
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+### Go Patch ###
+#/vendor/
+/Godeps/
+
+### OSX ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+
+# Temporary
+.netrwhist
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+### VisualStudioCode ###
+.vscode
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+
+# End of https://www.gitignore.io/api/go,vim,osx,emacs,visualstudiocode
+.idea
+*.iml
 deployment-settings.yml
 npm-debug.log
 .DS_Store

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
       if (nop) {
         let filename = env.SETTINGS_FILE_PATH
         if (!deploymentConfig) {
-          filename = 'deployment-settings.yml'
+          filename = env.DEPLOYMENT_CONFIG_FILE
           deploymentConfig = {}
         }
         const nopcommand = new NopCommand(filename, repo, null, e, 'ERROR')
@@ -51,7 +51,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
       if (nop) {
         let filename = env.SETTINGS_FILE_PATH
         if (!deploymentConfig) {
-          filename = 'deployment-settings.yml'
+          filename = env.DEPLOYMENT_CONFIG_FILE
           deploymentConfig = {}
         }
         const nopcommand = new NopCommand(filename, repo, null, e, 'ERROR')
@@ -76,7 +76,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
       if (nop) {
         let filename = env.SETTINGS_FILE_PATH
         if (!deploymentConfig) {
-          filename = 'deployment-settings.yml'
+          filename = env.DEPLOYMENT_CONFIG_FILE
           deploymentConfig = {}
         }
         const nopcommand = new NopCommand(filename, repo, null, e, 'ERROR')
@@ -96,7 +96,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
    */
   async function loadYamlFileSystem () {
     if (deploymentConfig === undefined) {
-      const deploymentConfigPath = process.env.DEPLOYMENT_CONFIG_FILE ? process.env.DEPLOYMENT_CONFIG_FILE : 'deployment-settings.yml'
+      const deploymentConfigPath = env.DEPLOYMENT_CONFIG_FILE
       if (fs.existsSync(deploymentConfigPath)) {
         deploymentConfig = yaml.load(fs.readFileSync(deploymentConfigPath))
       } else {

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const cron = require('node-cron')
 const Glob = require('./lib/glob')
 const ConfigManager = require('./lib/configManager')
 const NopCommand = require('./lib/nopcommand')
+const env = require('./lib/env')
 
 let deploymentConfig
 module.exports = (robot, _, Settings = require('./lib/settings')) => {
@@ -23,7 +24,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
       }
     } catch (e) {
       if (nop) {
-        let filename = 'settings.yml'
+        let filename = env.SETTINGS_FILE_PATH
         if (!deploymentConfig) {
           filename = 'deployment-settings.yml'
           deploymentConfig = {}
@@ -48,7 +49,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
       return Settings.syncSubOrgs(nop, context, suborg, repo, config, ref)
     } catch (e) {
       if (nop) {
-        let filename = 'settings.yml'
+        let filename = env.SETTINGS_FILE_PATH
         if (!deploymentConfig) {
           filename = 'deployment-settings.yml'
           deploymentConfig = {}
@@ -73,7 +74,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
       return Settings.sync(nop, context, repo, config, ref)
     } catch (e) {
       if (nop) {
-        let filename = 'settings.yml'
+        let filename = env.SETTINGS_FILE_PATH
         if (!deploymentConfig) {
           filename = 'deployment-settings.yml'
           deploymentConfig = {}
@@ -205,7 +206,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
         },
         octokit: github,
         log: robot.log,
-        repo: () => { return { repo: 'admin', owner: installation.account.login } }
+        repo: () => { return { repo: env.ADMIN_REPO, owner: installation.account.login } }
       }
       return syncAllSettings(false, context)
     }
@@ -216,7 +217,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
     const { payload } = context
     const { repository } = payload
 
-    const adminRepo = repository.name === 'admin'
+    const adminRepo = repository.name === env.ADMIN_REPO
     if (!adminRepo) {
       return
     }
@@ -285,7 +286,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
   robot.on('check_suite.requested', async context => {
     const { payload } = context
     const { repository } = payload
-    const adminRepo = repository.name === 'admin'
+    const adminRepo = repository.name === env.ADMIN_REPO
     robot.log.debug(`Is Admin repo event ${adminRepo}`)
     if (!adminRepo) {
       robot.log.debug('Not working on the Admin repo, returning...')
@@ -308,7 +309,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
     robot.log.debug('Pull_request opened !')
     const { payload } = context
     const { repository } = payload
-    const adminRepo = repository.name === 'admin'
+    const adminRepo = repository.name === env.ADMIN_REPO
     robot.log.debug(`Is Admin repo event ${adminRepo}`)
     if (!adminRepo) {
       robot.log.debug('Not working on the Admin repo, returning...')
@@ -328,7 +329,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
     const { payload } = context
     const { repository } = payload
     const pull_request = payload.pull_request
-    const adminRepo = repository.name === 'admin'
+    const adminRepo = repository.name === env.ADMIN_REPO
 
     robot.log.debug(`Is Admin repo event ${adminRepo}`)
     if (!adminRepo) {
@@ -367,7 +368,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
       return
     }
 
-    const adminRepo = repository.name === 'admin'
+    const adminRepo = repository.name === env.ADMIN_REPO
     robot.log.debug(`Is Admin repo event ${adminRepo}`)
     if (!adminRepo) {
       robot.log.debug('Not working on the Admin repo, returning...')

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
       }
     } catch (e) {
       if (nop) {
-        let filename = env.SAFE_SETTINGS_SETTINGS_FILE_PATH
+        let filename = env.SETTINGS_FILE_PATH
         if (!deploymentConfig) {
           filename = 'deployment-settings.yml'
           deploymentConfig = {}
@@ -49,7 +49,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
       return Settings.syncSubOrgs(nop, context, suborg, repo, config, ref)
     } catch (e) {
       if (nop) {
-        let filename = env.SAFE_SETTINGS_SETTINGS_FILE_PATH
+        let filename = env.SETTINGS_FILE_PATH
         if (!deploymentConfig) {
           filename = 'deployment-settings.yml'
           deploymentConfig = {}
@@ -74,7 +74,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
       return Settings.sync(nop, context, repo, config, ref)
     } catch (e) {
       if (nop) {
-        let filename = env.SAFE_SETTINGS_SETTINGS_FILE_PATH
+        let filename = env.SETTINGS_FILE_PATH
         if (!deploymentConfig) {
           filename = 'deployment-settings.yml'
           deploymentConfig = {}
@@ -206,7 +206,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
         },
         octokit: github,
         log: robot.log,
-        repo: () => { return { repo: env.SAFE_SETTINGS_ADMIN_REPO, owner: installation.account.login } }
+        repo: () => { return { repo: env.ADMIN_REPO, owner: installation.account.login } }
       }
       return syncAllSettings(false, context)
     }
@@ -217,7 +217,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
     const { payload } = context
     const { repository } = payload
 
-    const adminRepo = repository.name === env.SAFE_SETTINGS_ADMIN_REPO
+    const adminRepo = repository.name === env.ADMIN_REPO
     if (!adminRepo) {
       return
     }
@@ -286,7 +286,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
   robot.on('check_suite.requested', async context => {
     const { payload } = context
     const { repository } = payload
-    const adminRepo = repository.name === env.SAFE_SETTINGS_ADMIN_REPO
+    const adminRepo = repository.name === env.ADMIN_REPO
     robot.log.debug(`Is Admin repo event ${adminRepo}`)
     if (!adminRepo) {
       robot.log.debug('Not working on the Admin repo, returning...')
@@ -309,7 +309,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
     robot.log.debug('Pull_request opened !')
     const { payload } = context
     const { repository } = payload
-    const adminRepo = repository.name === env.SAFE_SETTINGS_ADMIN_REPO
+    const adminRepo = repository.name === env.ADMIN_REPO
     robot.log.debug(`Is Admin repo event ${adminRepo}`)
     if (!adminRepo) {
       robot.log.debug('Not working on the Admin repo, returning...')
@@ -329,7 +329,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
     const { payload } = context
     const { repository } = payload
     const pull_request = payload.pull_request
-    const adminRepo = repository.name === env.SAFE_SETTINGS_ADMIN_REPO
+    const adminRepo = repository.name === env.ADMIN_REPO
 
     robot.log.debug(`Is Admin repo event ${adminRepo}`)
     if (!adminRepo) {
@@ -368,7 +368,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
       return
     }
 
-    const adminRepo = repository.name === env.SAFE_SETTINGS_ADMIN_REPO
+    const adminRepo = repository.name === env.ADMIN_REPO
     robot.log.debug(`Is Admin repo event ${adminRepo}`)
     if (!adminRepo) {
       robot.log.debug('Not working on the Admin repo, returning...')

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
       }
     } catch (e) {
       if (nop) {
-        let filename = env.SETTINGS_FILE_PATH
+        let filename = env.SAFE_SETTINGS_SETTINGS_FILE_PATH
         if (!deploymentConfig) {
           filename = 'deployment-settings.yml'
           deploymentConfig = {}
@@ -49,7 +49,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
       return Settings.syncSubOrgs(nop, context, suborg, repo, config, ref)
     } catch (e) {
       if (nop) {
-        let filename = env.SETTINGS_FILE_PATH
+        let filename = env.SAFE_SETTINGS_SETTINGS_FILE_PATH
         if (!deploymentConfig) {
           filename = 'deployment-settings.yml'
           deploymentConfig = {}
@@ -74,7 +74,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
       return Settings.sync(nop, context, repo, config, ref)
     } catch (e) {
       if (nop) {
-        let filename = env.SETTINGS_FILE_PATH
+        let filename = env.SAFE_SETTINGS_SETTINGS_FILE_PATH
         if (!deploymentConfig) {
           filename = 'deployment-settings.yml'
           deploymentConfig = {}
@@ -206,7 +206,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
         },
         octokit: github,
         log: robot.log,
-        repo: () => { return { repo: env.ADMIN_REPO, owner: installation.account.login } }
+        repo: () => { return { repo: env.SAFE_SETTINGS_ADMIN_REPO, owner: installation.account.login } }
       }
       return syncAllSettings(false, context)
     }
@@ -217,7 +217,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
     const { payload } = context
     const { repository } = payload
 
-    const adminRepo = repository.name === env.ADMIN_REPO
+    const adminRepo = repository.name === env.SAFE_SETTINGS_ADMIN_REPO
     if (!adminRepo) {
       return
     }
@@ -286,7 +286,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
   robot.on('check_suite.requested', async context => {
     const { payload } = context
     const { repository } = payload
-    const adminRepo = repository.name === env.ADMIN_REPO
+    const adminRepo = repository.name === env.SAFE_SETTINGS_ADMIN_REPO
     robot.log.debug(`Is Admin repo event ${adminRepo}`)
     if (!adminRepo) {
       robot.log.debug('Not working on the Admin repo, returning...')
@@ -309,7 +309,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
     robot.log.debug('Pull_request opened !')
     const { payload } = context
     const { repository } = payload
-    const adminRepo = repository.name === env.ADMIN_REPO
+    const adminRepo = repository.name === env.SAFE_SETTINGS_ADMIN_REPO
     robot.log.debug(`Is Admin repo event ${adminRepo}`)
     if (!adminRepo) {
       robot.log.debug('Not working on the Admin repo, returning...')
@@ -329,7 +329,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
     const { payload } = context
     const { repository } = payload
     const pull_request = payload.pull_request
-    const adminRepo = repository.name === env.ADMIN_REPO
+    const adminRepo = repository.name === env.SAFE_SETTINGS_ADMIN_REPO
 
     robot.log.debug(`Is Admin repo event ${adminRepo}`)
     if (!adminRepo) {
@@ -368,7 +368,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
       return
     }
 
-    const adminRepo = repository.name === env.ADMIN_REPO
+    const adminRepo = repository.name === env.SAFE_SETTINGS_ADMIN_REPO
     robot.log.debug(`Is Admin repo event ${adminRepo}`)
     if (!adminRepo) {
       robot.log.debug('Not working on the Admin repo, returning...')

--- a/lib/configManager.js
+++ b/lib/configManager.js
@@ -16,7 +16,7 @@ module.exports = class ConfigManager {
 */
   async loadYaml (filePath) {
     try {
-      const repo = { owner: this.context.repo().owner, repo: env.ADMIN_ORG }
+      const repo = { owner: this.context.repo().owner, repo: env.SAFE_SETTINGS_ADMIN_ORG }
       const params = Object.assign(repo, { path: filePath, ref: this.ref })
       const response = await this.context.octokit.repos.getContent(params).catch(e => {
         this.log.error(`Error getting settings ${e}`)
@@ -50,8 +50,8 @@ module.exports = class ConfigManager {
    * @return The parsed YAML file
    */
   async loadGlobalSettingsYaml () {
-    const CONFIG_PATH = env.CONFIG_PATH
-    const filePath = path.posix.join(CONFIG_PATH, env.SETTINGS_FILE_PATH)
+    const CONFIG_PATH = env.SAFE_SETTINGS_CONFIG_PATH
+    const filePath = path.posix.join(CONFIG_PATH, env.SAFE_SETTINGS_SETTINGS_FILE_PATH)
     return this.loadYaml(filePath)
   }
 }

--- a/lib/configManager.js
+++ b/lib/configManager.js
@@ -16,7 +16,7 @@ module.exports = class ConfigManager {
 */
   async loadYaml (filePath) {
     try {
-      const repo = { owner: this.context.repo().owner, repo: env.ADMIN_ORG }
+      const repo = { owner: this.context.repo().owner, repo: env.ADMIN_REPO }
       const params = Object.assign(repo, { path: filePath, ref: this.ref })
       const response = await this.context.octokit.repos.getContent(params).catch(e => {
         this.log.error(`Error getting settings ${e}`)

--- a/lib/configManager.js
+++ b/lib/configManager.js
@@ -16,7 +16,7 @@ module.exports = class ConfigManager {
 */
   async loadYaml (filePath) {
     try {
-      const repo = { owner: this.context.repo().owner, repo: env.SAFE_SETTINGS_ADMIN_ORG }
+      const repo = { owner: this.context.repo().owner, repo: env.ADMIN_ORG }
       const params = Object.assign(repo, { path: filePath, ref: this.ref })
       const response = await this.context.octokit.repos.getContent(params).catch(e => {
         this.log.error(`Error getting settings ${e}`)
@@ -50,8 +50,8 @@ module.exports = class ConfigManager {
    * @return The parsed YAML file
    */
   async loadGlobalSettingsYaml () {
-    const CONFIG_PATH = env.SAFE_SETTINGS_CONFIG_PATH
-    const filePath = path.posix.join(CONFIG_PATH, env.SAFE_SETTINGS_SETTINGS_FILE_PATH)
+    const CONFIG_PATH = env.CONFIG_PATH
+    const filePath = path.posix.join(CONFIG_PATH, env.SETTINGS_FILE_PATH)
     return this.loadYaml(filePath)
   }
 }

--- a/lib/configManager.js
+++ b/lib/configManager.js
@@ -1,5 +1,7 @@
 const path = require('path')
 const yaml = require('js-yaml')
+const env = require('env')
+
 module.exports = class ConfigManager {
   constructor (context, ref) {
     this.context = context
@@ -14,7 +16,7 @@ module.exports = class ConfigManager {
 */
   async loadYaml (filePath) {
     try {
-      const repo = { owner: this.context.repo().owner, repo: 'admin' }
+      const repo = { owner: this.context.repo().owner, repo: env.ADMIN_ORG }
       const params = Object.assign(repo, { path: filePath, ref: this.ref })
       const response = await this.context.octokit.repos.getContent(params).catch(e => {
         this.log.error(`Error getting settings ${e}`)
@@ -48,8 +50,8 @@ module.exports = class ConfigManager {
    * @return The parsed YAML file
    */
   async loadGlobalSettingsYaml () {
-    const CONFIG_PATH = '.github'
-    const filePath = path.posix.join(CONFIG_PATH, 'settings.yml')
+    const CONFIG_PATH = env.CONFIG_PATH
+    const filePath = path.posix.join(CONFIG_PATH, env.SETTINGS_FILE_PATH)
     return this.loadYaml(filePath)
   }
 }

--- a/lib/configManager.js
+++ b/lib/configManager.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const yaml = require('js-yaml')
-const env = require('env')
+const env = require('./env')
 
 module.exports = class ConfigManager {
   constructor (context, ref) {

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,5 +1,4 @@
 module.exports = {
-  ADMIN_ORG: process.env.SAFE_SETTINGS_ADMIN_ORG || 'admin',
   ADMIN_REPO: process.env.SAFE_SETTINGS_ADMIN_REPO || 'admin',
   CONFIG_PATH: process.env.SAFE_SETTINGS_CONFIG_PATH || '.github',
   SETTINGS_FILE_PATH: process.env.SAFE_SETTINGS_SETTINGS_FILE_PATH || 'settings.yml'

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,0 +1,6 @@
+export default {
+  ADMIN_ORG: process.env.ADMIN_ORG || 'admin',
+  ADMIN_REPO: process.env.ADMIN_REPO || 'admin',
+  CONFIG_PATH: '.github',
+  SETTINGS_FILE_PATH: 'settings.yml'
+}

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,6 +1,6 @@
 module.exports = {
-  SAFE_SETTINGS_ADMIN_ORG: process.env.ADMIN_ORG || 'admin',
-  SAFE_SETTINGS_ADMIN_REPO: process.env.ADMIN_REPO || 'admin',
-  SAFE_SETTINGS_CONFIG_PATH: '.github',
-  SAFE_SETTINGS_SETTINGS_FILE_PATH: 'settings.yml'
+  ADMIN_ORG: process.env.ADMIN_ORG || 'admin',
+  ADMIN_REPO: process.env.ADMIN_REPO || 'admin',
+  CONFIG_PATH: '.github',
+  SETTINGS_FILE_PATH: 'settings.yml'
 }

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,5 +1,6 @@
 module.exports = {
   ADMIN_REPO: process.env.SAFE_SETTINGS_ADMIN_REPO || 'admin',
   CONFIG_PATH: process.env.SAFE_SETTINGS_CONFIG_PATH || '.github',
-  SETTINGS_FILE_PATH: process.env.SAFE_SETTINGS_SETTINGS_FILE_PATH || 'settings.yml'
+  SETTINGS_FILE_PATH: process.env.SAFE_SETTINGS_SETTINGS_FILE_PATH || 'settings.yml',
+  DEPLOYMENT_CONFIG_FILE: process.env.DEPLOYMENT_CONFIG_FILE || 'deployment-settings.yml'
 }

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,6 +1,6 @@
 module.exports = {
-  ADMIN_ORG: process.env.ADMIN_ORG || 'admin',
-  ADMIN_REPO: process.env.ADMIN_REPO || 'admin',
-  CONFIG_PATH: '.github',
-  SETTINGS_FILE_PATH: 'settings.yml'
+  SAFE_SETTINGS_ADMIN_ORG: process.env.ADMIN_ORG || 'admin',
+  SAFE_SETTINGS_ADMIN_REPO: process.env.ADMIN_REPO || 'admin',
+  SAFE_SETTINGS_CONFIG_PATH: '.github',
+  SAFE_SETTINGS_SETTINGS_FILE_PATH: 'settings.yml'
 }

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,6 +1,6 @@
 module.exports = {
-  ADMIN_REPO: process.env.SAFE_SETTINGS_ADMIN_REPO || 'admin',
+  ADMIN_REPO: process.env.ADMIN_REPO || 'admin',
   CONFIG_PATH: '.github',
-  SETTINGS_FILE_PATH: process.env.SAFE_SETTINGS_SETTINGS_FILE_PATH || 'settings.yml',
+  SETTINGS_FILE_PATH: process.env.SETTINGS_FILE_PATH || 'settings.yml',
   DEPLOYMENT_CONFIG_FILE: process.env.DEPLOYMENT_CONFIG_FILE || 'deployment-settings.yml'
 }

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,6 +1,6 @@
 module.exports = {
   ADMIN_ORG: process.env.SAFE_SETTINGS_ADMIN_ORG || 'admin',
   ADMIN_REPO: process.env.SAFE_SETTINGS_ADMIN_REPO || 'admin',
-  CONFIG_PATH: '.github',
-  SETTINGS_FILE_PATH: 'settings.yml'
+  CONFIG_PATH: process.env.SAFE_SETTINGS_CONFIG_PATH || '.github',
+  SETTINGS_FILE_PATH: process.env.SAFE_SETTINGS_SETTINGS_FILE_PATH || 'settings.yml'
 }

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,4 +1,11 @@
-export default {
+// export default {
+//   ADMIN_ORG: process.env.ADMIN_ORG || 'admin',
+//   ADMIN_REPO: process.env.ADMIN_REPO || 'admin',
+//   CONFIG_PATH: '.github',
+//   SETTINGS_FILE_PATH: 'settings.yml'
+// }
+
+module.exports = {
   ADMIN_ORG: process.env.ADMIN_ORG || 'admin',
   ADMIN_REPO: process.env.ADMIN_REPO || 'admin',
   CONFIG_PATH: '.github',

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,10 +1,3 @@
-// export default {
-//   ADMIN_ORG: process.env.ADMIN_ORG || 'admin',
-//   ADMIN_REPO: process.env.ADMIN_REPO || 'admin',
-//   CONFIG_PATH: '.github',
-//   SETTINGS_FILE_PATH: 'settings.yml'
-// }
-
 module.exports = {
   ADMIN_ORG: process.env.ADMIN_ORG || 'admin',
   ADMIN_REPO: process.env.ADMIN_REPO || 'admin',

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,6 +1,6 @@
 module.exports = {
-  ADMIN_ORG: process.env.ADMIN_ORG || 'admin',
-  ADMIN_REPO: process.env.ADMIN_REPO || 'admin',
+  ADMIN_ORG: process.env.SAFE_SETTINGS_ADMIN_ORG || 'admin',
+  ADMIN_REPO: process.env.SAFE_SETTINGS_ADMIN_REPO || 'admin',
   CONFIG_PATH: '.github',
   SETTINGS_FILE_PATH: 'settings.yml'
 }

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,6 +1,6 @@
 module.exports = {
   ADMIN_REPO: process.env.SAFE_SETTINGS_ADMIN_REPO || 'admin',
-  CONFIG_PATH: process.env.SAFE_SETTINGS_CONFIG_PATH || '.github',
+  CONFIG_PATH: '.github',
   SETTINGS_FILE_PATH: process.env.SAFE_SETTINGS_SETTINGS_FILE_PATH || 'settings.yml',
   DEPLOYMENT_CONFIG_FILE: process.env.DEPLOYMENT_CONFIG_FILE || 'deployment-settings.yml'
 }

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -3,8 +3,9 @@ const eta = require('eta')
 const Glob = require('./glob')
 const NopCommand = require('./nopcommand')
 const MergeDeep = require('./mergeDeep')
+const env = require('./env')
+const CONFIG_PATH = env.CONFIG_PATH
 
-const CONFIG_PATH = '.github'
 class Settings {
   static async syncAll (nop, context, repo, config, ref) {
     const settings = new Settings(nop, context, repo, config, ref)
@@ -424,8 +425,8 @@ ${this.results.reduce((x, y) => {
   async getRepoConfigMap () {
     try {
       this.log.debug(` In getRepoConfigMap ${JSON.stringify(this.repo)}`)
-      const repo = { owner: this.repo.owner, repo: 'admin' }
-      const CONFIG_PATH = '.github'
+      const repo = { owner: this.repo.owner, repo: env.ADMIN_REPO }
+      const CONFIG_PATH = env.CONFIG_PATH
       const params = Object.assign(repo, { path: path.posix.join(CONFIG_PATH, 'repos'), ref: this.ref })
 
       const response = await this.loadConfigMap(params)
@@ -451,7 +452,7 @@ ${this.results.reduce((x, y) => {
   async getSubOrgConfigMap () {
     try {
       this.log.debug(` In getSubOrgConfigMap ${JSON.stringify(this.repo)}`)
-      const repo = { owner: this.repo.owner, repo: 'admin' }
+      const repo = { owner: this.repo.owner, repo: env.ADMIN_REPO }
       const params = Object.assign(repo, { path: path.posix.join(CONFIG_PATH, 'suborgs'), ref: this.ref })
 
       const response = await this.loadConfigMap(params)
@@ -581,7 +582,7 @@ ${this.results.reduce((x, y) => {
    */
   async loadYaml (filePath) {
     try {
-      const repo = { owner: this.repo.owner, repo: 'admin' }
+      const repo = { owner: this.repo.owner, repo: env.ADMIN_REPO }
       const params = Object.assign(repo, { path: filePath, ref: this.ref })
       const response = await this.github.repos.getContent(params).catch(e => {
         this.log.error(`Error getting settings ${e}`)

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -690,7 +690,7 @@ ${this.results.reduce((x, y) => {
   }
 }
 
-Settings.FILE_NAME = '.github/settings.yml'
+Settings.FILE_NAME = '.github/' + env.SETTINGS_FILE_PATH
 
 Settings.PLUGINS = {
   repository: require('./plugins/repository'),

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -4,7 +4,7 @@ const Glob = require('./glob')
 const NopCommand = require('./nopcommand')
 const MergeDeep = require('./mergeDeep')
 const env = require('./env')
-const CONFIG_PATH = env.SAFE_SETTINGS_CONFIG_PATH
+const CONFIG_PATH = env.CONFIG_PATH
 
 class Settings {
   static async syncAll (nop, context, repo, config, ref) {
@@ -425,8 +425,8 @@ ${this.results.reduce((x, y) => {
   async getRepoConfigMap () {
     try {
       this.log.debug(` In getRepoConfigMap ${JSON.stringify(this.repo)}`)
-      const repo = { owner: this.repo.owner, repo: env.SAFE_SETTINGS_ADMIN_REPO }
-      const CONFIG_PATH = env.SAFE_SETTINGS_CONFIG_PATH
+      const repo = { owner: this.repo.owner, repo: env.ADMIN_REPO }
+      const CONFIG_PATH = env.CONFIG_PATH
       const params = Object.assign(repo, { path: path.posix.join(CONFIG_PATH, 'repos'), ref: this.ref })
 
       const response = await this.loadConfigMap(params)
@@ -452,7 +452,7 @@ ${this.results.reduce((x, y) => {
   async getSubOrgConfigMap () {
     try {
       this.log.debug(` In getSubOrgConfigMap ${JSON.stringify(this.repo)}`)
-      const repo = { owner: this.repo.owner, repo: env.SAFE_SETTINGS_ADMIN_REPO }
+      const repo = { owner: this.repo.owner, repo: env.ADMIN_REPO }
       const params = Object.assign(repo, { path: path.posix.join(CONFIG_PATH, 'suborgs'), ref: this.ref })
 
       const response = await this.loadConfigMap(params)
@@ -582,7 +582,7 @@ ${this.results.reduce((x, y) => {
    */
   async loadYaml (filePath) {
     try {
-      const repo = { owner: this.repo.owner, repo: env.SAFE_SETTINGS_ADMIN_REPO }
+      const repo = { owner: this.repo.owner, repo: env.ADMIN_REPO }
       const params = Object.assign(repo, { path: filePath, ref: this.ref })
       const response = await this.github.repos.getContent(params).catch(e => {
         this.log.error(`Error getting settings ${e}`)

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -4,7 +4,7 @@ const Glob = require('./glob')
 const NopCommand = require('./nopcommand')
 const MergeDeep = require('./mergeDeep')
 const env = require('./env')
-const CONFIG_PATH = env.CONFIG_PATH
+const CONFIG_PATH = env.SAFE_SETTINGS_CONFIG_PATH
 
 class Settings {
   static async syncAll (nop, context, repo, config, ref) {
@@ -425,8 +425,8 @@ ${this.results.reduce((x, y) => {
   async getRepoConfigMap () {
     try {
       this.log.debug(` In getRepoConfigMap ${JSON.stringify(this.repo)}`)
-      const repo = { owner: this.repo.owner, repo: env.ADMIN_REPO }
-      const CONFIG_PATH = env.CONFIG_PATH
+      const repo = { owner: this.repo.owner, repo: env.SAFE_SETTINGS_ADMIN_REPO }
+      const CONFIG_PATH = env.SAFE_SETTINGS_CONFIG_PATH
       const params = Object.assign(repo, { path: path.posix.join(CONFIG_PATH, 'repos'), ref: this.ref })
 
       const response = await this.loadConfigMap(params)
@@ -452,7 +452,7 @@ ${this.results.reduce((x, y) => {
   async getSubOrgConfigMap () {
     try {
       this.log.debug(` In getSubOrgConfigMap ${JSON.stringify(this.repo)}`)
-      const repo = { owner: this.repo.owner, repo: env.ADMIN_REPO }
+      const repo = { owner: this.repo.owner, repo: env.SAFE_SETTINGS_ADMIN_REPO }
       const params = Object.assign(repo, { path: path.posix.join(CONFIG_PATH, 'suborgs'), ref: this.ref })
 
       const response = await this.loadConfigMap(params)
@@ -582,7 +582,7 @@ ${this.results.reduce((x, y) => {
    */
   async loadYaml (filePath) {
     try {
-      const repo = { owner: this.repo.owner, repo: env.ADMIN_REPO }
+      const repo = { owner: this.repo.owner, repo: env.SAFE_SETTINGS_ADMIN_REPO }
       const params = Object.assign(repo, { path: filePath, ref: this.ref })
       const response = await this.github.repos.getContent(params).catch(e => {
         this.log.error(`Error getting settings ${e}`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10753,7 +10753,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-5.3.1.tgz",
       "integrity": "sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==",
-      "deprecated": "Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>. Thanks to @shadowgate15, @spence-s, and @niftylettuce. Superagent is sponsored by Forward Email at <https://forwardemail.net>.",
+      "deprecated": "Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.",
       "dev": true,
       "dependencies": {
         "component-emitter": "^1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10753,7 +10753,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-5.3.1.tgz",
       "integrity": "sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==",
-      "deprecated": "Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.",
+      "deprecated": "Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>. Thanks to @shadowgate15, @spence-s, and @niftylettuce. Superagent is sponsored by Forward Email at <https://forwardemail.net>.",
       "dev": true,
       "dependencies": {
         "component-emitter": "^1.3.0",

--- a/test/unit/lib/env.test.js
+++ b/test/unit/lib/env.test.js
@@ -6,22 +6,22 @@ describe('env', () => {
     const envTest = require('../../../lib/env')
 
     it('loads default CONFIG_PATH if not passed', () => {
-      const CONFIG_PATH = envTest.SAFE_SETTINGS_CONFIG_PATH
+      const CONFIG_PATH = envTest.CONFIG_PATH
       expect(CONFIG_PATH).toEqual('.github')
     })
 
     it('loads default SETTINGS_FILE_PATH if not passed', () => {
-      const SETTINGS_FILE_PATH = envTest.SAFE_SETTINGS_SETTINGS_FILE_PATH
+      const SETTINGS_FILE_PATH = envTest.SETTINGS_FILE_PATH
       expect(SETTINGS_FILE_PATH).toEqual('settings.yml')
     })
 
     it('loads default ADMIN_ORG if not passed', () => {
-      const ADMIN_ORG = envTest.SAFE_SETTINGS_ADMIN_ORG
+      const ADMIN_ORG = envTest.ADMIN_ORG
       expect(ADMIN_ORG).toEqual('admin')
     })
 
     it('loads default ADMIN_REPO if not passed', () => {
-      const ADMIN_REPO = envTest.SAFE_SETTINGS_ADMIN_REPO
+      const ADMIN_REPO = envTest.ADMIN_REPO
       expect(ADMIN_REPO).toEqual('admin')
     })
   })
@@ -36,9 +36,9 @@ describe('env', () => {
 
     it('loads override values if passed', () => {
       const envTest = require('../../../lib/env')
-      const ADMIN_ORG = envTest.SAFE_SETTINGS_ADMIN_ORG
+      const ADMIN_ORG = envTest.ADMIN_ORG
       expect(ADMIN_ORG).toEqual('.github')
-      const ADMIN_REPO = envTest.SAFE_SETTINGS_ADMIN_REPO
+      const ADMIN_REPO = envTest.ADMIN_REPO
       expect(ADMIN_REPO).toEqual('.github')
     })
   })

--- a/test/unit/lib/env.test.js
+++ b/test/unit/lib/env.test.js
@@ -6,22 +6,22 @@ describe('env', () => {
     const envTest = require('../../../lib/env')
 
     it('loads default CONFIG_PATH if not passed', () => {
-      const CONFIG_PATH = envTest.CONFIG_PATH
+      const CONFIG_PATH = envTest.SAFE_SETTINGS_CONFIG_PATH
       expect(CONFIG_PATH).toEqual('.github')
     })
 
     it('loads default SETTINGS_FILE_PATH if not passed', () => {
-      const SETTINGS_FILE_PATH = envTest.SETTINGS_FILE_PATH
+      const SETTINGS_FILE_PATH = envTest.SAFE_SETTINGS_SETTINGS_FILE_PATH
       expect(SETTINGS_FILE_PATH).toEqual('settings.yml')
     })
 
     it('loads default ADMIN_ORG if not passed', () => {
-      const ADMIN_ORG = envTest.ADMIN_ORG
+      const ADMIN_ORG = envTest.SAFE_SETTINGS_ADMIN_ORG
       expect(ADMIN_ORG).toEqual('admin')
     })
 
     it('loads default ADMIN_REPO if not passed', () => {
-      const ADMIN_REPO = envTest.ADMIN_REPO
+      const ADMIN_REPO = envTest.SAFE_SETTINGS_ADMIN_REPO
       expect(ADMIN_REPO).toEqual('admin')
     })
   })
@@ -36,9 +36,9 @@ describe('env', () => {
 
     it('loads override values if passed', () => {
       const envTest = require('../../../lib/env')
-      const ADMIN_ORG = envTest.ADMIN_ORG
+      const ADMIN_ORG = envTest.SAFE_SETTINGS_ADMIN_ORG
       expect(ADMIN_ORG).toEqual('.github')
-      const ADMIN_REPO = envTest.ADMIN_REPO
+      const ADMIN_REPO = envTest.SAFE_SETTINGS_ADMIN_REPO
       expect(ADMIN_REPO).toEqual('.github')
     })
   })

--- a/test/unit/lib/env.test.js
+++ b/test/unit/lib/env.test.js
@@ -26,8 +26,8 @@ describe('env', () => {
 
     beforeAll(() => {
       jest.resetModules()
-      process.env.SAFE_SETTINGS_ADMIN_REPO = '.github'
-      process.env.SAFE_SETTINGS_SETTINGS_FILE_PATH = 'safe-settings.yml'
+      process.env.ADMIN_REPO = '.github'
+      process.env.SETTINGS_FILE_PATH = 'safe-settings.yml'
       process.env.DEPLOYMENT_CONFIG_FILE = 'safe-settings-deployment.yml'
     })
 

--- a/test/unit/lib/env.test.js
+++ b/test/unit/lib/env.test.js
@@ -5,9 +5,9 @@ describe('env', () => {
 
     const envTest = require('../../../lib/env')
 
-    it('loads default CONFIG_PATH if not passed', () => {
-      const CONFIG_PATH = envTest.CONFIG_PATH
-      expect(CONFIG_PATH).toEqual('.github')
+    it('loads default ADMIN_REPO if not passed', () => {
+      const ADMIN_REPO = envTest.ADMIN_REPO
+      expect(ADMIN_REPO).toEqual('admin')
     })
 
     it('loads default SETTINGS_FILE_PATH if not passed', () => {
@@ -20,10 +20,6 @@ describe('env', () => {
       expect(SETTINGS_FILE_PATH).toEqual('deployment-settings.yml')
     })
 
-    it('loads default ADMIN_REPO if not passed', () => {
-      const ADMIN_REPO = envTest.ADMIN_REPO
-      expect(ADMIN_REPO).toEqual('admin')
-    })
   })
 
   describe('load override values', () => {
@@ -31,7 +27,6 @@ describe('env', () => {
     beforeAll(() => {
       jest.resetModules()
       process.env.SAFE_SETTINGS_ADMIN_REPO = '.github'
-      process.env.SAFE_SETTINGS_CONFIG_PATH = '.config'
       process.env.SAFE_SETTINGS_SETTINGS_FILE_PATH = 'safe-settings.yml'
       process.env.DEPLOYMENT_CONFIG_FILE = 'safe-settings-deployment.yml'
     })
@@ -40,8 +35,6 @@ describe('env', () => {
       const envTest = require('../../../lib/env')
       const ADMIN_REPO = envTest.ADMIN_REPO
       expect(ADMIN_REPO).toEqual('.github')
-      const CONFIG_PATH = envTest.CONFIG_PATH
-      expect(CONFIG_PATH).toEqual('.config')
       const SETTINGS_FILE_PATH = envTest.SETTINGS_FILE_PATH
       expect(SETTINGS_FILE_PATH).toEqual('safe-settings.yml')
       const DEPLOYMENT_CONFIG_FILE = envTest.DEPLOYMENT_CONFIG_FILE

--- a/test/unit/lib/env.test.js
+++ b/test/unit/lib/env.test.js
@@ -32,6 +32,8 @@ describe('env', () => {
       jest.resetModules()
       process.env.SAFE_SETTINGS_ADMIN_ORG = '.github'
       process.env.SAFE_SETTINGS_ADMIN_REPO = '.github'
+      process.env.SAFE_SETTINGS_CONFIG_PATH = 'whatever'
+      process.env.SAFE_SETTINGS_SETTINGS_FILE_PATH = 'safe-settings.yml'
     })
 
     it('loads override values if passed', () => {
@@ -40,6 +42,10 @@ describe('env', () => {
       expect(ADMIN_ORG).toEqual('.github')
       const ADMIN_REPO = envTest.ADMIN_REPO
       expect(ADMIN_REPO).toEqual('.github')
+      const CONFIG_PATH = envTest.CONFIG_PATH
+      expect(CONFIG_PATH).toEqual('whatever')
+      const SETTINGS_FILE_PATH = envTest.SETTINGS_FILE_PATH
+      expect(SETTINGS_FILE_PATH).toEqual('safe-settings.yml')
     })
   })
 

--- a/test/unit/lib/env.test.js
+++ b/test/unit/lib/env.test.js
@@ -1,0 +1,46 @@
+/* eslint-disable no-undef */
+describe('env', () => {
+
+  describe('load default values without override', () => {
+
+    const envTest = require('../../../lib/env')
+
+    it('loads default CONFIG_PATH if not passed', () => {
+      const CONFIG_PATH = envTest.CONFIG_PATH
+      expect(CONFIG_PATH).toEqual('.github')
+    })
+
+    it('loads default SETTINGS_FILE_PATH if not passed', () => {
+      const SETTINGS_FILE_PATH = envTest.SETTINGS_FILE_PATH
+      expect(SETTINGS_FILE_PATH).toEqual('settings.yml')
+    })
+
+    it('loads default ADMIN_ORG if not passed', () => {
+      const ADMIN_ORG = envTest.ADMIN_ORG
+      expect(ADMIN_ORG).toEqual('admin')
+    })
+
+    it('loads default ADMIN_REPO if not passed', () => {
+      const ADMIN_REPO = envTest.ADMIN_REPO
+      expect(ADMIN_REPO).toEqual('admin')
+    })
+  })
+
+  describe('load override values', () => {
+
+    beforeAll(() => {
+      jest.resetModules()
+      process.env.ADMIN_ORG = '.github'
+      process.env.ADMIN_REPO = '.github'
+    })
+
+    it('loads override values if passed', () => {
+      const envTest = require('../../../lib/env')
+      const ADMIN_ORG = envTest.ADMIN_ORG
+      expect(ADMIN_ORG).toEqual('.github')
+      const ADMIN_REPO = envTest.ADMIN_REPO
+      expect(ADMIN_REPO).toEqual('.github')
+    })
+  })
+
+})

--- a/test/unit/lib/env.test.js
+++ b/test/unit/lib/env.test.js
@@ -30,8 +30,8 @@ describe('env', () => {
 
     beforeAll(() => {
       jest.resetModules()
-      process.env.ADMIN_ORG = '.github'
-      process.env.ADMIN_REPO = '.github'
+      process.env.SAFE_SETTINGS_ADMIN_ORG = '.github'
+      process.env.SAFE_SETTINGS_ADMIN_REPO = '.github'
     })
 
     it('loads override values if passed', () => {

--- a/test/unit/lib/env.test.js
+++ b/test/unit/lib/env.test.js
@@ -15,6 +15,11 @@ describe('env', () => {
       expect(SETTINGS_FILE_PATH).toEqual('settings.yml')
     })
 
+    it('loads default DEPLOYMENT_CONFIG_FILE if not passed', () => {
+      const SETTINGS_FILE_PATH = envTest.DEPLOYMENT_CONFIG_FILE
+      expect(SETTINGS_FILE_PATH).toEqual('deployment-settings.yml')
+    })
+
     it('loads default ADMIN_REPO if not passed', () => {
       const ADMIN_REPO = envTest.ADMIN_REPO
       expect(ADMIN_REPO).toEqual('admin')
@@ -25,10 +30,10 @@ describe('env', () => {
 
     beforeAll(() => {
       jest.resetModules()
-      process.env.SAFE_SETTINGS_ADMIN_ORG = '.github'
       process.env.SAFE_SETTINGS_ADMIN_REPO = '.github'
-      process.env.SAFE_SETTINGS_CONFIG_PATH = 'whatever'
+      process.env.SAFE_SETTINGS_CONFIG_PATH = '.config'
       process.env.SAFE_SETTINGS_SETTINGS_FILE_PATH = 'safe-settings.yml'
+      process.env.DEPLOYMENT_CONFIG_FILE = 'safe-settings-deployment.yml'
     })
 
     it('loads override values if passed', () => {
@@ -36,9 +41,11 @@ describe('env', () => {
       const ADMIN_REPO = envTest.ADMIN_REPO
       expect(ADMIN_REPO).toEqual('.github')
       const CONFIG_PATH = envTest.CONFIG_PATH
-      expect(CONFIG_PATH).toEqual('whatever')
+      expect(CONFIG_PATH).toEqual('.config')
       const SETTINGS_FILE_PATH = envTest.SETTINGS_FILE_PATH
       expect(SETTINGS_FILE_PATH).toEqual('safe-settings.yml')
+      const DEPLOYMENT_CONFIG_FILE = envTest.DEPLOYMENT_CONFIG_FILE
+      expect(DEPLOYMENT_CONFIG_FILE).toEqual('safe-settings-deployment.yml')
     })
   })
 

--- a/test/unit/lib/env.test.js
+++ b/test/unit/lib/env.test.js
@@ -15,11 +15,6 @@ describe('env', () => {
       expect(SETTINGS_FILE_PATH).toEqual('settings.yml')
     })
 
-    it('loads default ADMIN_ORG if not passed', () => {
-      const ADMIN_ORG = envTest.ADMIN_ORG
-      expect(ADMIN_ORG).toEqual('admin')
-    })
-
     it('loads default ADMIN_REPO if not passed', () => {
       const ADMIN_REPO = envTest.ADMIN_REPO
       expect(ADMIN_REPO).toEqual('admin')
@@ -38,8 +33,6 @@ describe('env', () => {
 
     it('loads override values if passed', () => {
       const envTest = require('../../../lib/env')
-      const ADMIN_ORG = envTest.ADMIN_ORG
-      expect(ADMIN_ORG).toEqual('.github')
       const ADMIN_REPO = envTest.ADMIN_REPO
       expect(ADMIN_REPO).toEqual('.github')
       const CONFIG_PATH = envTest.CONFIG_PATH


### PR DESCRIPTION
Issue: [230](https://github.com/github/safe-settings/issues/230)

Extract configuration to an external library so it can be updated via env variables. This should allow to select a different default admin organization.

This change permits to pass an environment variable for `ADMIN_REPO`, `SETTINGS_FILE_PATH` and `DEPLOYMENT_CONFIG_FILE` so they can be modified, like for example selecting as `ADMIN_REPO` the repository `.github` as other probot apps.

| Environment Variable               | Internal Reference       | Default Value             |
|------------------------------------|--------------------------|---------------------------|
| `ADMIN_REPO`         | `ADMIN_REPO`             | `admin`                   |
| `SETTINGS_FILE_PATH` | `SETTINGS_FILE_PATH`     | `settings.yml`            |
| `DEPLOYMENT_CONFIG_FILE`           | `DEPLOYMENT_CONFIG_FILE` | `deployment-settings.yml` |

Example:

```
ADMIN_REPO=global-config
SETTINGS_FILE_PATH=safe-settings.yml
DEPLOYMENT_CONFIG_FILE=safe-settings-deployment.yml
```

And the code will look within your `<ORG>/global-config/.github/safe-settings.yml` instead of default `<ORG>/admin/.github/settings.yml`