### PR TITLE
Decyjphr/merge 520

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:me": "jest ",
     "test:unit:watch": "npm run test:unit -- --watch",
     "test:integration": "jest --testRegex=test/integration/.*\\.test\\.js",
-    "test:integration:debug": "LOG_LEVEL=debug DEBUG=nock run-s test:integration"
+    "test:integration:debug": "LOG_LEVEL=debug DEBUG=nock run-s test:integration",
+    "test:unit:ci": "npm run test:unit --reporters=default --reporters=github-actions"
   },
   "author": "Yadhav Jayaraman",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "lint:lockfile": "lockfile-lint --path package-lock.json --type npm --validate-https --allowed-hosts npm",
     "lint:engines": "check-engine",
     "lint:peer": "npm ls >/dev/null",
-    "test:unit": "jest 'test/unit/'",
+    "test:unit": "jest --testRegex=test/unit/.*\\.test\\.js",
     "test:me": "jest ",
     "test:unit:watch": "npm run test:unit -- --watch",
-    "test:integration": "jest 'test/integration/'",
+    "test:integration": "jest --testRegex=test/integration/.*\\.test\\.js",
     "test:integration:debug": "LOG_LEVEL=debug DEBUG=nock run-s test:integration"
   },
   "author": "Yadhav Jayaraman",

--- a/test/unit/lib/plugins/autolinks.test.js
+++ b/test/unit/lib/plugins/autolinks.test.js
@@ -1,0 +1,48 @@
+const Autolinks = require('../../../../lib/plugins/autolinks')
+
+describe('Autolinks', () => {
+  let github
+
+  function configure (config) {
+    const log = { debug: jest.fn(), error: console.error }
+    const nop = false
+    return new Autolinks(nop, github, { owner: 'bkeepers', repo: 'test' }, config, log)
+  }
+
+  beforeEach(() => {
+    github = {
+      repos: {
+        listAutolinks: jest.fn().mockResolvedValue([]),
+        createAutolink: jest.fn().mockResolvedValue(),
+        deleteAutolink: jest.fn().mockResolvedValue(),
+      }
+    }
+  })
+
+  describe('sync', () => {
+    it('syncs autolinks', () => {
+      const plugin = configure([
+        { key_prefix: 'ADD-', url_template: 'https://add/<num>' },
+        { key_prefix: 'SAME-', url_template: 'https://same/<num>' },
+        { key_prefix: 'NEW_URL-', url_template: 'https://new-url/<num>' },
+      ])
+
+      github.repos.listAutolinks.mockResolvedValueOnce({
+        data: [
+          { id: '1', key_prefix: 'SAME-', url_template: 'https://same/<num>', is_alphanumeric: true },
+          { id: '2', key_prefix: 'REMOVE-', url_template: 'https://test/<num>', is_alphanumeric: true },
+          { id: '3', key_prefix: 'NEW_URL-', url_template: 'https://old-url/<num>', is_alphanumeric: true },
+        ]
+      })
+
+      return plugin.sync().then(() => {
+        expect(github.repos.createAutolink).toHaveBeenCalledWith({
+          key_prefix: 'ADD-',
+          url_template: 'https://add/<num>',
+          owner: 'bkeepers',
+          repo: 'test'
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
Basically applied the changes in #520 by manually fixing the conflicts and removing:
```
<<<<<<< HEAD
    "test:unit": "jest --roots=lib --roots=test/unit",
    "test:unit:ci": "npm run test:unit --reporters=default --reporters=github-actions",
    "test:me": "jest ",
    "test:unit:watch": "npm run test:unit -- --watch",
    "test:integration": "jest --roots=lib --roots=test/integration",
=======
```