### PR TITLE
fix: handle empty deployment config yaml file

### DIFF
--- a/lib/deploymentConfig.js
+++ b/lib/deploymentConfig.js
@@ -15,21 +15,21 @@ class DeploymentConfig {
   static {
     const deploymentConfigPath = process.env.DEPLOYMENT_CONFIG_FILE ? process.env.DEPLOYMENT_CONFIG_FILE : 'deployment-settings.yml'
     if (fs.existsSync(deploymentConfigPath)) {
-      this.config = yaml.load(fs.readFileSync(deploymentConfigPath))
+      this.config = yaml.load(fs.readFileSync(deploymentConfigPath)) || {}
     } else {
       this.config = { restrictedRepos: ['admin', '.github', 'safe-settings'] }
     }
 
-    const overridevalidators = this.config.overridevalidators
-    if (this.isIterable(overridevalidators)) {
+    const overridevalidators = this.config.overridevalidators || []
+    if (this.isNonEmptyArray(overridevalidators)) {
       for (const validator of overridevalidators) {
         // eslint-disable-next-line no-new-func
         const f = new Function('baseconfig', 'overrideconfig', 'githubContext', validator.script)
         this.overridevalidators[validator.plugin] = { canOverride: f, error: validator.error }
       }
     }
-    const configvalidators = this.config.configvalidators
-    if (this.isIterable(configvalidators)) {
+    const configvalidators = this.config.configvalidators || []
+    if (this.isNonEmptyArray(configvalidators)) {
       for (const validator of configvalidators) {
         // eslint-disable-next-line no-new-func
         const f = new Function('baseconfig', 'githubContext', validator.script)
@@ -38,12 +38,8 @@ class DeploymentConfig {
     }
   }
 
-  static isIterable (obj) {
-    // checks for null and undefined
-    if (obj == null) {
-      return false
-    }
-    return typeof obj[Symbol.iterator] === 'function'
+  static isNonEmptyArray (obj) {
+    return Array.isArray(obj) && obj.length > 0
   }
 
   // eslint-disable-next-line no-useless-constructor


### PR DESCRIPTION
Fixes #730

Changes:
- Add `|| {}` fallback for yaml.load() results
- Add `|| []` fallback for array properties (`overridevalidators` and `configvalidators`)
- Add array validation before iteration

Testing:
- Verified handling of empty config file
- Verified handling of null array cases