### PR TITLE
feat: allow archiving/unarchiving repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,9 @@ repository:
   # Default: `false`
   delete_branch_on_merge: true  
       
+  # Whether to archive this repository. false will unarchive a previously archived repository.
+  archived: false
+
 # The following attributes are applied to any repo within the org
 # So if a repo is not listed above is created or edited
 # The app will apply the following settings to it

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -16,7 +16,6 @@ const ignorableFields = [
   'watchers_count',
   'language',
   'forks_count',
-  'archived',
   'disabled',
   'open_issues_count',
   'license',
@@ -254,7 +253,7 @@ module.exports = class Repository {
           resArray.push((new NopCommand(this.constructor.name, this.repo, null, `no need to update security for ${repoData.name}`)))
           return Promise.resolve(resArray)
         }
-      } 
+      }
   }
 
   updateAutomatedSecurityFixes(repoData, resArray) {


### PR DESCRIPTION
This PR is allowing to archive/unarchive repositories. The functionality is available in the REST API (see `archived`): https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#update-a-repository

I am a bit confused about #193 because it has some heavy code around the unarchiving. Not sure whether unarchiving was in 2022 not possible but the API version I mentioned above mentions it clearly that archiving/unarchiving works through REST API.