### PR TITLE
Update CRON schedule to address rate limit issues

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -30,6 +30,6 @@ functions:
       LOG_LEVEL: debug
     events:
       - schedule:
-          rate: rate(30 minutes)
-          enabled: false # set to true to auto-enable
+          rate: rate(4 hours)
+          enabled: true # set to true to auto-enable
           input: {}


### PR DESCRIPTION
Related to #559

Updates the CRON schedule in `serverless.yml` to address rate limit issues.
- Changes the CRON execution frequency from every 30 minutes to every 4 hours.
- Enables the CRON schedule by default, setting `enabled` to `true`.


