### PR TITLE
Add code to handle both rename and reassign of default branch

### DIFF
--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -162,7 +162,7 @@ module.exports = class Repository extends ErrorStash {
       repo: this.settings.repo,
       branch: newname
     }).then((res) => {
-      this.log.debug(`Branch ${newname} already exists ${JSON.stringify(res.data)}. Making it the default branch`)
+      this.log.debug(`Branch ${newname} already exists. Making it the default branch`)
       // If the old branch was renamed github will find the branch with the oldname the branch but the ref doesn't exist
       // So we'd have to rename it back to the oldname
       if (res.data.name !== newname) {

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -91,12 +91,7 @@ module.exports = class Repository extends ErrorStash {
         const promises = []
         if (topicChanges.hasChanges) {
           promises.push(this.updatetopics(resp.data, resArray))
-        } else {
-          this.log.debug(`There are no changes for repo ${JSON.stringify(this.repo)}.`)
-          if (this.nop) {
-            resArray.push(new NopCommand('Repository', this.repo, null, `There are no changes for repo ${JSON.stringify(this.repo)}.`))
-          }
-        }
+        } 
         if (changes.hasChanges) {
           this.log.debug('There are repo changes')
           let updateDefaultBranchPromise = Promise.resolve()
@@ -166,8 +161,13 @@ module.exports = class Repository extends ErrorStash {
       owner: this.settings.owner,
       repo: this.settings.repo,
       branch: newname
-    }).then(() => {
-      this.log.debug(`Branch ${newname} already exists. Making it the default branch`)
+    }).then((res) => {
+      this.log.debug(`Branch ${newname} already exists ${JSON.stringify(res.data)}. Making it the default branch`)
+      // If the old branch was renamed github will find the branch with the oldname the branch but the ref doesn't exist
+      // So we'd have to rename it back to the oldname
+      if (res.data.name !== newname) {
+        return this.renameBranch(oldname, newname, resArray)
+      }
       const parms = {
         owner: this.settings.owner,
         repo: this.settings.repo,
@@ -181,23 +181,27 @@ module.exports = class Repository extends ErrorStash {
       }
     }).catch(e => {
       if (e.status === 404) {
-        this.log.debug(`${newname} does not exist`)
-        const parms = {
-          owner: this.settings.owner,
-          repo: this.settings.repo,
-          branch: oldname,
-          new_name: newname
-        }
-        this.log.info(`Rename default branch repo with settings ${JSON.stringify(parms)}`)
-        if (this.nop) {
-          resArray.push(new NopCommand(this.constructor.name, this.repo, this.github.repos.renameBranch.endpoint(oldname, this.settings.default_branch), `Repo rename default branch to ${this.settings.default_branch}`))
-        } else {
-          return this.github.repos.renameBranch(parms)
-        }
+        return this.renameBranch(oldname, newname, resArray)
       } else {
         this.logError(`Error ${JSON.stringify(e)}`)
       }
     })
+  }
+
+  renameBranch(oldname, newname, resArray) {
+    this.log.error(`Branch ${newname} does not exist. So renaming the current default branch ${oldname} to ${newname}`)
+    const parms = {
+      owner: this.settings.owner,
+      repo: this.settings.repo,
+      branch: oldname,
+      new_name: newname
+    }
+    this.log.info(`Rename default branch repo with settings ${JSON.stringify(parms)}`)
+    if (this.nop) {
+      resArray.push(new NopCommand(this.constructor.name, this.repo, this.github.repos.renameBranch.endpoint(oldname, this.settings.default_branch), `Repo rename default branch to ${this.settings.default_branch}`))
+    } else {
+      return this.github.repos.renameBranch(parms)
+    }
   }
 
   updaterepo (resArray) {

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -167,17 +167,18 @@ module.exports = class Repository extends ErrorStash {
       // So we'd have to rename it back to the oldname
       if (res.data.name !== newname) {
         return this.renameBranch(oldname, newname, resArray)
-      }
-      const parms = {
-        owner: this.settings.owner,
-        repo: this.settings.repo,
-        default_branch: newname
-      }
-      if (this.nop) {
-        resArray.push(new NopCommand(this.constructor.name, this.repo, this.github.repos.update.endpoint(parms), 'Update Repo'))
       } else {
-        this.log.debug(`Updating repo with settings ${JSON.stringify(parms)}`)
-        return this.github.repos.update(parms)
+        const parms = {
+          owner: this.settings.owner,
+          repo: this.settings.repo,
+          default_branch: newname
+        }
+        if (this.nop) {
+          resArray.push(new NopCommand(this.constructor.name, this.repo, this.github.repos.update.endpoint(parms), 'Update Repo'))
+        } else {
+          this.log.debug(`Updating repo with settings ${JSON.stringify(parms)}`)
+          return this.github.repos.update(parms)
+        }
       }
     }).catch(e => {
       if (e.status === 404) {


### PR DESCRIPTION
Handle both rename and reassignment of default branch. If  it is reassigned and `repository` settings has a `default-branch` then `safe-settings` will reset it back. 

If it is a rename of the current default branch, safe-settings will rename it back. 

Any new refs that are created by the user will still remain as they would be pointing to the current default branch and cannot be deleted.