### PR TITLE
import eta templates as javascript strings

### DIFF
--- a/lib/commentmessage.js
+++ b/lib/commentmessage.js
@@ -1,6 +1,6 @@
-* Run on: `<%= new Date() %>`
+module.exports = `* Run on: \` <%= new Date() %> \`
 
-* Number of repos that were considered: `<%= Object.keys(it.reposProcessed).length  %>`
+* Number of repos that were considered: \`<%= Object.keys(it.reposProcessed).length %> \`
 
 ### Breakdown of changes
 | Repo <% Object.keys(it.changes).forEach(plugin => { %> | <%= plugin %> settings  <% }) %> |
@@ -19,7 +19,7 @@
 ### Breakdown of errors
 
 <% if (Object.keys(it.errors).length === 0) { %>
-`None`
+\`None\`
 <% } else { %>
   <% Object.keys(it.errors).forEach(repo => { %>
     <%_= repo %>: 
@@ -28,6 +28,4 @@
     <% }) %>
 
   <% }) %>
-<% } %>
-
-
+<% } %>`

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,4 +1,4 @@
-Run on: `<%= new Date().toISOString() %>`
+module.exports = `Run on: \`<%= new Date().toISOString() %>\`
 
 #### Breakdown of Errors
 | Owner| Repo | Plugin | Error 
@@ -9,3 +9,4 @@ Run on: `<%= new Date().toISOString() %>`
 <% }) -%>
 
 
+`

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -1,5 +1,7 @@
 const path = require('path')
 const { Eta } = require('eta')
+const commetMessageTemplate = require('./commentmessage')
+const errorTemplate = require('./error')
 const Glob = require('./glob')
 const NopCommand = require('./nopcommand')
 const MergeDeep = require('./mergeDeep')
@@ -103,7 +105,7 @@ class Settings {
     if (this.errors.length > 0) {
       conclusion = 'failure'
       summary = 'Safe-Settings finished with errors.'
-      details = await eta.render('./error', this.errors)
+      details = await eta.renderString(errorTemplate, this.errors)
     }
 
     // Use the latest commit to create the check against
@@ -217,7 +219,7 @@ class Settings {
     <tbody>
     `
 
-    const commentmessage = await eta.render('./commentmessage', stats)
+    const renderedCommentMessage = await eta.renderString(commetMessageTemplate, stats)
 
     if (env.CREATE_PR_COMMENT === 'true') {
       const summary = `
@@ -262,7 +264,7 @@ ${this.results.reduce((x, y) => {
       completed_at: new Date().toISOString(),
       output: {
         title: error ? 'Safe-Settings Dry-Run Finished with Error' : 'Safe-Settings Dry-Run Finished with success',
-        summary: commentmessage.length > 55536 ? `${commentmessage.substring(0, 55536)}... (too many changes to report)` : commentmessage
+        summary: renderedCommentMessage.length > 55536 ? `${renderedCommentMessage.substring(0, 55536)}... (too many changes to report)` : renderedCommentMessage
       }
     }
 


### PR DESCRIPTION
This pull request aims to move away from importing eta templates using the file system location and instead rely on the node module resolution system, passing the template as a string.

The underlying reason for this change is because the current implementation will break bundled deployments which are fairly common within a serverless deployment and I cannot see negatives to non-bundled users of this package.