### PR TITLE
fix: add missing nop logic for custom properties plugin

### DIFF
--- a/lib/plugins/custom_properties.js
+++ b/lib/plugins/custom_properties.js
@@ -1,25 +1,47 @@
 const Diffable = require('./diffable')
+const NopCommand = require('../nopcommand')
 
 module.exports = class CustomProperties extends Diffable {
   constructor (...args) {
     super(...args)
 
     if (this.entries) {
-      // Force all names to lowercase to avoid comparison issues.
-      this.entries.forEach(prop => {
-        prop.name = prop.name.toLowerCase()
-      })
+      this.normalizeEntries()
     }
   }
 
-  async find () {
-    const data = await this.github.request('GET /repos/:org/:repo/properties/values', {
-      org: this.repo.owner,
-      repo: this.repo.repo
-    })
+  // Force all names to lowercase to avoid comparison issues.
+  normalizeEntries () {
+    this.entries = this.entries.map(({ name, value }) => ({
+      name: name.toLowerCase(),
+      value
+    }))
+  }
 
-    const properties = data.data.map(d => { return { name: d.property_name, value: d.value } })
-    return properties
+  async find () {
+    const { owner, repo } = this.repo
+    const repoFullName = `${owner}/${repo}`
+
+    this.log.debug(`Getting all custom properties for the repo ${repoFullName}`)
+
+    const customProperties = await this.github.paginate(
+      this.github.repos.getCustomPropertiesValues,
+      {
+        owner,
+        repo,
+        per_page: 100
+      }
+    )
+    this.log.debug(`Found ${customProperties.length} custom properties`)
+    return this.normalize(customProperties)
+  }
+
+  // Force all names to lowercase to avoid comparison issues.
+  normalize (properties) {
+    return properties.map(({ property_name: propertyName, value }) => ({
+      name: propertyName.toLowerCase(),
+      value
+    }))
   }
 
   comparator (existing, attrs) {
@@ -30,38 +52,47 @@ module.exports = class CustomProperties extends Diffable {
     return attrs.value !== existing.value
   }
 
-  async update (existing, attrs) {
-    await this.github.request('PATCH /repos/:org/:repo/properties/values', {
-      org: this.repo.owner,
-      repo: this.repo.repo,
-      properties: [{
-        property_name: attrs.name,
-        value: attrs.value
-      }]
-    })
+  async update ({ name }, { value }) {
+    return this.modifyProperty('Update', { name, value })
   }
 
-  async add (attrs) {
-    await this.github.request('PATCH /repos/:org/:repo/properties/values', {
-      org: this.repo.owner,
-      repo: this.repo.repo,
-      properties: [{
-        property_name: attrs.name,
-        value: attrs.value
-      }]
-    })
+  async add ({ name, value }) {
+    return this.modifyProperty('Create', { name, value })
   }
 
-  async remove (existing) {
-    await this.github.request('PATCH /repos/:org/:repo/properties/values', {
-      org: this.repo.owner,
-      repo: this.repo.repo,
-      properties: [
-        {
-          property_name: existing.name,
-          value: null
-        }
-      ]
-    })
+  // Custom Properties on repository does not support deletion, so we set the value to null
+  async remove ({ name }) {
+    return this.modifyProperty('Delete', { name, value: null })
+  }
+
+  async modifyProperty (operation, { name, value }) {
+    const { owner, repo } = this.repo
+    const repoFullName = `${owner}/${repo}`
+
+    const params = {
+      owner,
+      repo,
+      properties: [{
+        property_name: name,
+        value
+      }]
+    }
+
+    if (this.nop) {
+      return new NopCommand(
+        this.constructor.name,
+        this.repo,
+        this.github.repos.createOrUpdateCustomPropertiesValues.endpoint(params),
+        `${operation} Custom Property`
+      )
+    }
+
+    try {
+      this.log.debug(`${operation} Custom Property "${name}" for the repo ${repoFullName}`)
+      await this.github.repos.createOrUpdateCustomPropertiesValues(params)
+      this.log.debug(`Successfully ${operation.toLowerCase()}d Custom Property "${name}" for the repo ${repoFullName}`)
+    } catch (e) {
+      this.logError(`Error during ${operation} Custom Property "${name}" for the repo ${repoFullName}: ${e.message || e}`)
+    }
   }
 }


### PR DESCRIPTION
Fixes #734

Implements proper `nop` (dry-run) logic handling for Custom PropertIes plugin, aligning with documentation and other plugins.

## Changes

- Add nop mode support for property modifications
- Add `paginate` for gettings all custom properties
- Switch to built-in Octokit functions instead of `github.request`
- Update API endpoint format from `/repos/:org/:repo/properties/values` to `/repos/{owner}/{repo}/properties/values` for consistency with GitHub API
- Refactor property modification logic into a single `modifyProperty` method
- Add debug logging for better troubleshooting
- Normalize custom property names (from GH API) to lowercase to prevent case-sensitivity comparison issues
- Update test cases

## Note

Currently, organization properties are not fetched from the GH Organization API. When modifying repo custom properties, this results in a 422 error if the property isn't defined at the org level. Future improvements could:

- Handle missing org properties to enable preview changes in nop mode
- Add support for defining Organization custom properties (requires broader changes)
