### PR TITLE
Fix: array comparison breaks if using the environments plugin

### DIFF
--- a/lib/mergeDeep.js
+++ b/lib/mergeDeep.js
@@ -378,5 +378,4 @@ class MergeDeep {
   }
 }
 MergeDeep.NAME_FIELDS = NAME_FIELDS
-MergeDeep.NAME_FIELDS = NAME_FIELDS
 module.exports = MergeDeep

--- a/lib/plugins/diffable.js
+++ b/lib/plugins/diffable.js
@@ -93,7 +93,7 @@ module.exports = class Diffable extends ErrorStash {
           }
         }
 
-        // Filter out all empty entries (usually from repo override)
+        // Remove any null or undefined values from the diffables (usually comes from repo override)
         for (const entry of filteredEntries) {
           for (const key of Object.keys(entry)) {
             if (entry[key] === null || entry[key] === undefined) {
@@ -101,6 +101,7 @@ module.exports = class Diffable extends ErrorStash {
             }
           }
         }
+        // Delete any diffable that now only has name and no other attributes
         filteredEntries = filteredEntries.filter(entry => Object.keys(entry).filter(key => !MergeDeep.NAME_FIELDS.includes(key)).length !== 0)
 
         const changes = []

--- a/lib/plugins/environments.js
+++ b/lib/plugins/environments.js
@@ -296,7 +296,7 @@ module.exports = class Environments extends Diffable {
         let filteredEntries = this.filterEntries()
         return this.find().then(existingRecords => {
 
-          // Filter out all empty entries (usually from repo override)
+          // Remove any null or undefined values from the diffables (usually comes from repo override)
           for (const entry of filteredEntries) {
             for (const key of Object.keys(entry)) {
               if (entry[key] === null || entry[key] === undefined) {

--- a/lib/plugins/environments.js
+++ b/lib/plugins/environments.js
@@ -17,10 +17,6 @@ module.exports = class Environments extends Diffable {
               }
             })
         }
-
-        // Remove 'name' from filtering list so Environments with only a name defined are processed.
-        MergeDeep.NAME_FIELDS.splice(MergeDeep.NAME_FIELDS.indexOf('name'), 1)
-
     }
 
     async find() {
@@ -304,7 +300,7 @@ module.exports = class Environments extends Diffable {
               }
             }
           }
-          filteredEntries = filteredEntries.filter(entry => Object.keys(entry).filter(key => !MergeDeep.NAME_FIELDS.includes(key)).length !== 0)
+          // For environments, we want to keep the entries with only name defined.
 
           const changes = []
 


### PR DESCRIPTION
I believe this will solve what I think is a serious bug introduced in version 2.1.11 as reported in issue 108.

If I understand things correctly, loading the environment plugin removes the `name` value from the `MergeDeep.NAME_FIELDS` array and this again breaks merging arrays, thus leading to diff reporting not working as expected.

I believe this change keeps the result of the fix that caused the bug, but in a way that removes the problem.

I also did a quick change at the end of `mergeDeep.js` where this line was duplicated (I believe that must be just a slip):
```javascript
MergeDeep.NAME_FIELDS = NAME_FIELDS
MergeDeep.NAME_FIELDS = NAME_FIELDS
module.exports = MergeDeep
```