### PR TITLE
fix: add missing nop param for full-sync

### DIFF
--- a/full-sync.js
+++ b/full-sync.js
@@ -1,14 +1,14 @@
 const appFn = require('./')
-const { FULL_SYNC_NOOP } = require('./lib/env')
+const { FULL_SYNC_NOP } = require('./lib/env')
 const { createProbot } = require('probot')
 
-async function performFullSync (appFn, noop) {
+async function performFullSync (appFn, nop) {
   const probot = createProbot()
-  probot.log.info(`Starting full sync with NOOP=${noop}`)
+  probot.log.info(`Starting full sync with NOP=${nop}`)
 
   try {
     const app = appFn(probot, {})
-    const settings = await app.syncInstallation(noop)
+    const settings = await app.syncInstallation(nop)
 
     if (settings.errors && settings.errors.length > 0) {
       probot.log.error('Errors occurred during full sync.')
@@ -22,7 +22,7 @@ async function performFullSync (appFn, noop) {
   }
 }
 
-performFullSync(appFn, FULL_SYNC_NOOP).catch((error) => {
+performFullSync(appFn, FULL_SYNC_NOP).catch((error) => {
   console.error('Fatal error during full sync:', error)
   process.exit(1)
 })

--- a/index.js
+++ b/index.js
@@ -230,7 +230,7 @@ module.exports = (robot, { getRouter }, Settings = require('./lib/settings')) =>
     }
   }
 
-  async function syncInstallation () {
+  async function syncInstallation (noop = false) {
     robot.log.trace('Fetching installations')
     const github = await robot.auth()
 
@@ -249,7 +249,7 @@ module.exports = (robot, { getRouter }, Settings = require('./lib/settings')) =>
         log: robot.log,
         repo: () => { return { repo: env.ADMIN_REPO, owner: installation.account.login } }
       }
-      return syncAllSettings(false, context)
+      return syncAllSettings(noop, context)
     }
     return null
   }

--- a/index.js
+++ b/index.js
@@ -230,7 +230,7 @@ module.exports = (robot, { getRouter }, Settings = require('./lib/settings')) =>
     }
   }
 
-  async function syncInstallation (noop = false) {
+  async function syncInstallation (nop = false) {
     robot.log.trace('Fetching installations')
     const github = await robot.auth()
 
@@ -249,7 +249,7 @@ module.exports = (robot, { getRouter }, Settings = require('./lib/settings')) =>
         log: robot.log,
         repo: () => { return { repo: env.ADMIN_REPO, owner: installation.account.login } }
       }
-      return syncAllSettings(noop, context)
+      return syncAllSettings(nop, context)
     }
     return null
   }

--- a/lib/env.js
+++ b/lib/env.js
@@ -6,5 +6,5 @@ module.exports = {
   CREATE_PR_COMMENT: process.env.CREATE_PR_COMMENT || 'true',
   CREATE_ERROR_ISSUE: process.env.CREATE_ERROR_ISSUE || 'true',
   BLOCK_REPO_RENAME_BY_HUMAN: process.env.BLOCK_REPO_RENAME_BY_HUMAN || 'false',
-  FULL_SYNC_NOOP: process.env.FULL_SYNC_NOOP === 'true'
+  FULL_SYNC_NOP: process.env.FULL_SYNC_NOP === 'true'
 }

--- a/lib/env.js
+++ b/lib/env.js
@@ -5,5 +5,6 @@ module.exports = {
   DEPLOYMENT_CONFIG_FILE: process.env.DEPLOYMENT_CONFIG_FILE || 'deployment-settings.yml',
   CREATE_PR_COMMENT: process.env.CREATE_PR_COMMENT || 'true',
   CREATE_ERROR_ISSUE: process.env.CREATE_ERROR_ISSUE || 'true',
-  BLOCK_REPO_RENAME_BY_HUMAN: process.env.BLOCK_REPO_RENAME_BY_HUMAN || 'false'
+  BLOCK_REPO_RENAME_BY_HUMAN: process.env.BLOCK_REPO_RENAME_BY_HUMAN || 'false',
+  FULL_SYNC_NOOP: process.env.FULL_SYNC_NOOP === 'true'
 }

