### PR TITLE
Special handling in compareDeep for users, teams and apps

### DIFF
--- a/lib/mergeDeep.js
+++ b/lib/mergeDeep.js
@@ -125,6 +125,8 @@ class MergeDeep {
                 visited[a.name] = a
               } else if (a.username) {
                 visited[a.username] = a
+              } else if (a.login) {
+                visited[a.login] = a
               }
             } else {
               // If already seen this, it is not a missing field
@@ -139,8 +141,28 @@ class MergeDeep {
           for (const fields of Object.keys(visited)) {
             combined.push(visited[fields])
           }
-          // Elements that are in target are not additions
-          additions[key] = combined.filter(value => !target[key].includes(value))
+          if (["apps","teams","users"].includes(key)) {
+            let sourceAdditions = combined.filter(value => !target[key].includes(value))
+            let targetAdditions = combined.filter(value => {
+              for (const entity of source[key]) {
+                if (entity.name === value.login) {
+                  return false
+                }
+                if (entity.username === value.login) {
+                  return false
+                }
+                if (entity.login === value.login) {
+                  return false
+                }
+              }
+              return true
+            }
+            )
+            additions[key] = sourceAdditions.length > targetAdditions.length ? sourceAdditions : targetAdditions
+          } else {
+            // Elements that are in target are not additions
+            additions[key] = combined.filter(value => !target[key].includes(value))
+          }
         } else {
           // recursively compare the objects
           this.compareDeep(target[key], source[key], additions[key], modifications[key])
@@ -158,6 +180,8 @@ class MergeDeep {
             modifications.name = source.name
           } else if (source.username) {
             modifications.username = source.username
+          } else if (source.login) {
+            modifications.login = source.login
           }
         }
       }

--- a/test/unit/lib/mergeDeep.test.js
+++ b/test/unit/lib/mergeDeep.test.js
@@ -221,6 +221,7 @@ branches:
     // console.log(`source ${JSON.stringify(source, null, 2)}`)
     // console.log(`target ${JSON.stringify(target, null, 2)}`)
     // console.log(`diffs ${JSON.stringify(merged, null, 2)}`)
+    expect(merged.hasChanges).toBeTruthy()
     expect(merged.additions).toEqual(expected.additions)
     expect(merged.modifications.length).toEqual(expected.modifications.length)
 
@@ -1018,13 +1019,55 @@ it('CompareDeep produces correct result for arrays of named objects', () => {
 it('CompareDeep result has changes when source is empty and target is not', () => {
   const ignorableFields = []
   const mergeDeep = new MergeDeep(log, ignorableFields)
-  const target = [
-      { username: 'unwanted-collaborator' }
-    ]
-  const source = []
+  const target = {
+    required_pull_request_reviews: {
+      dismissal_restrictions: {
+        apps: [],
+        teams: [],
+        users: [{ login: 'test' }, { login: 'test2' }]
+      }
+    }
+  }
+
+  const source = {
+    required_pull_request_reviews: {
+      dismissal_restrictions: {
+        apps: [],
+        teams: [],
+        users: []
+      }
+    }
+  }
   const result = mergeDeep.compareDeep(target, source)
 
   expect(result.hasChanges).toBeTruthy()
+})
+
+it('CompareDeep result has no change when source and target match', () => {
+  const ignorableFields = []
+  const mergeDeep = new MergeDeep(log, ignorableFields)
+  const target = {
+    required_pull_request_reviews: {
+      dismissal_restrictions: {
+        apps: [],
+        teams: [],
+        users: [{ login: 'test' }, { login: 'test2' }]
+      }
+    }
+  }
+
+  const source = {
+    required_pull_request_reviews: {
+      dismissal_restrictions: {
+        apps: [],
+        teams: [],
+        users: [{ login: 'test' }, { login: 'test2' }]
+      }
+    }
+  }
+  const result = mergeDeep.compareDeep(target, source)
+
+  expect(result.hasChanges).toBeFalsy()
 })
 
 it('CompareDeep finds modifications on top-level arrays with different ordering', () => {
@@ -1038,6 +1081,16 @@ it('CompareDeep finds modifications on top-level arrays with different ordering'
       { username: 'collaborator-2' },
       { username: 'collaborator-1' },
     ]
+  const result = mergeDeep.compareDeep(target, source)
+
+  expect(result.hasChanges).toBeFalsy()
+})
+
+it('CompareDeep does not report changes for matching empty targets', () => {
+  const ignorableFields = []
+  const mergeDeep = new MergeDeep(log, ignorableFields)
+  const target = []
+  const source = []
   const result = mergeDeep.compareDeep(target, source)
 
   expect(result.hasChanges).toBeFalsy()


### PR DESCRIPTION
This change fixes #433. The logic in mergeDeep.compareDeep() is a pain to understand and work with. It does a lot of work just to figure out what the additions and modifications are, only to report these details to the logs. Is that all necessary? I wan't going to rewrite this function for this change. 

The logic I implemented basically looks at both the source and target to find out of they differ from one another. If so, there is a change and the settings need to be reapplied. 

I have tested this and it seems to be working as expected.