### PR TITLE
Fix code scanning alert no. 2: Prototype-polluting function

### DIFF
--- a/lib/mergeDeep.js
+++ b/lib/mergeDeep.js
@@ -91,6 +91,10 @@ class MergeDeep {
     // One of the oddities is when we compare objects, we are only interested in the properties of source
     // So any property in the target that is not in the source is not treated as a deletion
     for (const key in source) {
+      // Skip prototype pollution vectors
+      if (key === "__proto__" || key === "constructor") {
+        continue;
+      }
       // Logic specific for Github
       // API response includes urls for resources, or other ignorable fields; we can ignore them
       if (key.indexOf('url') >= 0 || this.ignorableFields.indexOf(key) >= 0) {


### PR DESCRIPTION
Fixes [https://github.com/github/safe-settings/security/code-scanning/2](https://github.com/github/safe-settings/security/code-scanning/2)

To fix the prototype pollution vulnerability, we need to ensure that properties like `__proto__` and `constructor` are not merged into the `modifications`, `additions`, or `deletions` objects. This can be achieved by adding checks to skip these properties during the merge process.

The best way to fix the problem without changing existing functionality is to add a condition to skip these properties in the `compareDeep` method. Specifically, we will add a check before processing each key to ensure it is not `__proto__` or `constructor`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
