### PR TITLE
Fix code scanning alert no. 2: Prototype-polluting function

### DIFF
--- a/lib/mergeDeep.js
+++ b/lib/mergeDeep.js
@@ -91,6 +91,10 @@ class MergeDeep {
     // One of the oddities is when we compare objects, we are only interested in the properties of source
     // So any property in the target that is not in the source is not treated as a deletion
     for (const key in source) {
+      // Skip prototype pollution properties
+      if (key === "__proto__" || key === "constructor") {
+        continue;
+      }
       // Logic specific for Github
       // API response includes urls for resources, or other ignorable fields; we can ignore them
       if (key.indexOf('url') >= 0 || this.ignorableFields.indexOf(key) >= 0) {


### PR DESCRIPTION
Fixes [https://github.com/github/safe-settings/security/code-scanning/2](https://github.com/github/safe-settings/security/code-scanning/2)

To fix the prototype pollution vulnerability, we need to ensure that properties like `__proto__` and `constructor` are not copied from the `source` object to the `modifications` object. This can be achieved by adding a check to skip these properties during the merge process.

- Add a check to skip `__proto__` and `constructor` properties in the `for...in` loop that iterates over `source`.
- This change should be made in the `compareDeep` method of the `MergeDeep` class in the `lib/mergeDeep.js` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
