### PR TITLE
Adding optional CONFIG_PATH env var support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@
    1. Org-level settings are defined in `.github/settings.yml`  
        > **Note**
        > It is possible to override this behavior and specify a different filename for the `settings` yml repo.<br>
-       > This could be done by setting an `env` variable called `SETTINGS_FILE_PATH`.
+       > This could be done by setting an `env` variable called `SETTINGS_FILE_PATH`.<br>
+       > Similarly, the `.github` directory can be overridden with an `env` variable called `CONFIG_PATH`.
 
    2. `Suborg` level settings. A `suborg` is an arbitrary collection of repos belonging to projects, business units, or teams. The `suborg` settings reside in a yaml file for each `suborg` in the `.github/suborgs` folder.
    3. `Repo` level settings. They reside in a repo specific yaml in `.github/repos` folder

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ module.exports = (robot, { getRouter }, Settings = require('./lib/settings')) =>
   }
 
   function getAllChangedSubOrgConfigs (payload) {
-    const settingPattern = new Glob('.github/suborgs/*.yml')
+    const settingPattern = new Glob(`${env.CONFIG_PATH}/suborgs/*.yml`)
     // Changes will be an array of files that were added
     const added = payload.commits.map(c => {
       return (c.added.filter(s => {
@@ -132,7 +132,7 @@ module.exports = (robot, { getRouter }, Settings = require('./lib/settings')) =>
   }
 
   function getAllChangedRepoConfigs (payload, owner) {
-    const settingPattern = new Glob('.github/repos/*.yml')
+    const settingPattern = new Glob(`${env.CONFIG_PATH}/repos/*.yml`)
     // Changes will be an array of files that were added
     const added = payload.commits.map(c => {
       return (c.added.filter(s => {
@@ -473,14 +473,14 @@ module.exports = (robot, { getRouter }, Settings = require('./lib/settings')) =>
       return syncAllSettings(true, context, context.repo(), pull_request.head.ref)
     }
 
-    const repoChanges = getChangedRepoConfigName(new Glob('.github/repos/*.yml'), files, context.repo().owner)
+    const repoChanges = getChangedRepoConfigName(new Glob(`${env.CONFIG_PATH}/repos/*.yml`), files, context.repo().owner)
     if (repoChanges.length > 0) {
       return Promise.all(repoChanges.map(repo => {
         return syncSettings(true, context, repo, pull_request.head.ref)
       }))
     }
 
-    const subOrgChanges = getChangedSubOrgConfigName(new Glob('.github/suborgs/*.yml'), files, context.repo().owner)
+    const subOrgChanges = getChangedSubOrgConfigName(new Glob(`${env.CONFIG_PATH}/suborgs/*.yml`), files, context.repo().owner)
     if (subOrgChanges.length) {
       return Promise.all(subOrgChanges.map(suborg => {
         return syncSubOrgSettings(true, context, suborg, context.repo(), pull_request.head.ref)

--- a/lib/deploymentConfig.js
+++ b/lib/deploymentConfig.js
@@ -48,6 +48,6 @@ class DeploymentConfig {
     constructor (nop, context, repo, config, ref, suborg) {
     }
 }
-DeploymentConfig.FILE_NAME = '.github/settings.yml'
+DeploymentConfig.FILE_NAME = `${env.CONFIG_PATH}/settings.yml`
 
 module.exports = DeploymentConfig

--- a/lib/deploymentConfig.js
+++ b/lib/deploymentConfig.js
@@ -1,5 +1,6 @@
 const yaml = require('js-yaml')
 const fs = require('fs')
+const env = require('./env')
 
 /**
  * Class representing a deployment config.

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,6 +1,6 @@
 module.exports = {
   ADMIN_REPO: process.env.ADMIN_REPO || 'admin',
-  CONFIG_PATH: '.github',
+  CONFIG_PATH: process.env.CONFIG_PATH || '.github',
   SETTINGS_FILE_PATH: process.env.SETTINGS_FILE_PATH || 'settings.yml',
   DEPLOYMENT_CONFIG_FILE: process.env.DEPLOYMENT_CONFIG_FILE || 'deployment-settings.yml',
   CREATE_PR_COMMENT: process.env.CREATE_PR_COMMENT || 'true',

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -801,7 +801,7 @@ function prettify(obj) {
   return JSON.stringify(obj, null, 2).replaceAll('\n', '<br>').replaceAll(' ', '&nbsp;')
 }
 
-Settings.FILE_NAME = `${CONFIG_PATH}/${env.SETTINGS_FILE_PATH}`
+Settings.FILE_NAME = path.posix.join(CONFIG_PATH, env.SETTINGS_FILE_PATH)
 
 Settings.PLUGINS = {
   repository: require('./plugins/repository'),

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -180,7 +180,7 @@ class Settings {
     this.results.forEach(res => {
       if (res) {
         stats.reposProcessed[res.repo] = true
-        // if (res.action.additions === null && res.action.deletions === null && res.action.modifications === null) { 
+        // if (res.action.additions === null && res.action.deletions === null && res.action.modifications === null) {
         //   // No changes
         // } else
         if (res.type === 'ERROR') {
@@ -538,7 +538,7 @@ ${this.results.reduce((x, y) => {
       // any pagination. They suggest to use Tree api.
       // https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content
 
-      // get .github/repos directory sha to use in the getTree api
+      // get <CONFIG_PATH>/repos directory sha to use in the getTree api
       const repo = { owner: this.repo.owner, repo: env.ADMIN_REPO }
       const params = Object.assign(repo, { path: path.posix.join(CONFIG_PATH), ref: this.ref })
       const githubDirectoryContentResponse = await this.github.repos.getContent(params).catch(e => {
@@ -546,13 +546,13 @@ ${this.results.reduce((x, y) => {
       })
 
       if (!githubDirectoryContentResponse) {
-        throw new Error('Error reading .github directory')
+        throw new Error(`Error reading ${CONFIG_PATH} directory`)
       }
 
       const githubDirContent = githubDirectoryContentResponse.data
       const repoDirInfo = githubDirContent.filter(dir => dir.name === 'repos')[0]
       if (!repoDirInfo) {
-        this.log.debug('No repos directory in the admin/.github')
+        this.log.debug(`No repos directory in the ${env.ADMIN_REPO}/${CONFIG_PATH}`)
         return []
       }
 
@@ -801,7 +801,7 @@ function prettify(obj) {
   return JSON.stringify(obj, null, 2).replaceAll('\n', '<br>').replaceAll(' ', '&nbsp;')
 }
 
-Settings.FILE_NAME = '.github/' + env.SETTINGS_FILE_PATH
+Settings.FILE_NAME = `${CONFIG_PATH}/${env.SETTINGS_FILE_PATH}`
 
 Settings.PLUGINS = {
   repository: require('./plugins/repository'),

--- a/test/unit/lib/env.test.js
+++ b/test/unit/lib/env.test.js
@@ -10,6 +10,11 @@ describe('env', () => {
       expect(ADMIN_REPO).toEqual('admin')
     })
 
+    it('loads default CONFIG_PATH if not passed', () => {
+      const CONFIG_PATH = envTest.CONFIG_PATH
+      expect(CONFIG_PATH).toEqual('.github')
+    })
+
     it('loads default SETTINGS_FILE_PATH if not passed', () => {
       const SETTINGS_FILE_PATH = envTest.SETTINGS_FILE_PATH
       expect(SETTINGS_FILE_PATH).toEqual('settings.yml')
@@ -32,6 +37,7 @@ describe('env', () => {
     beforeAll(() => {
       jest.resetModules()
       process.env.ADMIN_REPO = '.github'
+      process.env.CONFIG_PATH = '.config'
       process.env.SETTINGS_FILE_PATH = 'safe-settings.yml'
       process.env.DEPLOYMENT_CONFIG_FILE = 'safe-settings-deployment.yml'
       process.env.CREATE_PR_COMMENT = 'false'
@@ -41,6 +47,8 @@ describe('env', () => {
       const envTest = require('../../../lib/env')
       const ADMIN_REPO = envTest.ADMIN_REPO
       expect(ADMIN_REPO).toEqual('.github')
+      const CONFIG_PATH = envTest.CONFIG_PATH
+      expect(CONFIG_PATH).toEqual('.config')
       const SETTINGS_FILE_PATH = envTest.SETTINGS_FILE_PATH
       expect(SETTINGS_FILE_PATH).toEqual('safe-settings.yml')
       const DEPLOYMENT_CONFIG_FILE = envTest.DEPLOYMENT_CONFIG_FILE


### PR DESCRIPTION
This PR adds support for defining the CONFIG_PATH settings through an environment variable. I'm not in love with the env var's name since it is pretty generic, but I stuck with the naming convention of the other variables in env.js