### PR TITLE
fix validator hangs on the PR (getSubOrgConfig - cannot convert undefined or null to object)

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -261,10 +261,12 @@ ${this.results.reduce((x, y) => {
   }
 
   getSubOrgConfig (repoName) {
-    for (const k of Object.keys(this.subOrgConfigs)) {
-      const repoPattern = new Glob(k)
-      if (repoName.search(repoPattern) >= 0) {
-        return this.subOrgConfigs[k]
+    if (this.subOrgConfigs) {
+      for (const k of Object.keys(this.subOrgConfigs)) {
+        const repoPattern = new Glob(k)
+        if (repoName.search(repoPattern) >= 0) {
+          return this.subOrgConfigs[k]
+        }
       }
     }
     return undefined


### PR DESCRIPTION
Fix an issue related to validator hangs on the PR with provided non-valid repository

ggregateError: 
    TypeError: Cannot convert undefined or null to object
        at Function.keys (<anonymous>)
        at Settings.getSubOrgConfig (/opt/safe-settings/lib/settings.js:264:28)
        at Settings.updateRepos (/opt/safe-settings/lib/settings.js:196:31)
        at async Promise.all (index 4)
        at async Function.syncSubOrgs (/opt/safe-settings/lib/settings.js:21:5)
        at async Promise.all (index 0)
        at async Promise.all (index 0)
        at async middleware (/opt/safe-settings/node_modules/@octokit/webhooks/dist-node/index.js:355:5)