### PR TITLE
fix up initialization of MergeDeep to account for ignorableFields

### DIFF
--- a/lib/mergeDeep.js
+++ b/lib/mergeDeep.js
@@ -6,7 +6,7 @@ const NAME_USERNAME_PROPERTY = item => NAME_FIELDS.find(prop => Object.prototype
 const GET_NAME_USERNAME_PROPERTY = item => { if (NAME_USERNAME_PROPERTY(item)) return item[NAME_USERNAME_PROPERTY(item)] }
 
 class MergeDeep {
-  constructor (log, github, ignorableFields, configvalidators = {}, overridevalidators = {}) {
+  constructor (log, github, ignorableFields = [], configvalidators = {}, overridevalidators = {}) {
     this.log = log
     this.github = github
     this.ignorableFields = ignorableFields

--- a/test/unit/lib/mergeDeep.test.js
+++ b/test/unit/lib/mergeDeep.test.js
@@ -820,7 +820,14 @@ entries:
       hasChanges: true
     }
     const ignorableFields = []
-    const mergeDeep = new MergeDeep(log, ignorableFields)
+    const mockReturnGitHubContext = jest.fn().mockReturnValue({
+      request: () => {},
+    });
+    const mergeDeep = new MergeDeep(
+      log,
+      mockReturnGitHubContext,
+      ignorableFields
+    )
     const merged = mergeDeep.compareDeep(target, source)
     console.log(`diffs ${JSON.stringify(merged, null, 2)}`)
     expect(merged).toEqual(expected)

--- a/test/unit/lib/validator.test.js
+++ b/test/unit/lib/validator.test.js
@@ -113,7 +113,7 @@ describe('Validator Tests', () => {
 
     try {
       const ignorableFields = []
-      const mergeDeep = new MergeDeep(log, ignorableFields)
+      const mergeDeep = new MergeDeep(log, {}, ignorableFields)
       mergeDeep.mergeDeep(baseconfig, overrideconfig)
     } catch (err) {
       expect(err).toBeDefined()
@@ -168,7 +168,7 @@ describe('Validator Tests', () => {
 
     try {
       const ignorableFields = []
-      const mergeDeep = new MergeDeep(log, ignorableFields)
+      const mergeDeep = new MergeDeep(log, {}, ignorableFields)
       mergeDeep.mergeDeep(baseconfig, overrideconfig)
     } catch (err) {
       expect(err).toBeDefined()


### PR DESCRIPTION
We started hitting issues like `github+safe-settings+6c297f2fdb1f5e00704b60a4e74093ea566170a6/node_modules/safe-settings/lib/settings.js:17:7)","type":"Error","msg":"Cannot read properties of undefined (reading 'indexOf')`

Turns out its because not all new MergeDeep's pass ignorable fields, so lets allow ignoreableFields to default to `[]`.

Additionally fixes up some tests which werent correctly passing ignorable fields