### PR TITLE
template repo sample fix

### DIFF
--- a/docs/sample-settings/repo.yml
+++ b/docs/sample-settings/repo.yml
@@ -7,7 +7,7 @@ repository:
   force_create: true
 
   # Use a template when creating the repo
-  template_repo: template_repo
+  template: template_repo
 
   # This is the settings that need to be applied to all repositories in the org 
   # See https://developer.github.com/v3/repos/#edit for all available settings for a repository  


### PR DESCRIPTION
To use a template repo you need to use `template` in your yml file, not `template_repo`.   

See the [code here](https://github.com/github/safe-settings/blob/b0aa116f13e40ed6f35704265af79d829e92c1b2/lib/plugins/repository.js#L56).  