### PR TITLE
Failing unit test for Autolinks sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "lint:lockfile": "lockfile-lint --path package-lock.json --type npm --validate-https --allowed-hosts npm",
     "lint:engines": "check-engine",
     "lint:peer": "npm ls >/dev/null",
-    "test:unit": "jest 'test/unit/'",
+    "test:unit": "jest --testRegex=test/unit/.*\\.test\\.js",
     "test:me": "jest ",
     "test:unit:watch": "npm run test:unit -- --watch",
-    "test:integration": "jest 'test/integration/'",
+    "test:integration": "jest --testRegex=test/integration/.*\\.test\\.js",
     "test:integration:debug": "LOG_LEVEL=debug DEBUG=nock run-s test:integration"
   },
   "author": "Yadhav Jayaraman",

--- a/test/unit/lib/plugins/autolinks.test.js
+++ b/test/unit/lib/plugins/autolinks.test.js
@@ -1,0 +1,48 @@
+const Autolinks = require('../../../../lib/plugins/autolinks')
+
+describe('Autolinks', () => {
+  let github
+
+  function configure (config) {
+    const log = { debug: jest.fn(), error: console.error }
+    const nop = false
+    return new Autolinks(nop, github, { owner: 'bkeepers', repo: 'test' }, config, log)
+  }
+
+  beforeEach(() => {
+    github = {
+      repos: {
+        listAutolinks: jest.fn().mockResolvedValue([]),
+        createAutolink: jest.fn().mockResolvedValue(),
+        deleteAutolink: jest.fn().mockResolvedValue(),
+      }
+    }
+  })
+
+  describe('sync', () => {
+    it('syncs autolinks', () => {
+      const plugin = configure([
+        { key_prefix: 'ADD-', url_template: 'https://add/<num>' },
+        { key_prefix: 'SAME-', url_template: 'https://same/<num>' },
+        { key_prefix: 'NEW_URL-', url_template: 'https://new-url/<num>' },
+      ])
+
+      github.repos.listAutolinks.mockResolvedValueOnce({
+        data: [
+          { id: '1', key_prefix: 'SAME-', url_template: 'https://same/<num>', is_alphanumeric: true },
+          { id: '2', key_prefix: 'REMOVE-', url_template: 'https://test/<num>', is_alphanumeric: true },
+          { id: '3', key_prefix: 'NEW_URL-', url_template: 'https://old-url/<num>', is_alphanumeric: true },
+        ]
+      })
+
+      return plugin.sync().then(() => {
+        expect(github.repos.createAutolink).toHaveBeenCalledWith({
+          key_prefix: 'ADD-',
+          url_template: 'https://add/<num>',
+          owner: 'bkeepers',
+          repo: 'test'
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
No modifications are made if the number of existing and configured autolinks is equal.

Seems to be a conflict in the mergeDeep behaviour with the other plugins. Removing the condition around this line fixes it https://github.com/github/safe-settings/blob/main-enterprise/lib/mergeDeep.js#L88

As a side note, currently 18 unit tests are failing (hopefully because they have become incorrect). [Running the tests on CI](https://github.com/github/safe-settings/pull/375) should be a priority. The failing tests can be skipped and fixed incrementally. I'm happy to contribute to getting the the above PR merged.

Thanks