### PR TITLE
Create official helm chart for safe-settings

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -66,6 +66,27 @@ jobs:
           provenance: false
           sbom: false
 
+  helm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v4
+
+      - name: Prepare
+        run: |
+          # OCI standard enforces lower-case paths
+          GHCR_REPO=$(echo "ghcr.io/${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          HELM_REPO=$(echo "oci://ghcr.io/${{ github.repository_owner }}/helm-charts" | tr '[:upper:]' '[:lower:]')
+          echo "GHCR_REPO=$GHCR_REPO" >> $GITHUB_ENV
+          echo "HELM_REPO=$HELM_REPO" >> $GITHUB_ENV
+
+      - name: Publish Helm charts
+        run: |
+          cd helm
+          helm registry login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
+          helm package --app-version ${{ github.ref_name }} --version ${{ github.ref_name }} safe-settings
+          helm push safe-settings-${{ github.ref_name }}.tgz ${{ env.HELM_REPO }}
+
   #trigger-deployment:
   #  needs: build
   #  runs-on: ubuntu-latest

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,11 +1,9 @@
 name: Create a release
 on:
-   workflow_dispatch:
+  workflow_dispatch:
 #  push:
 #    branches:
 #      - main-enterprise
-
-   
 
 env:
   REGISTRY: ghcr.io
@@ -23,12 +21,12 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          cache: 'npm'
+          cache: "npm"
       - run: npm install
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Log in to the Container registry
-        uses: docker/login-action@v2 
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -39,7 +37,7 @@ jobs:
           context: .
           file: ./Dockerfile
           load: true
-          tags:  |
+          tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-enterprise
       - name: Inspect the Docker Image
         run: |
@@ -50,7 +48,7 @@ jobs:
           docker run --env APP_ID=${{ secrets.APP_ID }} --env PRIVATE_KEY=${{ secrets.PRIVATE_KEY }} --env WEBHOOK_SECRET=${{ secrets.WEBHOOK_SECRET }} -d -p 3000:3000 ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-enterprise
           sleep 10
           curl http://localhost:3000
-      - name: Tag a final release 
+      - name: Tag a final release
         id: finalrelease
         uses: actionsdesk/semver@0.6.0-rc.10
         with:

--- a/helm/safe-settings/.helmignore
+++ b/helm/safe-settings/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/safe-settings/Chart.yaml
+++ b/helm/safe-settings/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: safe-settings
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "2.1.2"

--- a/helm/safe-settings/README.md
+++ b/helm/safe-settings/README.md
@@ -1,0 +1,64 @@
+# safe-settings
+
+A Helm chart for Kubernetes
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| autoscaling.enabled | bool | `false` |  |
+| autoscaling.maxReplicas | int | `10` |  |
+| autoscaling.minReplicas | int | `2` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| deploymentConfig.configvalidators[0].error | string | `"`Admin cannot be assigned to collaborators`\n"` |  |
+| deploymentConfig.configvalidators[0].plugin | string | `"collaborators"` |  |
+| deploymentConfig.configvalidators[0].script | string | `"console.log(`baseConfig ${JSON.stringify(baseconfig)}`)\nreturn baseconfig.permission != 'admin'\n"` |  |
+| deploymentConfig.overridevalidators[0].error | string | `"`Branch protection required_approving_review_count cannot be overidden to a lower value`\n"` |  |
+| deploymentConfig.overridevalidators[0].plugin | string | `"branches"` |  |
+| deploymentConfig.overridevalidators[0].script | string | `"console.log(`baseConfig ${JSON.stringify(baseconfig)}`)\nconsole.log(`overrideConfig ${JSON.stringify(overrideconfig)}`)\nif (baseconfig.protection.required_pull_request_reviews.required_approving_review_count && overrideconfig.protection.required_pull_request_reviews.required_approving_review_count ) {\n  return overrideconfig.protection.required_pull_request_reviews.required_approving_review_count >= baseconfig.protection.required_pull_request_reviews.required_approving_review_count\n}\nreturn true\n"` |  |
+| deploymentConfig.overridevalidators[1].error | string | `"Some error\n"` |  |
+| deploymentConfig.overridevalidators[1].plugin | string | `"labels"` |  |
+| deploymentConfig.overridevalidators[1].script | string | `"return true\n"` |  |
+| deploymentConfig.restrictedRepos.exclude[0] | string | `"^admin$"` |  |
+| deploymentConfig.restrictedRepos.exclude[1] | string | `"^\\.github$"` |  |
+| deploymentConfig.restrictedRepos.exclude[2] | string | `"^safe-settings$"` |  |
+| deploymentConfig.restrictedRepos.exclude[3] | string | `".*-test"` |  |
+| deploymentConfig.restrictedRepos.include[0] | string | `"^test$"` |  |
+| env | list | `[]` |  |
+| envFrom | list | `[]` |  |
+| extraObjects | list | `[]` | Add dynamic manifests via values. Example: extraObjects: - kind: ConfigMap   apiVersion: v1   metadata:     name: extra-cm-{{ .Release.Name }}   data: |     extra.yml: "does-my-install-need-extra-info: true" |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"ghcr.io/github/safe-settings"` |  |
+| image.tag | string | `""` |  |
+| imagePullSecrets | list | `[]` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.className | string | `""` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.hosts[0].host | string | `"chart-example.local"` |  |
+| ingress.hosts[0].paths[0].path | string | `"/"` |  |
+| ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
+| ingress.tls | list | `[]` |  |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| podSecurityContext | object | `{}` |  |
+| replicaCount | int | `2` |  |
+| resources | object | `{}` |  |
+| securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| securityContext.privileged | bool | `false` |  |
+| securityContext.readOnlyRootFilesystem | bool | `true` |  |
+| securityContext.runAsNonRoot | bool | `true` |  |
+| securityContext.runAsUser | int | `1000` |  |
+| service.port | int | `80` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.automountServiceAccountToken | bool | `false` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| tolerations | list | `[]` |  |
+| volumeMounts | list | `[]` |  |
+| volumes | list | `[]` |  |
+

--- a/helm/safe-settings/templates/NOTES.txt
+++ b/helm/safe-settings/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "safe-settings.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "safe-settings.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "safe-settings.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "safe-settings.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/helm/safe-settings/templates/_helpers.tpl
+++ b/helm/safe-settings/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "safe-settings.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "safe-settings.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "safe-settings.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "safe-settings.labels" -}}
+helm.sh/chart: {{ include "safe-settings.chart" . }}
+{{ include "safe-settings.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "safe-settings.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "safe-settings.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "safe-settings.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "safe-settings.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/safe-settings/templates/deployment-config.yaml
+++ b/helm/safe-settings/templates/deployment-config.yaml
@@ -1,0 +1,8 @@
+{{- $fullName := include "safe-settings.fullname" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $fullName }}-deployment-config
+data:
+  deployment-settings.yml: |
+    {{ .Values.deploymentConfig | toYaml | nindent 4 }}

--- a/helm/safe-settings/templates/deployment.yaml
+++ b/helm/safe-settings/templates/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "safe-settings.fullname" . }}
+  labels:
+    {{- include "safe-settings.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "safe-settings.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "safe-settings.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "safe-settings.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.env }}
+          envFrom:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+          - name: config-volume
+            mountPath: /opt/safe-settings/deployment-settings.yml
+            subPath: deployment-settings.yml
+          - name: tmp-dir
+            mountPath: /home/node/.npm/
+         {{- with .Values.volumeMounts }}
+         {{- toYaml . | nindent 10 }}
+         {{- end }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ include "safe-settings.fullname" . }}-deployment-config
+        - name: tmp-dir
+          emptyDir: {}
+         {{- with .Values.volumes }}
+         {{- toYaml . | nindent 8 }}
+         {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/safe-settings/templates/deployment.yaml
+++ b/helm/safe-settings/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
             {{- toYaml . | nindent 10 }}
           {{- end }}
           {{- with .Values.env }}
-          envFrom:
+          env:
             {{- toYaml . | nindent 10 }}
           {{- end }}
           ports:

--- a/helm/safe-settings/templates/deployment.yaml
+++ b/helm/safe-settings/templates/deployment.yaml
@@ -45,14 +45,6 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: http
-          readinessProbe:
-            httpGet:
-              path: /
-              port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/helm/safe-settings/templates/extra-manifests.yaml
+++ b/helm/safe-settings/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/helm/safe-settings/templates/hpa.yaml
+++ b/helm/safe-settings/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "safe-settings.fullname" . }}
+  labels:
+    {{- include "safe-settings.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "safe-settings.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/safe-settings/templates/ingress.yaml
+++ b/helm/safe-settings/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "safe-settings.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "safe-settings.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/safe-settings/templates/service.yaml
+++ b/helm/safe-settings/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "safe-settings.fullname" . }}
+  labels:
+    {{- include "safe-settings.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "safe-settings.selectorLabels" . | nindent 4 }}

--- a/helm/safe-settings/templates/service.yaml
+++ b/helm/safe-settings/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "safe-settings.fullname" . }}
   labels:
     {{- include "safe-settings.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/helm/safe-settings/templates/serviceaccount.yaml
+++ b/helm/safe-settings/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "safe-settings.serviceAccountName" . }}
+  labels:
+    {{- include "safe-settings.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/helm/safe-settings/values.yaml
+++ b/helm/safe-settings/values.yaml
@@ -48,7 +48,7 @@ env: []
 
 service:
   type: ClusterIP
-  port: 80
+  port: 3000
 
 ingress:
   enabled: false

--- a/helm/safe-settings/values.yaml
+++ b/helm/safe-settings/values.yaml
@@ -49,6 +49,7 @@ env: []
 service:
   type: ClusterIP
   port: 3000
+  annotations: {}
 
 ingress:
   enabled: false

--- a/helm/safe-settings/values.yaml
+++ b/helm/safe-settings/values.yaml
@@ -1,0 +1,139 @@
+# Default values for safe-settings.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 2
+
+image:
+  repository: ghcr.io/github/safe-settings
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+  automountServiceAccountToken: false
+
+podAnnotations: {}
+
+podSecurityContext:
+  {}
+  # fsGroup: 2000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  privileged: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+
+envFrom: []
+# - secretRef:
+#     name: app-env
+
+env: []
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations:
+    {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+volumeMounts: []
+
+volumes: []
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+deploymentConfig:
+  restrictedRepos:
+    # You can exclude certain repos from safe-settings processing
+    #  If no file is specified, then the following repositories - 'admin', '.github', 'safe-settings' are exempted by default
+    exclude: ["^admin$", '^\.github$', "^safe-settings$", ".*-test"]
+    # Alternatively you can only include certain repos
+    include: ["^test$"]
+  configvalidators:
+    - plugin: collaborators
+      error: |
+        `Admin cannot be assigned to collaborators`
+      script: |
+        console.log(`baseConfig ${JSON.stringify(baseconfig)}`)
+        return baseconfig.permission != 'admin'
+  overridevalidators:
+    - plugin: branches
+      error: |
+        `Branch protection required_approving_review_count cannot be overidden to a lower value`
+      script: |
+        console.log(`baseConfig ${JSON.stringify(baseconfig)}`)
+        console.log(`overrideConfig ${JSON.stringify(overrideconfig)}`)
+        if (baseconfig.protection.required_pull_request_reviews.required_approving_review_count && overrideconfig.protection.required_pull_request_reviews.required_approving_review_count ) {
+          return overrideconfig.protection.required_pull_request_reviews.required_approving_review_count >= baseconfig.protection.required_pull_request_reviews.required_approving_review_count
+        }
+        return true
+    - plugin: labels
+      error: |
+        Some error
+      script: |
+        return true
+
+# -- Add dynamic manifests via values. Example:
+# extraObjects:
+# - kind: ConfigMap
+#   apiVersion: v1
+#   metadata:
+#     name: extra-cm-{{ .Release.Name }}
+#   data: |
+#     extra.yml: "does-my-install-need-extra-info: true"
+extraObjects: []


### PR DESCRIPTION
This helm chart has taken much inspiration from https://github.com/decyjphr-org/charts/tree/main/helm-charts/safe-settings, but it differs in one main way.  It don't force the user to put any secrets directly in the values files. Instead, I make it possible to either set the environment variables or point to any Kubernetes secret you want. I assume that the secret already exists, how this secret is up to the user of the helm chart.

In a GitOps world, I would suggest something like 

- sealed secrets
- external-secrets 
- etc.

Or if you want, you can still add the secret through Kubernetes.

This of course makes it harder to use the helm chart, but it will help to enforce best practices. We can of course extend this PR to support a similar Kubernetes secret injection that the current helm chart supports. But it needs to be able to disable this feature.
 
I have created a helm chart so you can try it out if you want `helm upgrade -i safe-settings oci://ghcr.io/nissessenap/helm-charts/safe-settings --version 2.1.0`

## TODO

- I haven't written any docs
- The release won't work due to how the current release workflow works. This is an example on how it could be done.
If we instead would trigger on release https://github.com/NissesSenap/safe-settings/blob/main-enterprise/.github/workflows/create-release-2.yml this would work, but I don't want to put too much time in to this unless someone thinks this is worth merging.

Partly fixes #578 

Looking forward to your feedback.