### PR TITLE
Use GitHub package registry. Build multiplatform image.

### DIFF
--- a/.github/workflows/create-pre-release.yml
+++ b/.github/workflows/create-pre-release.yml
@@ -28,12 +28,8 @@ on:
         required: false
      
 env:
-  DOCKER_IMAGE_NAME: yadhav/safe-settings
-  IMAGE_REGISTRY_URL: docker.io
-  AZURE_RESOURCE_GROUP: aks-actions
-  AZURE_AKS_CLUSTER: actionsAKSCluster
-  AZURE_LOCATION: '"East US"'
-  AZURE_AKS_NAMESPACE: default
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
@@ -51,27 +47,28 @@ jobs:
       - run: npm install
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Login to DockerHub
+      - name: Log in to the Container registry
         uses: docker/login-action@v2 
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Docker Image Locally
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@master
         with:
           context: .
           file: ./Dockerfile
           load: true
           tags:  |
-            yadhav/safe-settings:main-enterprise
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-enterprise
       - name: Inspect the Docker Image
         run: |
-          docker image inspect yadhav/safe-settings:main-enterprise
+          docker image inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-enterprise
       - name: Run Functional Tests
         id: functionaltest
         run: |
-          docker run --env APP_ID=${{ secrets.APP_ID }} --env PRIVATE_KEY=${{ secrets.PRIVATE_KEY }} --env WEBHOOK_SECRET=${{ secrets.WEBHOOK_SECRET }} -d -p 3000:3000 yadhav/safe-settings:main-enterprise
-          sleep 5
+          docker run --env APP_ID=${{ secrets.APP_ID }} --env PRIVATE_KEY=${{ secrets.PRIVATE_KEY }} --env WEBHOOK_SECRET=${{ secrets.WEBHOOK_SECRET }} -d -p 3000:3000 ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-enterprise
+          sleep 10
           curl http://localhost:3000
       - run: echo "${{ github.ref }}"
       - name: Tag a final release 
@@ -84,12 +81,13 @@ jobs:
           commitish: ${{ github.ref }}
       - name: Push Docker Image
         if: ${{ success() }}
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@master
         with:
           context: .
           file: ./Dockerfile
           push: true
-          tags:  |
-            yadhav/safe-settings:${{ steps.prerelease.outputs.release }} 
-  
- 
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.prerelease.outputs.release }}
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          sbom: false

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -8,12 +8,8 @@ on:
    
 
 env:
-  DOCKER_IMAGE_NAME: yadhav/safe-settings
-  IMAGE_REGISTRY_URL: docker.io
-  AZURE_RESOURCE_GROUP: aks-actions
-  AZURE_AKS_CLUSTER: actionsAKSCluster
-  AZURE_LOCATION: '"East US"'
-  AZURE_AKS_NAMESPACE: default
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
@@ -31,27 +27,28 @@ jobs:
       - run: npm install
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Login to DockerHub
+      - name: Log in to the Container registry
         uses: docker/login-action@v2 
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Docker Image Locally
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@master
         with:
           context: .
           file: ./Dockerfile
           load: true
           tags:  |
-            yadhav/safe-settings:main-enterprise
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-enterprise
       - name: Inspect the Docker Image
         run: |
-          docker image inspect yadhav/safe-settings:main-enterprise
+          docker image inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-enterprise
       - name: Run Functional Tests
         id: functionaltest
         run: |
-          docker run --env APP_ID=${{ secrets.APP_ID }} --env PRIVATE_KEY=${{ secrets.PRIVATE_KEY }} --env WEBHOOK_SECRET=${{ secrets.WEBHOOK_SECRET }} -d -p 3000:3000 yadhav/safe-settings:main-enterprise
-          sleep 5
+          docker run --env APP_ID=${{ secrets.APP_ID }} --env PRIVATE_KEY=${{ secrets.PRIVATE_KEY }} --env WEBHOOK_SECRET=${{ secrets.WEBHOOK_SECRET }} -d -p 3000:3000 ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-enterprise
+          sleep 10
           curl http://localhost:3000
       - name: Tag a final release 
         id: finalrelease
@@ -60,14 +57,17 @@ jobs:
           bump: final
       - name: Push Docker Image
         if: ${{ success() }}
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@master
         with:
           context: .
           file: ./Dockerfile
           push: true
-          tags:  |
-            yadhav/safe-settings:${{ steps.finalrelease.outputs.release }}    
-                  
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.prerelease.outputs.release }}
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          sbom: false
+
   #trigger-deployment:
   #  needs: build
   #  runs-on: ubuntu-latest


### PR DESCRIPTION
This change will create multi-platform images and push them to GitHub container registry. This is preferred over @decyjphr's personal space in dockerhub.

I have tested the pre-release workflow [here](https://github.com/robandpdx/safe-settings-robandpdx/actions/runs/4673230985).