### PR TITLE
fix: check runs never created when running in AWS Lambda

### DIFF
--- a/index.js
+++ b/index.js
@@ -301,7 +301,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
       return
     }
     const pull_request = payload.check_suite.pull_requests[0]
-    createCheckRun(context, pull_request, payload.check_suite.head_sha, payload.check_suite.head_branch)
+    return createCheckRun(context, pull_request, payload.check_suite.head_sha, payload.check_suite.head_branch)
   })
 
   robot.on('pull_request.opened', async context => {
@@ -320,7 +320,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
       return
     }
     const pull_request = payload.pull_request
-    createCheckRun(context, pull_request, payload.pull_request.head.sha, payload.pull_request.head.ref)
+    return createCheckRun(context, pull_request, payload.pull_request.head.sha, payload.pull_request.head.ref)
   })
 
   robot.on('pull_request.reopened', async context => {
@@ -341,17 +341,17 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
       robot.log.debug(' Working on the default branch, returning...')
       return
     }
-    createCheckRun(context, pull_request, payload.pull_request.head.sha, payload.pull_request.head.ref)
+    return createCheckRun(context, pull_request, payload.pull_request.head.sha, payload.pull_request.head.ref)
   })
 
   robot.on(['check_suite.rerequested'], async context => {
     robot.log.debug('Check suite was rerequested!')
-    createCheckRun(context)
+    return createCheckRun(context)
   })
 
   robot.on(['check_suite.rerequested'], async context => {
     robot.log.debug('Check suite was rerequested!')
-    createCheckRun(context)
+    return createCheckRun(context)
   })
 
   robot.on(['check_run.created'], async context => {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -334,7 +334,6 @@ ${this.results.reduce((x, y) => {
         return false
       }
     } else if (Array.isArray(restrictedRepos.include)) {
-
       if (this.includesRepo(repoName, restrictedRepos.include)) {
         this.log.debug(`Allowing ${repoName} in restrictedRepos.include [${restrictedRepos.include}]`)
         return false
@@ -354,7 +353,7 @@ ${this.results.reduce((x, y) => {
     return false
   }
 
-  includesRepo(repoName, restrictedRepos) {
+  includesRepo (repoName, restrictedRepos) {
     return restrictedRepos.filter((restrictedRepo) => { return RegExp(restrictedRepo).test(repoName) }).length > 0
   }
 

--- a/test/unit/lib/mergeDeep.test.js
+++ b/test/unit/lib/mergeDeep.test.js
@@ -218,19 +218,19 @@ branches:
     const ignorableFields = []
     const mergeDeep = new MergeDeep(log, ignorableFields)
     const merged = mergeDeep.compareDeep(target, source)
-    //console.log(`source ${JSON.stringify(source, null, 2)}`)
-    //console.log(`target ${JSON.stringify(target, null, 2)}`)
-    //console.log(`diffs ${JSON.stringify(merged, null, 2)}`)
+    // console.log(`source ${JSON.stringify(source, null, 2)}`)
+    // console.log(`target ${JSON.stringify(target, null, 2)}`)
+    // console.log(`diffs ${JSON.stringify(merged, null, 2)}`)
     expect(merged.additions).toEqual(expected.additions)
     expect(merged.modifications.length).toEqual(expected.modifications.length)
 
-    //console.log(`target = ${JSON.stringify(target, null, 2)}`)
+    // console.log(`target = ${JSON.stringify(target, null, 2)}`)
     const overrideConfig = mergeDeep.mergeDeep({}, target, source)
 
-    //console.log(`overrideConfig = ${JSON.stringify(overrideConfig, null, 2)}`)
+    // console.log(`overrideConfig = ${JSON.stringify(overrideConfig, null, 2)}`)
 
     const same = mergeDeep.compareDeep(overrideConfig, source)
-    //console.log(`new diffs ${JSON.stringify(same, null, 2)}`)
+    // console.log(`new diffs ${JSON.stringify(same, null, 2)}`)
     expect(same.additions).toEqual({})
     expect(same.modifications).toEqual(combinedModifications)
   })
@@ -624,9 +624,9 @@ branches:
     const ignorableFields = []
     const mergeDeep = new MergeDeep(log, ignorableFields)
     const merged = mergeDeep.compareDeep(target, source)
-    //console.log(`source ${JSON.stringify(source, null, 2)}`)
-    //console.log(`target ${JSON.stringify(target, null, 2)}`)
-    //console.log(`diffs ${JSON.stringify(merged, null, 2)}`)
+    // console.log(`source ${JSON.stringify(source, null, 2)}`)
+    // console.log(`target ${JSON.stringify(target, null, 2)}`)
+    // console.log(`diffs ${JSON.stringify(merged, null, 2)}`)
     expect(merged.additions).toEqual(expected.additions)
     expect(merged.modifications.length).toEqual(expected.modifications.length)
 
@@ -984,11 +984,12 @@ it('CompareDeep does not mutate source object', () => {
   const source = {
     teams: ['developers']
   }
-  const result = mergeDeep.compareDeep(target, source)
+  mergeDeep.compareDeep(target, source)
 
-  //console.log(`source ${JSON.stringify(source, null, 2)}`)
-  //console.log(`target ${JSON.stringify(target, null, 2)}`)
-  //console.log(`result ${JSON.stringify(result, null, 2)}`)
+  // const result = mergeDeep.compareDeep(target, source)
+  // console.log(`source ${JSON.stringify(source, null, 2)}`)
+  // console.log(`target ${JSON.stringify(target, null, 2)}`)
+  // console.log(`result ${JSON.stringify(result, null, 2)}`)
 
   expect(source.teams).toEqual(['developers'])
 })
@@ -1007,9 +1008,9 @@ it('CompareDeep produces correct result for arrays of named objects', () => {
   }
   const result = mergeDeep.compareDeep(target, source)
 
-  //console.log(`source ${JSON.stringify(source, null, 2)}`)
-  //console.log(`target ${JSON.stringify(target, null, 2)}`)
-  //console.log(`result ${JSON.stringify(result, null, 2)}`)
+  // console.log(`source ${JSON.stringify(source, null, 2)}`)
+  // console.log(`target ${JSON.stringify(target, null, 2)}`)
+  // console.log(`result ${JSON.stringify(result, null, 2)}`)
 
   expect(result.modifications.teams).toEqual(['developers'])
 })

--- a/test/unit/lib/settings.test.js
+++ b/test/unit/lib/settings.test.js
@@ -3,14 +3,13 @@
 const Settings = require('../../../lib/settings')
 
 describe('Settings Tests', () => {
-
   let stubContext
   let mockRepo
   let stubConfig
   let mockRef
   let mockSubOrg
 
-  function createSettings(config) {
+  function createSettings (config) {
     return new Settings(false, stubContext, mockRepo, config, mockRef, mockSubOrg)
   }
 
@@ -41,7 +40,6 @@ describe('Settings Tests', () => {
   })
 
   describe('restrictedRepos', () => {
-
     describe('restrictedRepos not defined', () => {
       beforeEach(() => {
         stubConfig = {
@@ -52,15 +50,15 @@ describe('Settings Tests', () => {
 
       it('Allow repositories being configured', () => {
         settings = createSettings(stubConfig)
-        expect(settings.isRestricted("my-repo")).toEqual(false)
-        expect(settings.isRestricted("another-repo")).toEqual(false)
+        expect(settings.isRestricted('my-repo')).toEqual(false)
+        expect(settings.isRestricted('another-repo')).toEqual(false)
       })
 
       it('Do not allow default excluded repositories being configured', () => {
         settings = createSettings(stubConfig)
-        expect(settings.isRestricted(".github")).toEqual(false)
-        expect(settings.isRestricted("safe-settings")).toEqual(false)
-        expect(settings.isRestricted("admin")).toEqual(false)
+        expect(settings.isRestricted('.github')).toEqual(false)
+        expect(settings.isRestricted('safe-settings')).toEqual(false)
+        expect(settings.isRestricted('admin')).toEqual(false)
       })
     })
 
@@ -75,46 +73,46 @@ describe('Settings Tests', () => {
 
       it('Skipping excluded repository from being configured', () => {
         settings = createSettings(stubConfig)
-        expect(settings.isRestricted("foo")).toEqual(true)
+        expect(settings.isRestricted('foo')).toEqual(true)
       })
 
       it('Skipping excluded repositories matching regex in restrictedRepos.exclude', () => {
         settings = createSettings(stubConfig)
-        expect(settings.isRestricted("my-repo-test")).toEqual(true)
-        expect(settings.isRestricted("personal-repo")).toEqual(true)
+        expect(settings.isRestricted('my-repo-test')).toEqual(true)
+        expect(settings.isRestricted('personal-repo')).toEqual(true)
       })
 
       it('Allowing repositories not matching regex in restrictedRepos.exclude', () => {
         settings = createSettings(stubConfig)
-        expect(settings.isRestricted("my-repo-test-data")).toEqual(false)
-        expect(settings.isRestricted("personalization-repo")).toEqual(false)
+        expect(settings.isRestricted('my-repo-test-data')).toEqual(false)
+        expect(settings.isRestricted('personalization-repo')).toEqual(false)
       })
     })
 
     describe('restrictedRepos.include defined', () => {
-        beforeEach(() => {
-          stubConfig = {
-            restrictedRepos: {
-              include: ['foo', '.*-test$', '^personal-.*$']
-            }
+      beforeEach(() => {
+        stubConfig = {
+          restrictedRepos: {
+            include: ['foo', '.*-test$', '^personal-.*$']
           }
-        })
+        }
+      })
 
       it('Allowing repository from being configured', () => {
         settings = createSettings(stubConfig)
-        expect(settings.isRestricted("foo")).toEqual(false)
+        expect(settings.isRestricted('foo')).toEqual(false)
       })
 
       it('Allowing repositories matching regex in restrictedRepos.include', () => {
         settings = createSettings(stubConfig)
-        expect(settings.isRestricted("my-repo-test")).toEqual(false)
-        expect(settings.isRestricted("personal-repo")).toEqual(false)
+        expect(settings.isRestricted('my-repo-test')).toEqual(false)
+        expect(settings.isRestricted('personal-repo')).toEqual(false)
       })
 
       it('Skipping repositories not matching regex in restrictedRepos.include', () => {
         settings = createSettings(stubConfig)
-        expect(settings.isRestricted("my-repo-test-data")).toEqual(true)
-        expect(settings.isRestricted("personalization-repo")).toEqual(true)
+        expect(settings.isRestricted('my-repo-test-data')).toEqual(true)
+        expect(settings.isRestricted('personalization-repo')).toEqual(true)
       })
     })
 
@@ -122,7 +120,7 @@ describe('Settings Tests', () => {
       it('Throws TypeError if restrictedRepos not defined', () => {
         stubConfig = {}
         settings = createSettings(stubConfig)
-        expect(() => settings.isRestricted("my-repo")).toThrow('Cannot read properties of undefined (reading \'include\')')
+        expect(() => settings.isRestricted('my-repo')).toThrow('Cannot read properties of undefined (reading \'include\')')
       })
 
       it('Throws TypeError if restrictedRepos is null', () => {
@@ -130,7 +128,7 @@ describe('Settings Tests', () => {
           restrictedRepos: null
         }
         settings = createSettings(stubConfig)
-        expect(() => settings.isRestricted("my-repo")).toThrow('Cannot read properties of null (reading \'include\')')
+        expect(() => settings.isRestricted('my-repo')).toThrow('Cannot read properties of null (reading \'include\')')
       })
 
       it('Allowing all repositories if restrictedRepos is empty', () => {
@@ -138,7 +136,7 @@ describe('Settings Tests', () => {
           restrictedRepos: []
         }
         settings = createSettings(stubConfig)
-        expect(settings.isRestricted("my-repo")).toEqual(false)
+        expect(settings.isRestricted('my-repo')).toEqual(false)
       })
     })
   }) // restrictedRepos


### PR DESCRIPTION
**Description**

Adds `return` for `createCheckRun` to allow it to run to completion before the Lambda function exits.
Fixes #380

**Background**

Just like mentioned in #380 by @aJanuary, I also couldn't figure out why no check runs were created when running as an AWS Lambda function.
(It worked perfect when running locally in VSCode)

I couldn't get my head around this so I added some more logging to the function itself:

```
  async function createCheckRun (context, pull_request, head_sha, head_branch) {
    const { payload } = context
    robot.log.debug(`Check suite was requested! for ${context.repo()} ${pull_request.number} ${head_sha} ${head_branch}`)
    const create_payload = {
      owner: payload.repository.owner.login,
      repo: payload.repository.name,
      name: 'Safe-setting validator',
      head_sha
    }
    robot.log.debug(`Creating check run with payload ${JSON.stringify(create_payload)}`)
    try {
      const res = await context.octokit.checks.create(create_payload)
      robot.log.debug('Check run created')
      robot.log.debug(JSON.stringify(res, null))
    } catch (error) {
      robot.log.debug('Error creating check run')
      throw error
    }
  }
```

The cloudwatch log streams just ends when it comes to the `await`:
<img width="424" alt="Screenshot 2023-01-30 at 12 24 47" src="https://user-images.githubusercontent.com/435885/215468978-a540b6d5-0273-4e16-9cc6-a22c52c733c5.png">

...and GitHub webhook log shows no check run created events:
<img width="715" alt="Screenshot 2023-01-30 at 12 31 42" src="https://user-images.githubusercontent.com/435885/215468971-fd7bc1f0-6343-4c3d-89cb-57708f64621f.png">

Then I noticed that no calls to the function were awaited upon and when adding the return statements it works like a charm, also in AWS Lambda! 🎉 

Note: I have only checked this function for proper return statements. I have not checked other async functions that may lack return or await. The scope for this fix is only for calls to `createCheckRun`.