### PR TITLE
Fix Lambda/Serverless Cron

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -11,6 +11,6 @@ module.exports.webhooks = createLambdaFunction(appFn, {
 
 module.exports.scheduler = function () {
   const probot = createProbot()
-  const app = appFn(probot)
+  const app = appFn(probot, {})
   return app.syncInstallation()
 }


### PR DESCRIPTION
This fixes a bug introduced by changing module.exports in index.js
(commit 1540810)

In https://github.com/github/safe-settings/commit/15408100d15ac18d2698ac2e3bd901b6ba5545db the following change happend in index.js (and that broke the cron/scheduler handler):

```diff
- module.exports = (robot, _, Settings = require('./lib/settings')) => {
+ module.exports = (robot, { getRouter }, Settings = require('./lib/settings')) => {
```

