### PR TITLE
cosmetic: use table to report upcoming changes on PRs

### DIFF
--- a/lib/summary.tmpl
+++ b/lib/summary.tmpl
@@ -1,24 +1,41 @@
 ## :robot: Safe-Settings Settings Dry-Run Summary
-### Run on: <%= new Date() %>
 
-### Number of repos that were considered: `<%= Object.keys(it.reposProcessed).length  %>` 
+* Run on: `<%= new Date() %>`
 
-### Breakdown of errors
-<% Object.keys(it.errors).forEach(repo => { %>
-  <%= repo %>: <%= it.errors[repo] %>
-<% }) %>
+* Number of repos that were considered: `<%= Object.keys(it.reposProcessed).length  %>`
 
 ### Breakdown of changes
 
-<% Object.keys(it.changes).forEach(plugin => { %>
-<details>
-  <summary>
-  Repos with changes to <%= plugin %> settings: <%= Object.keys(it.changes[plugin]).length %>
-  </summary>
-  <% Object.keys(it.changes[plugin]).forEach( repo => { %>
-  <%= repo %><br>
+<table>
+  <tr>
+  <th>Name</th>
+  <% Object.keys(it.changes).forEach(plugin => { %>
+    <th><%= plugin %> settings</th>
   <% }) %>
-</details>
-<% }) %>
+  </tr>
+  <% Object.keys(it.reposProcessed).forEach( repo => { %>
+    <tr>
+      <td><%= repo %></td>
+    <% Object.keys(it.changes).forEach(plugin => { %>
+      <% if (it.changes[plugin][repo]) { %>
+        <td>:hand:</td>
+      <% } else { %>
+        <td>:grey_exclamation:</td>
+      <% } %>
+    <% }) %>
+    </tr>
+  <% }) %>
+</table>
 
- 
+:hand: -> Changes to be applied to the GitHub repository.
+:grey_exclamation: -> nothing to be changed in that particular GitHub repository.
+
+### Breakdown of errors
+
+<% if (Object.keys(it.errors).length === 0) { %>
+`None`
+<% } else { %>
+  <% Object.keys(it.errors).forEach(repo => { %>
+    <%= repo %>: <%= it.errors[repo] %>
+  <% }) %>
+<% } %>


### PR DESCRIPTION
### What

Transformed the summary of changes in a HTML table.
I additionally changed the date and number of repos in a list of strings rather than headers, and added `None` if no errors

### Why

Help to visualise what repositories are affected for the new changes.

### UI changes

Current UI:

<img width="552" alt="image" src="https://github.com/github/safe-settings/assets/2871786/41d7d975-fe63-480d-9398-66b8cc67bf10">

In this proposal

<img width="1094" alt="image" src="https://github.com/github/safe-settings/assets/2871786/cb25bf7c-4ecc-42ea-a921-af9a3f0f88ce">


### Further examples

See https://github.com/elastic-robots/admin/pull/1/checks


### Questions

- If you like this approach please feel free to propose a different emojis, I looked at https://gist.github.com/rxaviers/7360908 but could not find something more explicit
