### PR TITLE
fix(branches): Not adding checks to existing branch protection contexts

### DIFF
--- a/lib/mergeDeep.js
+++ b/lib/mergeDeep.js
@@ -246,9 +246,9 @@ class MergeDeep {
       if (visited[id]) {
         this.compareDeep(a, visited[id], additions[additions.length - 1], modifications[modifications.length - 1], deletions[deletions.length - 1])
       }
-      // Any addtions for the matching key must be moved to modifications
+      // Any additions for the matching key must be moved to modifications
       if (!this.isEmpty(additions)) {
-        modifications = modifications.concat(additions)
+        modifications.push(...additions)
       }
       // Add name attribute to the modifications to make it look better ; it won't be added otherwise as it would be the same
       if (!this.isEmpty(modifications[modifications.length - 1])) {

--- a/test/unit/lib/mergeDeep.test.js
+++ b/test/unit/lib/mergeDeep.test.js
@@ -1315,5 +1315,68 @@ entries:
     //console.log(`target ${JSON.stringify(target, null, 2)}`)
     //console.log(`diffs ${JSON.stringify(merged, null, 2)}`)
   })
-  
+
+  it('Has changes with additions to arrays', () => {
+    const target = {
+      branches: [
+        {
+          name: 'master',
+          protection: {
+            required_status_checks: {
+              strict: true,
+              contexts: [
+                "test1",
+              ],
+            }
+          }
+        }
+      ]
+    }
+
+    const source = {
+      branches: [
+        {
+          name: 'master',
+          protection: {
+            required_status_checks: {
+              strict: true,
+              contexts: [
+                'test1',
+                'test2'
+              ],
+            }
+          }
+        }
+      ]
+    }
+
+    const expected = {
+      additions: {},
+      deletions: {},
+      modifications: {
+        branches: [
+          {
+            name: "master",
+            protection: {
+              required_status_checks: {
+                contexts: [
+                  'test2'
+                ]
+              },
+            },
+          }
+        ]
+      },
+      hasChanges: true
+    }
+
+    const ignorableFields = []
+    const mergeDeep = new MergeDeep(
+      log,
+      jest.fn(),
+      ignorableFields
+    );
+    const changes = mergeDeep.compareDeep(target, source)
+    expect(changes).toEqual(expected)
+  })
 })


### PR DESCRIPTION
All I can say is that the changed line implements what I assume is the intention of mutating the `modifications` parameter and fixes this particular case.