### PR TITLE
feat: add the ability to enable Automated Security Fixes

### DIFF
--- a/docs/sample-settings/repo.yml
+++ b/docs/sample-settings/repo.yml
@@ -34,6 +34,7 @@ repository:
   # Dependabot Alerts
   security:
    enableVulnerabilityAlerts: true
+   enableAutomatedSecurityFixes: true
 
   # Either `true` to make the repository private, or `false` to make it public. 
   # If this value is changed and if Org members cannot change the visibility of repos

--- a/docs/sample-settings/settings.yml
+++ b/docs/sample-settings/settings.yml
@@ -24,8 +24,9 @@
 
   # Settings for Code security and analysis
   # Dependabot Alerts
-  #security:
-  # enableVulnerabilityAlerts: true 
+  # security:
+    # enableVulnerabilityAlerts: true
+    # enableAutomatedSecurityFixes: true
   
   # Either `true` to make the repository private, or `false` to make it public. 
   # If this value is changed and if Org members cannot change the visibility of repos

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -104,7 +104,7 @@ module.exports = class Repository {
               return this.updateSecurity(resp.data, resArray)
             }))
           promises.push(this.updaterepo(resArray).then(() => {
-            return this.updateSecurityDependabotAlerts(resp.data, resArray)
+            return this.updateAutomatedSecurityFixes(resp.data, resArray)
           }))
         }
         if (topicChanges.hasChanges) {

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -100,12 +100,14 @@ module.exports = class Repository {
           }
           // Remove topics as it would be handled seperately
           delete this.settings.topics
-            promises.push(this.updaterepo(resArray).then(() => {
+          promises.push(this.updaterepo(resArray).then(() => {
               return this.updateSecurity(resp.data, resArray)
             }))
           promises.push(this.updaterepo(resArray).then(() => {
             return this.updateAutomatedSecurityFixes(resp.data, resArray)
           }))
+        } else {
+          promises.push(this.updateSecurity(resp.data, resArray))
         }
         if (topicChanges.hasChanges) {
           promises.push(this.updatetopics(resp.data, resArray))
@@ -224,7 +226,7 @@ module.exports = class Repository {
             resArray.push((new NopCommand(this.constructor.name, this.repo, this.github.repos.enableVulnerabilityAlerts.endpoint({
               owner: repoData.owner.login,
               repo: repoData.name
-            }), 'Update Topics')))
+            }), 'Enabling Dependabot alerts')))
             return Promise.resolve(resArray)
           }
           return this.github.repos.enableVulnerabilityAlerts({
@@ -238,7 +240,7 @@ module.exports = class Repository {
             resArray.push((new NopCommand(this.constructor.name, this.github.repos.disableVulnerabilityAlerts.endpoint({
               owner: repoData.owner.login,
               repo: repoData.name
-            }), 'Update Topics')))
+            }), 'Disabling Dependabot alerts')))
             return Promise.resolve(resArray)
           }
           return this.github.repos.disableVulnerabilityAlerts({
@@ -266,7 +268,7 @@ module.exports = class Repository {
             resArray.push((new NopCommand(this.constructor.name, this.repo, this.github.repos.enableAutomatedSecurityFixes.endpoint({
               owner: repoData.owner.login,
               repo: repoData.name
-            }), 'Update Topics')))
+            }), 'Enabling Dependabot security updates')))
             return Promise.resolve(resArray)
           }
           return this.github.repos.enableAutomatedSecurityFixes({
@@ -280,7 +282,7 @@ module.exports = class Repository {
             resArray.push((new NopCommand(this.constructor.name, this.github.repos.disableAutomatedSecurityFixes.endpoint({
               owner: repoData.owner.login,
               repo: repoData.name
-            }), 'Update Topics')))
+            }), 'Disabling Dependabot security updates')))
             return Promise.resolve(resArray)
           }
           return this.github.repos.disableAutomatedSecurityFixes({

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -217,9 +217,8 @@ module.exports = class Repository {
 
   // Added support for Code Security and Analysis
   updateSecurity (repoData, resArray) {
-    if (this.security) {
-      this.log(`Found repo with security settings ${JSON.stringify(this.security)}`)
       if (this.security?.enableVulnerabilityAlerts === true || this.security?.enableVulnerabilityAlerts === false) {
+        this.log(`Found repo with security settings ${JSON.stringify(this.security)}`)
         if (this.security.enableVulnerabilityAlerts === true) {
           this.log(`Enabling Dependabot alerts for owner: ${repoData.owner.login} and repo ${repoData.name}`)
           if (this.nop) {
@@ -255,12 +254,10 @@ module.exports = class Repository {
           resArray.push((new NopCommand(this.constructor.name, this.repo, null, `no need to update security for ${repoData.name}`)))
           return Promise.resolve(resArray)
         }
-      }
-    }
+      } 
   }
 
   updateAutomatedSecurityFixes(repoData, resArray) {
-    if (this.security) {
       if (this.security?.enableAutomatedSecurityFixes === true || this.security?.enableAutomatedSecurityFixes === false) {
         if (this.security.enableAutomatedSecurityFixes === true) {
           this.log(`Enabling Dependabot security updates for owner: ${repoData.owner.login} and repo ${repoData.name}`)
@@ -291,6 +288,5 @@ module.exports = class Repository {
           })
         }
       }
-    }
   }
 }

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -257,7 +257,7 @@ module.exports = class Repository {
     }
   }
 
-  updateSecurityDependabotAlerts(repoData, resArray) {
+  updateAutomatedSecurityFixes(repoData, resArray) {
     if (this.security) {
       if (this.security?.enableAutomatedSecurityFixes === true || this.security?.enableAutomatedSecurityFixes === false) {
         if (this.security.enableAutomatedSecurityFixes === true) {

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -233,7 +233,7 @@ module.exports = class Repository {
             repo: repoData.name
           })
         }
-        if (this.security.enableVulnerabilityAlerts === false) {
+        else {
           this.log(`Disabling Dependabot alerts for for owner: ${repoData.owner.login} and repo ${repoData.name}`)
           if (this.nop) {
             resArray.push((new NopCommand(this.constructor.name, this.github.repos.disableVulnerabilityAlerts.endpoint({
@@ -273,7 +273,7 @@ module.exports = class Repository {
             repo: repoData.name
           })
         }
-        if (this.security.enableAutomatedSecurityFixes === false) {
+        else {
           this.log(`Disabling Dependabot security updates for owner: ${repoData.owner.login} and repo ${repoData.name}`)
           if (this.nop) {
             resArray.push((new NopCommand(this.constructor.name, this.github.repos.disableAutomatedSecurityFixes.endpoint({

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -100,8 +100,11 @@ module.exports = class Repository {
           }
           // Remove topics as it would be handled seperately
           delete this.settings.topics
+            promises.push(this.updaterepo(resArray).then(() => {
+              return this.updateSecurity(resp.data, resArray)
+            }))
           promises.push(this.updaterepo(resArray).then(() => {
-            return this.updateSecurity(resp.data, resArray)
+            return this.updateSecurityDependabotAlerts(resp.data, resArray)
           }))
         }
         if (topicChanges.hasChanges) {
@@ -243,11 +246,47 @@ module.exports = class Repository {
             repo: repoData.name
           })
         }
-      } else {
+      }
+      else {
         this.log(`no need to update security for ${repoData.name}`)
         if (this.nop) {
           resArray.push((new NopCommand(this.constructor.name, this.repo, null, `no need to update security for ${repoData.name}`)))
           return Promise.resolve(resArray)
+        }
+      }
+    }
+  }
+
+  updateSecurityDependabotAlerts(repoData, resArray) {
+    if (this.security) {
+      if (this.security?.enableAutomatedSecurityFixes === true || this.security?.enableAutomatedSecurityFixes === false) {
+        if (this.security.enableAutomatedSecurityFixes === true) {
+          this.log(`Enabling Dependabot security updates for owner: ${repoData.owner.login} and repo ${repoData.name}`)
+          if (this.nop) {
+            resArray.push((new NopCommand(this.constructor.name, this.repo, this.github.repos.enableAutomatedSecurityFixes.endpoint({
+              owner: repoData.owner.login,
+              repo: repoData.name
+            }), 'Update Topics')))
+            return Promise.resolve(resArray)
+          }
+          return this.github.repos.enableAutomatedSecurityFixes({
+            owner: repoData.owner.login,
+            repo: repoData.name
+          })
+        }
+        if (this.security.enableAutomatedSecurityFixes === false) {
+          this.log(`Disabling Dependabot security updates for owner: ${repoData.owner.login} and repo ${repoData.name}`)
+          if (this.nop) {
+            resArray.push((new NopCommand(this.constructor.name, this.github.repos.disableAutomatedSecurityFixes.endpoint({
+              owner: repoData.owner.login,
+              repo: repoData.name
+            }), 'Update Topics')))
+            return Promise.resolve(resArray)
+          }
+          return this.github.repos.disableAutomatedSecurityFixes({
+            owner: repoData.owner.login,
+            repo: repoData.name
+          })
         }
       }
     }


### PR DESCRIPTION
There are two `security` options to enable for a repository

- [Enable Vulnerability Alerts](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#enable-vulnerability-alerts)
- [Enable Automated Security Fixes](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#enable-automated-security-fixes)

Currently only **Enable Vulnerability Alerts** is being enabled as part of safe-settings.

This PR will enable to decide which flag to enable/disable