### PR TITLE
fix(repository): ignore field `security`

### DIFF
--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -31,6 +31,7 @@ const ignorableFields = [
   'allow_auto_merge',
   'delete_branch_on_merge',
   'organization',
+  'security',
   'security_and_analysis',
   'network_count',
   'subscribers_count',
@@ -103,6 +104,8 @@ module.exports = class Repository {
           promises.push(this.updaterepo(resArray).then(() => {
             return this.updateSecurity(resp.data, resArray)
           }))
+        } else {
+          promises.push(this.updateSecurity(resp.data, resArray))
         }
         if (topicChanges.hasChanges) {
           promises.push(this.updatetopics(resp.data, resArray))


### PR DESCRIPTION
fix #387 

`security` is ignored from the comparison as it is not part of the GitHub response. Using `security` in the config will no longer do an update to the repo settings with `updateRepo` when there are no changes to the repository settings.
`updateSecurity` is always called since the data it depends on is not part of the repository response payload.