### PR TITLE
feat(labels): support exclusion regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,24 +322,28 @@ repository:
 # The app will apply the following settings to it
 labels:
   # Labels: define labels for Issues and Pull Requests
-  - name: bug
-    color: CC0000
-    description: An issue with the system
+  include:
+    - name: bug
+      color: CC0000
+      description: An issue with the system
 
-  - name: feature
-    # If including a `#`, make sure to wrap it with quotes!
-    color: '#336699'
-    description: New functionality.
+    - name: feature
+      # If including a `#`, make sure to wrap it with quotes!
+      color: '#336699'
+      description: New functionality.
 
-  - name: first-timers-only
-    # include the old name to rename an existing label
-    oldname: Help Wanted
-    color: '#326699'
+    - name: first-timers-only
+      # include the old name to rename an existing label
+      oldname: Help Wanted
+      color: '#326699'
 
-  - name: new-label
-    # include the old name to rename an existing label
-    oldname: Help Wanted
-    color: '#326699'
+    - name: new-label
+      # include the old name to rename an existing label
+      oldname: Help Wanted
+      color: '#326699'
+  exclude:
+    # don't delete any labels created on GitHub that starts with "release"
+    - name: ^release
 
 milestones:
 # Milestones: define milestones for Issues and Pull Requests

--- a/lib/plugins/labels.js
+++ b/lib/plugins/labels.js
@@ -3,8 +3,21 @@ const NopCommand = require('../nopcommand')
 const previewHeaders = { accept: 'application/vnd.github.symmetra-preview+json' }
 
 module.exports = class Labels extends Diffable {
-  constructor (...args) {
-    super(...args)
+  constructor (nop, github, repo, entries, log) {
+    const { include, exclude = [] } = entries
+    if (Array.isArray(include)) {
+      // Config is object with include array
+      // labels:
+      //   include:
+      //     - name: label
+      super(nop, github, repo, include, log)
+    } else {
+      // Config is array
+      // labels:
+      //   - name: label
+      super(nop, github, repo, entries, log)
+    }
+    this.exclude = exclude.filter(item => item?.name).map(item => new RegExp(item.name))
 
     if (this.entries) {
       this.entries.forEach(label => {
@@ -67,6 +80,9 @@ module.exports = class Labels extends Diffable {
   }
 
   remove (existing) {
+    if (this.isExcluded(existing)) {
+      return Promise.resolve([])
+    }
     if (this.nop) {
       return Promise.resolve([
         new NopCommand(this.constructor.name, this.repo, this.github.issues.deleteLabel.endpoint(this.wrapAttrs({ name: existing.name })), 'Delete label')
@@ -77,5 +93,9 @@ module.exports = class Labels extends Diffable {
 
   wrapAttrs (attrs) {
     return Object.assign({}, attrs, this.repo, { headers: previewHeaders })
+  }
+
+  isExcluded (label) {
+    return this.exclude.some(rx => rx.test(label.name))
   }
 }

--- a/test/unit/lib/plugins/labels.test.js
+++ b/test/unit/lib/plugins/labels.test.js
@@ -2,14 +2,19 @@ const Labels = require('../../../../lib/plugins/labels')
 
 describe('Labels', () => {
   let github
+  let log
 
-  function configure (config) {
-    return new Labels(github, { owner: 'bkeepers', repo: 'test' }, config)
+  function configure(config) {
+    const nop = false;
+    return new Labels(nop, github, { owner: 'bkeepers', repo: 'test' }, config, log)
   }
 
   beforeEach(() => {
     github = {
       paginate: jest.fn().mockImplementation(() => Promise.resolve()),
+      repos: {
+        get: jest.fn().mockImplementation(() => Promise.resolve({}))
+      },
       issues: {
         listLabelsForRepo: {
           endpoint: {
@@ -21,6 +26,7 @@ describe('Labels', () => {
         updateLabel: jest.fn().mockImplementation(() => Promise.resolve())
       }
     }
+    log = { debug: jest.fn(), error: console.error }
   })
 
   describe('sync', () => {
@@ -38,7 +44,7 @@ describe('Labels', () => {
         { name: 'new-name', oldname: 'update-me', color: 'FFFFFF', description: '' },
         { name: 'new-color', color: '999999', description: '' },
         { name: 'new-description', color: '#000000', description: 'Hello world' },
-        { name: 'added' }
+        { name: 'added', description: '' }
       ])
 
       return plugin.sync().then(() => {
@@ -53,6 +59,7 @@ describe('Labels', () => {
           owner: 'bkeepers',
           repo: 'test',
           name: 'added',
+          description: '',
           headers: { accept: 'application/vnd.github.symmetra-preview+json' }
         })
 


### PR DESCRIPTION
fixes #407
fixes https://github.com/github/safe-settings/discussions/398

Adds support for alternative `labels` configuration where labels matching a given pattern can be excluded from delete operations. This allows other tools to create labels without having them deleted by safe-settings.

Example: The following config would keep the labels `released`, `released on @dev`, `released on @7.x` created by a tool such as Semantic Release.

```
labels:
  include:
    - name: bug
      color: '#ff0000'
  exclude:
    - name: ^release
```

Include can be used without specifying exclude in the config, while also supporting the current format:

```
labels:
  - name: bug
    color: '#ff0000'
```