--- a/test/unit/lib/env.test.js
+++ b/test/unit/lib/env.test.js
@@ -27,6 +27,11 @@ describe('env', () => {
       const CREATE_PR_COMMENT = envTest.CREATE_PR_COMMENT
       expect(CREATE_PR_COMMENT).toEqual('true')
     })
+
+    it('loads default FULL_SYNC_NOOP if not passed', () => {
+      const FULL_SYNC_NOOP = envTest.FULL_SYNC_NOOP
+      expect(FULL_SYNC_NOOP).toEqual(false)
+    })
   })
 
   describe('load override values', () => {
@@ -37,6 +42,7 @@ describe('env', () => {
       process.env.SETTINGS_FILE_PATH = 'safe-settings.yml'
       process.env.DEPLOYMENT_CONFIG_FILE = 'safe-settings-deployment.yml'
       process.env.CREATE_PR_COMMENT = 'false'
+      process.env.FULL_SYNC_NOOP = false
     })
 
     it('loads override values if passed', () => {
@@ -51,6 +57,8 @@ describe('env', () => {
       expect(DEPLOYMENT_CONFIG_FILE).toEqual('safe-settings-deployment.yml')
       const CREATE_PR_COMMENT = envTest.CREATE_PR_COMMENT
       expect(CREATE_PR_COMMENT).toEqual('false')
+      const FULL_SYNC_NOOP = envTest.FULL_SYNC_NOOP
+      expect(FULL_SYNC_NOOP).toEqual(false)
     })
   })
 })

--- a/test/unit/lib/env.test.js
+++ b/test/unit/lib/env.test.js
@@ -28,9 +28,9 @@ describe('env', () => {
       expect(CREATE_PR_COMMENT).toEqual('true')
     })
 
-    it('loads default FULL_SYNC_NOOP if not passed', () => {
-      const FULL_SYNC_NOOP = envTest.FULL_SYNC_NOOP
-      expect(FULL_SYNC_NOOP).toEqual(false)
+    it('loads default FULL_SYNC_NOP if not passed', () => {
+      const FULL_SYNC_NOP = envTest.FULL_SYNC_NOP
+      expect(FULL_SYNC_NOP).toEqual(false)
     })
   })
 
@@ -42,7 +42,7 @@ describe('env', () => {
       process.env.SETTINGS_FILE_PATH = 'safe-settings.yml'
       process.env.DEPLOYMENT_CONFIG_FILE = 'safe-settings-deployment.yml'
       process.env.CREATE_PR_COMMENT = 'false'
-      process.env.FULL_SYNC_NOOP = false
+      process.env.FULL_SYNC_NOP = false
     })
 
     it('loads override values if passed', () => {
@@ -57,8 +57,8 @@ describe('env', () => {
       expect(DEPLOYMENT_CONFIG_FILE).toEqual('safe-settings-deployment.yml')
       const CREATE_PR_COMMENT = envTest.CREATE_PR_COMMENT
       expect(CREATE_PR_COMMENT).toEqual('false')
-      const FULL_SYNC_NOOP = envTest.FULL_SYNC_NOOP
-      expect(FULL_SYNC_NOOP).toEqual(false)
+      const FULL_SYNC_NOP = envTest.FULL_SYNC_NOP
+      expect(FULL_SYNC_NOP).toEqual(false)
     })
   })
 })

