### PR TITLE
chore: batch dependency updates from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,23 @@ updates:
     commit-message:
       prefix: ci
       include: scope
-
+    groups:
+      minor-patch-updates:
+        update-types:
+          - minor
+          - patch
+      all-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+    groups:
+      minor-patch-updates:
+        update-types:
+          - minor
+          - patch
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
To minimize the number of pull requests, this PR batches dependabot dependency update pull requests.

When minor/patch changes to dependencies, they are batched together in a pull request.

Major dependency changes are still their own PR to ensure visibility.