### PR TITLE
Fix up top-level array diffing

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,10 @@ branches:
         dismissal_restrictions:
           users: []
           teams: []
+        bypass_pull_request_allowances:
+          users: []
+          teams: []
+          apps: []
       # Required. Require status checks to pass before merging. Set to null to disable
       required_status_checks:
         # Required. Require branches to be up to date before merging.

--- a/lib/mergeDeep.js
+++ b/lib/mergeDeep.js
@@ -29,7 +29,7 @@ class MergeDeep {
 
   compareEmptyTarget (t, s, additions, modifications) {
     additions = Object.assign(additions, s)
-    return ({ additions, modifications, hasChanges: true })
+    return ({ additions, modifications, hasChanges: false })
   }
 
   /**

--- a/lib/mergeDeep.js
+++ b/lib/mergeDeep.js
@@ -61,8 +61,8 @@ class MergeDeep {
     }
 
     // Convert top-level array to object
-    const target = Object.assign({}, t)
-    const source = Object.assign({}, s)
+    const target = Array.isArray(t) ? Object.assign({}, { __array: t }) : t
+    const source = Array.isArray(s) ? Object.assign({}, { __array: s }) : s
 
     for (const key in source) {
       // Logic specific for Github

--- a/lib/mergeDeep.js
+++ b/lib/mergeDeep.js
@@ -28,8 +28,9 @@ class MergeDeep {
   }
 
   compareEmptyTarget (t, s, additions, modifications) {
+    const hasChanges = !(s === undefined || this.isEmpty(s));
     additions = Object.assign(additions, s)
-    return ({ additions, modifications, hasChanges: false })
+    return ({ additions, modifications, hasChanges })
   }
 
   /**

--- a/lib/plugins/branches.js
+++ b/lib/plugins/branches.js
@@ -112,6 +112,9 @@ module.exports = class Branches {
       protection.required_linear_history = protection.required_linear_history && protection.required_linear_history.enabled
       protection.enforce_admins = protection.enforce_admins && protection.enforce_admins.enabled
       protection.required_signatures = protection.required_signatures && protection.required_signatures.enabled
+      if(protection.required_pull_request_reviews && !protection.required_pull_request_reviews.bypass_pull_request_allowances) {
+        protection.required_pull_request_reviews.bypass_pull_request_allowances = { apps: [], teams: [], users: [] }
+      }
     }
     return protection
   }

--- a/lib/plugins/diffable.js
+++ b/lib/plugins/diffable.js
@@ -21,7 +21,7 @@
 //     }
 const MergeDeep = require('../mergeDeep')
 const NopCommand = require('../nopcommand')
-const ignorableFields = ['id', 'node_id', 'default']
+const ignorableFields = ['id', 'node_id', 'default', 'url']
 module.exports = class Diffable {
   constructor (nop, github, repo, entries, log) {
     this.github = github

--- a/lib/plugins/teams.js
+++ b/lib/plugins/teams.js
@@ -6,7 +6,7 @@ const teamRepoEndpoint = '/teams/:team_id/repos/:owner/:repo'
 module.exports = class Teams extends Diffable {
   async find () {
     this.log.debug(`Finding teams for ${this.repo.owner}/${this.repo.repo}`)
-    return this.github.repos.listTeams(this.repo).then(res => res.data).catch(e => { return [] })
+    return this.github.paginate(this.github.repos.listTeams, this.repo)
   }
 
   comparator (existing, attrs) {

--- a/test/unit/lib/mergeDeep.test.js
+++ b/test/unit/lib/mergeDeep.test.js
@@ -1026,3 +1026,19 @@ it('CompareDeep result has changes when source is empty and target is not', () =
 
   expect(result.hasChanges).toBeTruthy()
 })
+
+it('CompareDeep finds modifications on top-level arrays with different ordering', () => {
+  const ignorableFields = []
+  const mergeDeep = new MergeDeep(log, ignorableFields)
+  const target = [
+      { username: 'collaborator-1' },
+      { username: 'collaborator-2' },
+    ]
+  const source = [
+      { username: 'collaborator-2' },
+      { username: 'collaborator-1' },
+    ]
+  const result = mergeDeep.compareDeep(target, source)
+
+  expect(result.hasChanges).toBeFalsy()
+})

--- a/test/unit/lib/mergeDeep.test.js
+++ b/test/unit/lib/mergeDeep.test.js
@@ -1042,3 +1042,13 @@ it('CompareDeep finds modifications on top-level arrays with different ordering'
 
   expect(result.hasChanges).toBeFalsy()
 })
+
+it('CompareDeep does not report changes for matching empty targets', () => {
+  const ignorableFields = []
+  const mergeDeep = new MergeDeep(log, ignorableFields)
+  const target = []
+  const source = []
+  const result = mergeDeep.compareDeep(target, source)
+
+  expect(result.hasChanges).toBeFalsy()
+})


### PR DESCRIPTION
Issue: When passing in 2 arrays to merge-deep, the diffing doesnt work as expected (due to array ordering). Converting arrays to an object-wrapped array works (i believe thats the intention of the old code that was there - but these objects still look like arrays)