### PR TITLE
Fix code scanning alert no. 1: Prototype-polluting function

### DIFF
--- a/lib/mergeDeep.js
+++ b/lib/mergeDeep.js
@@ -91,6 +91,10 @@ class MergeDeep {
     // One of the oddities is when we compare objects, we are only interested in the properties of source
     // So any property in the target that is not in the source is not treated as a deletion
     for (const key in source) {
+      // Skip prototype pollution properties
+      if (key === "__proto__" || key === "constructor") {
+        continue;
+      }
       // Logic specific for Github
       // API response includes urls for resources, or other ignorable fields; we can ignore them
       if (key.indexOf('url') >= 0 || this.ignorableFields.indexOf(key) >= 0) {


### PR DESCRIPTION
Fixes [https://github.com/github/safe-settings/security/code-scanning/1](https://github.com/github/safe-settings/security/code-scanning/1)

To fix the prototype pollution issue, we need to ensure that properties like `__proto__` and `constructor` are not copied from the `source` object to the `additions` object. This can be achieved by adding a check to skip these properties during the merge process.

- Modify the `compareDeep` function to include a check that skips the `__proto__` and `constructor` properties.
- This change should be made in the `lib/mergeDeep.js` file, specifically in the loop that iterates over the `source` object's properties.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