--- a/test/unit/lib/plugins/branches.test.js
+++ b/test/unit/lib/plugins/branches.test.js
@@ -10,9 +10,9 @@ describe('Branches', () => {
   log.error = jest.fn()
 
   function configure (config) {
-    const noop = false
+    const nop = false
     const errors = []
-    return new Branches(noop, github, { owner: 'bkeepers', repo: 'test' }, config, log, errors)
+    return new Branches(nop, github, { owner: 'bkeepers', repo: 'test' }, config, log, errors)
   }
 
   beforeEach(() => {

--- a/test/unit/lib/plugins/repository.test.js
+++ b/test/unit/lib/plugins/repository.test.js
@@ -17,9 +17,9 @@ describe('Repository', () => {
   log.error = jest.fn()
 
   function configure (config) {
-    const noop = false
+    const nop = false
     const errors = []
-    return new Repository(noop, github, { owner: 'bkeepers', repo: 'test' }, config, 1, log, errors)
+    return new Repository(nop, github, { owner: 'bkeepers', repo: 'test' }, config, 1, log, errors)
   }
 
   describe('sync', () => {


### PR DESCRIPTION
Related to #378 (https://github.com/github/safe-settings/issues/378#issuecomment-2575164641)

Now the full-sync script will use the new env var `FULL_SYNC_NOOP` and so run is noop mode if true.
This helps run safe-settings GHA since you can add this var conditionaly based on event.

Example (based from https://github.com/UCL-MIRSG/.github/blob/4695e545829b91dcddc6e36358454bc4a879f751/.github/workflows/safe-settings.yaml thanks @paddyroddy) :

```yml
name: Safe Settings Sync
on:
  push:
    branches:
      - main
  pull_request:
    paths:
      - safe-settings/**
      - .github/workflows/safe-settings.yaml
  schedule:
    - cron: 0 */4 * * *
  # -->
  workflow_dispatch:
    inputs:
      NOOP:
        description: 'Run in no-op mode'
        required: false
        type: boolean
        default: false

concurrency:
  cancel-in-progress: true
  group: >-
    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

jobs:
  safe-settings-sync:
    runs-on: ubuntu-latest
    env:
      SAFE_SETTINGS_VERSION: 2.1.14
      SAFE_SETTINGS_CODE_DIR: .safe-settings-code
    steps:
      - name: Checkout source
        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

      - name: Checkout GitHub Safe-Settings repository
        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
        with:
          path: ${{ env.SAFE_SETTINGS_CODE_DIR }}
          ref: ${{ env.SAFE_SETTINGS_VERSION }}
          repository: github/safe-settings

      - name: Setup Node.js
        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
        with:
          cache-dependency-path:
            ${{ env.SAFE_SETTINGS_CODE_DIR }}/package-lock.json
          cache: npm
          node-version-file: ${{ env.SAFE_SETTINGS_CODE_DIR }}/.nvmrc

      - name: Install dependencies
        run: npm install
        working-directory: ${{ env.SAFE_SETTINGS_CODE_DIR }}

      # -->
      - name: Set no-op mode flag
        run: |
          echo "FULL_SYNC_NOOP=false" >> $GITHUB_ENV

          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
            echo "FULL_SYNC_NOOP=true" >> $GITHUB_ENV
          fi

          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
            if [[ "${{ inputs.NOOP }}" != "" ]]; then
              echo "FULL_SYNC_NOOP=${{ inputs.NOOP }}" >> $GITHUB_ENV
            fi
          fi

      - name: Run application
        run: npm run full-sync
        working-directory: ${{ env.SAFE_SETTINGS_CODE_DIR }}
        env:
          ADMIN_REPO: .github
          APP_ID: ${{ vars.SAFE_SETTINGS_APP_ID }}
          BLOCK_REPO_RENAME_BY_HUMAN: false
          CONFIG_PATH: safe-settings
          DEPLOYMENT_CONFIG_FILE:
            ${{ github.workspace }}/safe-settings/deployment.yaml
          ENABLE_PR_COMMENT: true
          GH_ORG: ${{ vars.SAFE_SETTINGS_GH_ORG }}
          GITHUB_CLIENT_ID: ${{ vars.SAFE_SETTINGS_GITHUB_CLIENT_ID }}
          GITHUB_CLIENT_SECRET:
            ${{ secrets.SAFE_SETTINGS_GITHUB_CLIENT_SECRET }}
          LOG_LEVEL: trace
          PRIVATE_KEY: ${{ secrets.SAFE_SETTINGS_PRIVATE_KEY }}
          SETTINGS_FILE_PATH: organisation.yaml
          # -->
          FULL_SYNC_NOOP: ${{ env.FULL_SYNC_NOOP }}

```