### PR TITLE
Fix patch vs post of environment variables

### DIFF
--- a/lib/plugins/environments.js
+++ b/lib/plugins/environments.js
@@ -167,7 +167,7 @@ module.exports = class Environments extends Diffable {
       for (const variable of attrs.variables) {
         const existingVariable = existingVariables.find((_var) => _var.name === variable.name)
         if (existingVariable) {
-          existingVariables = existingVariables.filter(_var => _var.name !== variable.name)
+          existingVariables = existingVariables.filter(_var => _var.name === variable.name)
           if (existingVariable.value !== variable.value) {
             await this.github.request('PATCH /repos/:org/:repo/environments/:environment_name/variables/:variable_name', {
               org: this.repo.owner,


### PR DESCRIPTION
This boolean was reversed when filtering existing variables,
so it consistently sent a POST request to existing vars.