### PR TITLE
feat: support for regular expressions in restrictedRepos

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ To apply `safe-settings` __only__ to a specific list of repos, add them to the `
 
 To ignore `safe-settings` for a specific list of repos, add them to the `restrictedRepos` section as `exclude` array.
 
-### Custom rules 
+**Note**: The `include` and `exclude` attributes support as well regular expressions.
+
+### Custom rules
+
 Admins setting up `safe-settings` can include custom rules that would be used to validate before applying a setting or overridding a broader scoped setting.
 
 The code has to return `true` if validation is successful, or `false` if it isn't.  

--- a/docs/sample-settings/sample-deployment-settings.yml
+++ b/docs/sample-settings/sample-deployment-settings.yml
@@ -1,7 +1,7 @@
 restrictedRepos: 
   # You can exclude certain repos from safe-settings processing
   #  If no file is specified, then the following repositories - 'admin', '.github', 'safe-settings' are exempted by default
-  exclude: ['admin', '.github', 'safe-settings']
+  exclude: ['admin', '.github', 'safe-settings', '.*-test']
   # Alternatively you can only include certain repos
   include: ['test']
 configvalidators:

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -334,7 +334,8 @@ ${this.results.reduce((x, y) => {
         return false
       }
     } else if (Array.isArray(restrictedRepos.include)) {
-      if (restrictedRepos.include.includes(repoName)) {
+
+      if (this.includesRepo(repoName, restrictedRepos.include)) {
         this.log.debug(`Allowing ${repoName} in restrictedRepos.include [${restrictedRepos.include}]`)
         return false
       } else {
@@ -342,7 +343,7 @@ ${this.results.reduce((x, y) => {
         return true
       }
     } else if (Array.isArray(restrictedRepos.exclude)) {
-      if (restrictedRepos.exclude.includes(repoName)) {
+      if (this.includesRepo(repoName, restrictedRepos.exclude)) {
         this.log.debug(`Skipping excluded repo ${repoName} in restrictedRepos.exclude`)
         return true
       } else {
@@ -352,6 +353,10 @@ ${this.results.reduce((x, y) => {
     }
     return false
   }
+
+  includesRepo(repoName, restrictedRepos) {
+    return restrictedRepos.filter((restrictedRepo) => { return RegExp(restrictedRepo).test(repoName) }).length > 0
+}
 
   async eachRepositoryRepos (github, restrictedRepos, log) {
     log.debug('Fetching repositories')

--- a/test/unit/lib/settings.test.js
+++ b/test/unit/lib/settings.test.js
@@ -1,0 +1,145 @@
+/* eslint-disable no-undef */
+
+const Settings = require('../../../lib/settings')
+
+describe('Settings Tests', () => {
+
+  let stubContext
+  let mockRepo
+  let stubConfig
+  let mockRef
+  let mockSubOrg
+
+  function createSettings(config) {
+    return new Settings(false, stubContext, mockRepo, config, mockRef, mockSubOrg)
+  }
+
+  beforeEach(() => {
+    stubContext = {
+      payload: {
+        installation: {
+          id: 123
+        }
+      },
+      octokit: jest.fn(),
+      log: {
+        debug: jest.fn((msg) => {
+          console.log(msg)
+        }),
+        info: jest.fn((msg) => {
+          console.log(msg)
+        }),
+        error: jest.fn((msg) => {
+          console.log(msg)
+        })
+      }
+    }
+
+    mockRepo = jest.fn()
+    mockRef = jest.fn()
+    mockSubOrg = jest.fn()
+  })
+
+  describe('restrictedRepos', () => {
+
+    describe('restrictedRepos not defined', () => {
+      beforeEach(() => {
+        stubConfig = {
+          restrictedRepos: {
+          }
+        }
+      })
+
+      it('Allow repositories being configured', () => {
+        settings = createSettings(stubConfig)
+        expect(settings.isRestricted("my-repo")).toEqual(false)
+        expect(settings.isRestricted("another-repo")).toEqual(false)
+      })
+
+      it('Do not allow default excluded repositories being configured', () => {
+        settings = createSettings(stubConfig)
+        expect(settings.isRestricted(".github")).toEqual(false)
+        expect(settings.isRestricted("safe-settings")).toEqual(false)
+        expect(settings.isRestricted("admin")).toEqual(false)
+      })
+    })
+
+    describe('restrictedRepos.exclude defined', () => {
+      beforeEach(() => {
+        stubConfig = {
+          restrictedRepos: {
+            exclude: ['foo', '.*-test$', '^personal-.*$']
+          }
+        }
+      })
+
+      it('Skipping excluded repository from being configured', () => {
+        settings = createSettings(stubConfig)
+        expect(settings.isRestricted("foo")).toEqual(true)
+      })
+
+      it('Skipping excluded repositories matching regex in restrictedRepos.exclude', () => {
+        settings = createSettings(stubConfig)
+        expect(settings.isRestricted("my-repo-test")).toEqual(true)
+        expect(settings.isRestricted("personal-repo")).toEqual(true)
+      })
+
+      it('Allowing repositories not matching regex in restrictedRepos.exclude', () => {
+        settings = createSettings(stubConfig)
+        expect(settings.isRestricted("my-repo-test-data")).toEqual(false)
+        expect(settings.isRestricted("personalization-repo")).toEqual(false)
+      })
+    })
+
+    describe('restrictedRepos.include defined', () => {
+        beforeEach(() => {
+          stubConfig = {
+            restrictedRepos: {
+              include: ['foo', '.*-test$', '^personal-.*$']
+            }
+          }
+        })
+
+      it('Allowing repository from being configured', () => {
+        settings = createSettings(stubConfig)
+        expect(settings.isRestricted("foo")).toEqual(false)
+      })
+
+      it('Allowing repositories matching regex in restrictedRepos.include', () => {
+        settings = createSettings(stubConfig)
+        expect(settings.isRestricted("my-repo-test")).toEqual(false)
+        expect(settings.isRestricted("personal-repo")).toEqual(false)
+      })
+
+      it('Skipping repositories not matching regex in restrictedRepos.include', () => {
+        settings = createSettings(stubConfig)
+        expect(settings.isRestricted("my-repo-test-data")).toEqual(true)
+        expect(settings.isRestricted("personalization-repo")).toEqual(true)
+      })
+    })
+
+    describe('restrictedRepos not defined', () => {
+      it('Throws TypeError if restrictedRepos not defined', () => {
+        stubConfig = {}
+        settings = createSettings(stubConfig)
+        expect(() => settings.isRestricted("my-repo")).toThrow('Cannot read properties of undefined (reading \'include\')')
+      })
+
+      it('Throws TypeError if restrictedRepos is null', () => {
+        stubConfig = {
+          restrictedRepos: null
+        }
+        settings = createSettings(stubConfig)
+        expect(() => settings.isRestricted("my-repo")).toThrow('Cannot read properties of null (reading \'include\')')
+      })
+
+      it('Allowing all repositories if restrictedRepos is empty', () => {
+        stubConfig = {
+          restrictedRepos: []
+        }
+        settings = createSettings(stubConfig)
+        expect(settings.isRestricted("my-repo")).toEqual(false)
+      })
+    })
+  }) // restrictedRepos
+}) // Settings Tests


### PR DESCRIPTION
In our org we would like to skip certain repositories (playgrounds, dev, PoC, etc.) from being configured with safe-settings. 

This PR introduces support for using regular expressions in the `restrictedRepos` attributes `include` and `exclude`. 