### PR TITLE
Support is_alphanumeric property in autolink configs

### DIFF
--- a/lib/plugins/autolinks.js
+++ b/lib/plugins/autolinks.js
@@ -13,11 +13,20 @@ module.exports = class Autolinks extends Diffable {
   }
 
   comparator (existing, attr) {
-    return existing.key_prefix === attr.key_prefix && existing.url_template === attr.url_template
+    return existing.key_prefix === attr.key_prefix &&
+      existing.url_template === attr.url_template
   }
 
   changed (existing, attr) {
-    return existing.key_prefix === attr.key_prefix && existing.url_template !== attr.url_template
+    // is_alphanumeric was added mid-2023. In order to continue to support settings yamls which dont specify this
+    // attribute, consider an unset is_alphanumeric as `true` (since that is the default value in the API)
+    // https://docs.github.com/en/rest/repos/autolinks?apiVersion=2022-11-28#create-an-autolink-reference-for-a-repository
+    const alphanumericMatches = attr.is_alphanumeric === undefined
+      ? existing.is_alphanumeric
+      : attr.is_alphanumeric === existing.is_alphanumeric
+    return existing.key_prefix === attr.key_prefix &&
+      existing.url_template !== attr.url_template &&
+      !alphanumericMatches
   }
 
   async update (existing, attr) {
@@ -25,11 +34,12 @@ module.exports = class Autolinks extends Diffable {
     return this.add(attr)
   }
 
-  async add ({ key_prefix, url_template }) {
+  async add ({ key_prefix, url_template, is_alphanumeric = true }) {
     const attrs = {
       ...this.repo,
       key_prefix,
-      url_template
+      url_template,
+      is_alphanumeric
     }
 
     if (this.nop) {

--- a/lib/plugins/autolinks.js
+++ b/lib/plugins/autolinks.js
@@ -21,12 +21,12 @@ module.exports = class Autolinks extends Diffable {
     // is_alphanumeric was added mid-2023. In order to continue to support settings yamls which dont specify this
     // attribute, consider an unset is_alphanumeric as `true` (since that is the default value in the API)
     // https://docs.github.com/en/rest/repos/autolinks?apiVersion=2022-11-28#create-an-autolink-reference-for-a-repository
-    const alphanumericMatches = attr.is_alphanumeric === undefined
-      ? existing.is_alphanumeric
+    const isAlphaNumericMatch = attr.is_alphanumeric === undefined
+      ? existing.is_alphanumeric // === true, the default
       : attr.is_alphanumeric === existing.is_alphanumeric
     return existing.key_prefix === attr.key_prefix &&
       existing.url_template !== attr.url_template &&
-      !alphanumericMatches
+      !isAlphaNumericMatch
   }
 
   async update (existing, attr) {


### PR DESCRIPTION
Now that this is_alphanumeric property is in the API, we need to support it - especially because the default value (true) is a change from before its introduction