### PR TITLE
Add Actions workflow to delete old releases

### DIFF
--- a/.github/workflows/delete-old-releases.yml
+++ b/.github/workflows/delete-old-releases.yml
@@ -1,0 +1,18 @@
+name: Delete old releases
+on:
+  workflow_dispatch:
+    inputs:
+      startDate:
+        type: text
+        required: true
+        description: enter the date in YYYY-mm-dd format
+        default: "2024-01-01"
+        
+jobs:
+  delete-releases:
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        # for i in $(gh release list --repo https://github.com/github/safe-settings --json createdAt,tagName --limit 1000 --jq '.[] | select(.createdAt < ${{ inputs.startDate }} ) | .tagName'); do gh release delete --repo https://github.com/github/safe-settings $i --cleanup-tag  -y; done
+        gh release list --repo https://github.com/github/safe-settings --json createdAt,tagName --limit 1000 --jq '.[] | select(.createdAt < ${{ inputs.startDate }} ) | .tagName'
+    

--- a/.github/workflows/delete-old-releases.yml
+++ b/.github/workflows/delete-old-releases.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - name: Delete releases
       run: |
-        for i in $(gh release list --repo https://github.com/$GITHUB_REPOSITORY --json createdAt,tagName --limit 1000  | jq --arg date $BEFORE_DATE '.[] | select(.createdAt < $date ) | .tagName' | tr -d '"'); do echo $i ; gh release delete $i -y --cleanup-tag --repo https://github.com/$GITHUB_REPOSITORY ;    done
+        for i in $(gh release list --repo https://github.com/$GITHUB_REPOSITORY --json createdAt,tagName --limit 1000  | jq --arg date $BEFORE_DATE '.[] | select(.createdAt < $date ) | .tagName' | tr -d '"'); do  gh release delete $i -y --cleanup-tag --repo https://github.com/$GITHUB_REPOSITORY ;    done
         echo Deleted releases before $BEFORE_DATE in https://github.com/$GITHUB_REPOSITORY >> $GITHUB_STEP_SUMMARY
       env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/delete-old-releases.yml
+++ b/.github/workflows/delete-old-releases.yml
@@ -1,18 +1,25 @@
 name: Delete old releases
+permissions: write-all
+  
 on:
   workflow_dispatch:
     inputs:
-      startDate:
-        type: text
+      beforeDate:
+        type: string
         required: true
-        description: enter the date in YYYY-mm-dd format
+        description: YYYY-MM-DD - All releases before this date are deleted.
         default: "2024-01-01"
         
 jobs:
   delete-releases:
     runs-on: ubuntu-latest
     steps:
-    - run: |
-        # for i in $(gh release list --repo https://github.com/github/safe-settings --json createdAt,tagName --limit 1000 --jq '.[] | select(.createdAt < ${{ inputs.startDate }} ) | .tagName'); do gh release delete --repo https://github.com/github/safe-settings $i --cleanup-tag  -y; done
-        gh release list --repo https://github.com/github/safe-settings --json createdAt,tagName --limit 1000 --jq '.[] | select(.createdAt < ${{ inputs.startDate }} ) | .tagName'
-    
+    - name: Delete releases
+      run: |
+        for i in $(gh release list --repo https://github.com/$GITHUB_REPOSITORY --json createdAt,tagName --limit 1000  | jq --arg date $BEFORE_DATE '.[] | select(.createdAt < $date ) | .tagName' | tr -d '"'); do echo $i ; gh release delete $i -y --cleanup-tag --repo https://github.com/$GITHUB_REPOSITORY ;    done
+        echo Deleted releases before $BEFORE_DATE in https://github.com/$GITHUB_REPOSITORY >> $GITHUB_STEP_SUMMARY
+      env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BEFORE_DATE: ${{ inputs.beforeDate }}
+         
+  


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the deletion of old releases. The workflow is designed to help manage repository storage by removing releases created before a specified date.