### PR TITLE
feat: add scheduler handler

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -8,3 +8,9 @@ const appFn = require('./')
 module.exports.webhooks = createLambdaFunction(appFn, {
   probot: createProbot()
 })
+
+module.exports.scheduler = function () {
+  const probot = createProbot()
+  const app = appFn(probot)
+  return app.syncInstallation()
+}

--- a/index.js
+++ b/index.js
@@ -459,4 +459,8 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
       syncInstallation()
     })
   }
+
+  return {
+    syncInstallation
+  }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -21,3 +21,15 @@ functions:
       - httpApi:
           path: /api/github/webhooks
           method: post
+  cronHandler:
+    handler: handler.scheduler
+    memorySize: 256
+    timeout: 900 # 15 mins (max)
+    environment:
+      NODE_ENV: production
+      LOG_LEVEL: debug
+    events:
+      - schedule:
+          rate: rate(30 minutes)
+          enabled: false # set to true to auto-enable
+          input: {}


### PR DESCRIPTION
Provides example configuration for using EventBridge events to run `syncInstallation` on a schedule in a separate Lambda function.

- The provided example trigger is disabled by default
- Manual invocation is possible by clicking the Test button in the Test tab of the Lambda in the AWS Console

Implemented based on the example provided by @viks-confluent in https://github.com/github/safe-settings/issues/313#issuecomment-1295371756

fixes #313

### Screenshots

Output from manual run

<img width="870" alt="Screenshot 2023-02-02 at 17 52 10" src="https://user-images.githubusercontent.com/435885/216390580-e9a99911-9a81-4d14-bd48-0be0b28fa860.png">

A useful query for CloudWatch Log Insights to get logs from both log groups (webhook invocations and scheduled/manual runs):
<img width="504" alt="Screenshot 2023-02-02 at 17 53 12" src="https://user-images.githubusercontent.com/435885/216390601-409e9261-d9f1-40da-ba08-8b0c0f67bfcb.png">
