### PR TITLE
Support swapping default_branch to existing branch

### DIFF
--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -90,20 +90,18 @@ module.exports = class Repository {
         const promises = []
         if (changes.hasChanges) {
           this.log.debug('There are repo changes')
+          let updateDefaultBranchPromise = Promise.resolve()
           if (this.settings.default_branch && (resp.data.default_branch !== this.settings.default_branch)) {
             this.log.debug('There is a rename of the default branch')
-            if (this.nop) {
-              resArray.push(new NopCommand('Repository', this.repo, this.github.repos.renameBranch.endpoint(resp.data.default_branch, this.settings.default_branch), `Repo rename default branch to ${this.settings.default_branch}`))
-            } else {
-              promises.push(this.renameBranch(resp.data.default_branch, this.settings.default_branch))
-            }
+            updateDefaultBranchPromise = this.updateDefaultBranch(resp.data.default_branch, this.settings.default_branch, resArray)
           }
           // Remove topics as it would be handled seperately
           delete this.settings.topics
-          promises.push(this.updaterepo(resArray).then(() => {
+          const updateRepoPromise = updateDefaultBranchPromise.then(() => this.updaterepo(resArray));
+          promises.push(updateRepoPromise.then(() => {
               return this.updateSecurity(resp.data, resArray)
             }))
-          promises.push(this.updaterepo(resArray).then(() => {
+          promises.push(updateRepoPromise.then(() => {
             return this.updateAutomatedSecurityFixes(resp.data, resArray)
           }))
         } else {
@@ -161,20 +159,44 @@ module.exports = class Repository {
       })
   }
 
-  renameBranch (oldname, newname) {
-    const parms = {
+  updateDefaultBranch (oldname, newname, resArray) {
+    this.log.debug(`Checking if ${newname} is already a branch`)
+    return this.github.repos.getBranch({
       owner: this.settings.owner,
       repo: this.settings.repo,
-      branch: oldname,
-      new_name: newname
-    }
-    this.log.debug(`Rename default branch repo with settings ${JSON.stringify(parms)}`)
-    if (this.nop) {
-      return Promise.resolve([
-        new NopCommand(this.constructor.name, this.repo, this.github.repos.renameBranch.endpoint(parms), 'Rename Branch')
-      ])
-    }
-    return this.github.repos.renameBranch(parms)
+      branch: newname
+    }).then(() => {
+      this.log.debug(`Branch ${newname} already exists. Making it the default branch`)
+      const parms = {
+        owner: this.settings.owner,
+        repo: this.settings.repo,
+        default_branch: newname,
+      }
+      if (this.nop) {
+        resArray.push(new NopCommand(this.constructor.name, this.repo, this.github.repos.update.endpoint(parms), 'Update Repo'))
+      } else {
+        this.log.debug(`Updating repo with settings ${JSON.stringify(parms)}`)
+        return this.github.repos.update(parms)
+      }
+    }).catch(e => {
+      if (e.status === 404) {
+        this.log.debug(`${newname} does not exist`)
+        const parms = {
+          owner: this.settings.owner,
+          repo: this.settings.repo,
+          branch: oldname,
+          new_name: newname
+        }
+        this.log.info(`Rename default branch repo with settings ${JSON.stringify(parms)}`)
+        if(this.nop) {
+          resArray.push(new NopCommand(this.constructor.name, this.repo, this.github.repos.renameBranch.endpoint(resp.data.default_branch, this.settings.default_branch), `Repo rename default branch to ${this.settings.default_branch}`))
+        } else {
+          return this.github.repos.renameBranch(parms)
+        }
+      } else {
+        this.log.error(`Error ${JSON.stringify(e)}`)
+      }
+    })
   }
 
   updaterepo (resArray) {


### PR DESCRIPTION
When changing default_branch, we simply try to rename the current default branch to `newname`. When branch `newname` already exists, the update fails. With this change, we check if `newname` exists. if it does, we swap default branches (instead of just changing names).

As an additional optimization, I noticed we call updaterepo twice, so updated that to only run once