### PR TITLE
docs: use strict repo names in sample config

### DIFF
--- a/docs/sample-settings/sample-deployment-settings.yml
+++ b/docs/sample-settings/sample-deployment-settings.yml
@@ -1,9 +1,9 @@
-restrictedRepos: 
+restrictedRepos:
   # You can exclude certain repos from safe-settings processing
   #  If no file is specified, then the following repositories - 'admin', '.github', 'safe-settings' are exempted by default
-  exclude: ['admin', '.github', 'safe-settings', '.*-test']
+  exclude: ['^admin$', '^\.github$', '^safe-settings$', '.*-test']
   # Alternatively you can only include certain repos
-  include: ['test']
+  include: ['^test$']
 configvalidators:
   - plugin: collaborators
     error: |
@@ -12,14 +12,14 @@ configvalidators:
       console.log(`baseConfig ${JSON.stringify(baseconfig)}`)
       return baseconfig.permission != 'admin'
 overridevalidators:
-  - plugin: branches   
+  - plugin: branches
     error: |
       `Branch protection required_approving_review_count cannot be overidden to a lower value`
     script: |
       console.log(`baseConfig ${JSON.stringify(baseconfig)}`)
       console.log(`overrideConfig ${JSON.stringify(overrideconfig)}`)
       if (baseconfig.protection.required_pull_request_reviews.required_approving_review_count && overrideconfig.protection.required_pull_request_reviews.required_approving_review_count ) {
-        return overrideconfig.protection.required_pull_request_reviews.required_approving_review_count >= baseconfig.protection.required_pull_request_reviews.required_approving_review_count 
+        return overrideconfig.protection.required_pull_request_reviews.required_approving_review_count >= baseconfig.protection.required_pull_request_reviews.required_approving_review_count
       }
       return true
   - plugin: labels


### PR DESCRIPTION
Aligns the provided sample config with the feature added in github/safe-settings#371 so it continues to match the intended repositories.

@decyjphr @martinm82 The change in #371 had some surprising side effects for me. Any repo containing the word `admin` became excluded and I also had my test repository named `safe-settings-test` excluded by the string `'safe-settings'`. 
