### PR TITLE
fix(branches): Users in branch protections always deleted and added

### DIFF
--- a/lib/mergeDeep.js
+++ b/lib/mergeDeep.js
@@ -1,7 +1,7 @@
 const mergeBy = require('./mergeArrayBy')
 const DeploymentConfig = require('./deploymentConfig')
 
-const NAME_FIELDS = ['name', 'username', 'actor_id', 'type', 'login', 'key_prefix']
+const NAME_FIELDS = ['name', 'username', 'actor_id', 'login', 'type', 'key_prefix']
 const NAME_USERNAME_PROPERTY = item => NAME_FIELDS.find(prop => Object.prototype.hasOwnProperty.call(item, prop))
 const GET_NAME_USERNAME_PROPERTY = item => { if (NAME_USERNAME_PROPERTY(item)) return item[NAME_USERNAME_PROPERTY(item)] }
 

--- a/test/unit/lib/mergeDeep.test.js
+++ b/test/unit/lib/mergeDeep.test.js
@@ -981,17 +981,17 @@ entries:
         dismissal_restrictions: {
           apps: [],
           teams: [],
-          users: [{ login: 'test' }, { login: 'test2' }]
+          users: [{ login: 'test', type: 'User' }, { login: 'test2', type: 'User' }]
         }
       }
     }
-  
+
     const source = {
       required_pull_request_reviews: {
         dismissal_restrictions: {
           apps: [],
           teams: [],
-          users: [{ login: 'test' }, { login: 'test2' }]
+          users: ['test', 'test2']
         }
       }
     }


### PR DESCRIPTION
`type` property ("User") is matched as the identifier before `login` so the diff always adds addition/deletion.

Theoretically this fix could break some other diff use-case and I wouldn't know
