### PR TITLE
fix: Handle scientific notation in label hex colors

### DIFF
--- a/lib/plugins/labels.js
+++ b/lib/plugins/labels.js
@@ -23,7 +23,13 @@ module.exports = class Labels extends Diffable {
       this.entries.forEach(label => {
         // Force color to string since some hex colors can be numerical (e.g. 999999)
         if (label.color) {
-          label.color = String(label.color).replace(/^#/, '')
+          // Handle scientific notation case for numerical color values
+          label.color = (
+            typeof label.color === 'number'
+              ? label.color.toString(16)
+              : String(label.color)
+          ).replace(/^#/, "")
+          label.color = String(label.color).replace(/^#/, "")
           if (label.color.length < 6) {
             label.color.padStart(6, '0')
           }


### PR DESCRIPTION
Fixes #707

Properly convert numeric hex colors that could be interpreted as scientific notation (e.g. 5319e7)

## Before
```yml
labels:
  - name: "example"
    color: 5319e7  # 53190000000
```

## After
```yml
labels:
  - name: "example"
    color: 5319e7  # 5319e7
```

