### PR TITLE
Enable back the GitHub pull request comment with a feature flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-# The organization where you want to register the app in the app creation manifest flow. 
-# If set, the app is registered for an organization (https://github.com/organizations/ORGANIZATION/settings/apps/new), 
+# The organization where you want to register the app in the app creation manifest flow.
+# If set, the app is registered for an organization (https://github.com/organizations/ORGANIZATION/settings/apps/new),
 # if not set, the GitHub app would be registered for the user account (https://github.com/settings/apps/new).
 # GH_ORG=
 
@@ -12,3 +12,6 @@
 
 # Go to https://smee.io/new set this to the URL that you are redirected to.
 # WEBHOOK_PROXY_URL=
+
+# Uncomment this to get GitHub comments for the Pull Request Workflow.
+# ENABLE_PR_COMMENT=true

--- a/README.md
+++ b/README.md
@@ -476,6 +476,10 @@ CRON=* * * * * # Run every minute
 ```
 LOG_LEVEL=trace
 ```
+3. Enable Pull Request comment using **ENABLE_PR_COMMENT**. For e.g.
+```
+ENABLE_PR_COMMENT=true
+```
 
 ### Runtime Settings 
 

--- a/lib/env.js
+++ b/lib/env.js
@@ -2,5 +2,6 @@ module.exports = {
   ADMIN_REPO: process.env.ADMIN_REPO || 'admin',
   CONFIG_PATH: '.github',
   SETTINGS_FILE_PATH: process.env.SETTINGS_FILE_PATH || 'settings.yml',
-  DEPLOYMENT_CONFIG_FILE: process.env.DEPLOYMENT_CONFIG_FILE || 'deployment-settings.yml'
+  DEPLOYMENT_CONFIG_FILE: process.env.DEPLOYMENT_CONFIG_FILE || 'deployment-settings.yml',
+  ENABLE_PR_COMMENT: process.env.ENABLE_PR_COMMENT || 'false'
 }

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -122,10 +122,10 @@ class Settings {
     const template = eta.loadFile(path.join(__dirname, 'summary.tmpl'))
     const commentmessage = await eta.render(template, stats)
 
-    /*
-    const commentmessage2 = `
-## :robot: Safe-Settings Validator summary
-### Run on: ${new Date()}
+    if (env.ENABLE_PR_COMMENT === 'true') {
+      const commentmessage2 = `
+#### :robot: Safe-Settings Validator summary
+
 ${this.results.reduce((x, y) => {
   if (!y) {
     return x
@@ -154,17 +154,16 @@ ${this.results.reduce((x, y) => {
   }
 }, '')}
 `
-    */
-    /*
-    const pullRequest = payload.check_run.check_suite.pull_requests[0]
+      const pullRequest = payload.check_run.check_suite.pull_requests[0]
 
-    await this.github.issues.createComment({
-      owner: payload.repository.owner.login,
-      repo: payload.repository.name,
-      issue_number: pullRequest.number,
-      body: commentmessage
-    })
-*/
+      await this.github.issues.createComment({
+        owner: payload.repository.owner.login,
+        repo: payload.repository.name,
+        issue_number: pullRequest.number,
+        body: commentmessage2
+      })
+    }
+
     const params = {
       owner: payload.repository.owner.login,
       repo: payload.repository.name,

--- a/test/unit/lib/env.test.js
+++ b/test/unit/lib/env.test.js
@@ -20,6 +20,11 @@ describe('env', () => {
       expect(SETTINGS_FILE_PATH).toEqual('deployment-settings.yml')
     })
 
+    it('loads default ENABLE_PR_COMMENT if not passed', () => {
+      const ENABLE_PR_COMMENT = envTest.ENABLE_PR_COMMENT
+      expect(ENABLE_PR_COMMENT).toEqual('false')
+    })
+
   })
 
   describe('load override values', () => {
@@ -29,6 +34,7 @@ describe('env', () => {
       process.env.ADMIN_REPO = '.github'
       process.env.SETTINGS_FILE_PATH = 'safe-settings.yml'
       process.env.DEPLOYMENT_CONFIG_FILE = 'safe-settings-deployment.yml'
+      process.env.ENABLE_PR_COMMENT = 'true'
     })
 
     it('loads override values if passed', () => {
@@ -39,6 +45,8 @@ describe('env', () => {
       expect(SETTINGS_FILE_PATH).toEqual('safe-settings.yml')
       const DEPLOYMENT_CONFIG_FILE = envTest.DEPLOYMENT_CONFIG_FILE
       expect(DEPLOYMENT_CONFIG_FILE).toEqual('safe-settings-deployment.yml')
+      const ENABLE_PR_COMMENT = envTest.ENABLE_PR_COMMENT
+      expect(ENABLE_PR_COMMENT).toEqual('true')
     })
   })
 


### PR DESCRIPTION
### What

Add `ENABLE_PR_COMMENT` env variable to create GitHub comments on Pull Request contributions. There is already a feature to support a summary using the GitHub check commits. 

In this particular case I re-enable the existing commented code but using the feature flag `ENABLE_PR_COMMENT`

### Test

See https://github.com/elastic-robots/admin/pull/1#issuecomment-1546908435

### Issues

Notifies https://github.com/github/safe-settings/issues/426