### PR TITLE
Feature: Allow PR status checks to be managed external to safe settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,42 @@ overridevalidators:
 
 A sample of `deployment-settings` file is found [here](docs/sample-settings/sample-deployment-settings.yml).
 
+### Custom Status Checks
+For branch protection rules and rulesets, you can allow for status checks to be defined outside of safe-settings together with your usual safe settings.
+
+This can be defined at the org, sub-org, and repo level.
+
+To configure this for branch protection rules, specifiy `{{EXTERNALLY_DEFINED}}` under the `contexts` keyword:
+```yaml
+branches:
+  - name: main
+    protection:
+      ...
+      required_status_checks:
+        contexts:
+          - "{{EXTERNALLY_DEFINED}}"
+```
+
+For rulesets, specify `{{EXTERNALLY_DEFINED}}` under the `required_status_checks` keyword:
+```yaml
+rulesets:
+  - name: Status Checks
+    ...
+    rules:
+      - type: required_status_checks
+        parameters:
+          required_status_checks:
+            - context: "{{EXTERNALLY_DEFINED}}"
+```
+
+Notes:
+  - For branch protection rules, contexts defined at the org level are merged together with the sub-org and repo level contexts.
+  - When `{{EXTERNALLY_DEFINED}}` is defined for a new branch protection rule or ruleset configuration, they will be deployed with no status checks.
+  - When an existing branch protection rule or ruleset configuration is ammended with `{{EXTERNALLY_DEFINED}}`, the status checks in the existing rules in GitHub will remain as is.
+
+⚠️ **Warning:**
+When `{{EXTERNALLY_DEFINED}}` is removed from an existing branch protection rule or ruleset configuration, the status checks in the existing rules in GitHub will revert to the checks that are defined in safe-settings.
+
 ### Performance
 When there are 1000s of repos to be managed -- and there is a global settings change -- safe-settings will have to work efficiently and only make the necessary API calls.
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ rulesets:
 
 Notes:
   - For the same branch that is covered by multi-level branch protection rules, contexts defined at the org level are merged into the sub-org and repo level contexts, while contexts defined at the sub-org level are merged into the repo level contexts.
+  - Rules from the sub-org level are merged into the repo level when their ruleset share the same name. Becareful not to define the same rule type in both levels as it will be rejected by GitHub.
   - When `{{EXTERNALLY_DEFINED}}` is defined for a new branch protection rule or ruleset configuration, they will be deployed with no status checks.
   - When an existing branch protection rule or ruleset configuration is amended with `{{EXTERNALLY_DEFINED}}`, the status checks in the existing rules in GitHub will remain as is.
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ For branch protection rules and rulesets, you can allow for status checks to be 
 
 This can be defined at the org, sub-org, and repo level.
 
-To configure this for branch protection rules, specifiy `{{EXTERNALLY_DEFINED}}` under the `contexts` keyword:
+To configure this for branch protection rules, specify `{{EXTERNALLY_DEFINED}}` under the `contexts` keyword:
 ```yaml
 branches:
   - name: main

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ rulesets:
 Notes:
   - For branch protection rules, contexts defined at the org level are merged together with the sub-org and repo level contexts.
   - When `{{EXTERNALLY_DEFINED}}` is defined for a new branch protection rule or ruleset configuration, they will be deployed with no status checks.
-  - When an existing branch protection rule or ruleset configuration is ammended with `{{EXTERNALLY_DEFINED}}`, the status checks in the existing rules in GitHub will remain as is.
+  - When an existing branch protection rule or ruleset configuration is amended with `{{EXTERNALLY_DEFINED}}`, the status checks in the existing rules in GitHub will remain as is.
 
 ⚠️ **Warning:**
 When `{{EXTERNALLY_DEFINED}}` is removed from an existing branch protection rule or ruleset configuration, the status checks in the existing rules in GitHub will revert to the checks that are defined in safe-settings.

--- a/README.md
+++ b/README.md
@@ -152,12 +152,15 @@ rulesets:
 ```
 
 Notes:
-  - For branch protection rules, contexts defined at the org level are merged together with the sub-org and repo level contexts.
+  - For the same branch that is covered by multi-level branch protection rules, contexts defined at the org level are merged into the sub-org and repo level contexts, while contexts defined at the sub-org level are merged into the repo level contexts.
   - When `{{EXTERNALLY_DEFINED}}` is defined for a new branch protection rule or ruleset configuration, they will be deployed with no status checks.
   - When an existing branch protection rule or ruleset configuration is amended with `{{EXTERNALLY_DEFINED}}`, the status checks in the existing rules in GitHub will remain as is.
 
-⚠️ **Warning:**
-When `{{EXTERNALLY_DEFINED}}` is removed from an existing branch protection rule or ruleset configuration, the status checks in the existing rules in GitHub will revert to the checks that are defined in safe-settings.
+> ⚠️ **Warning:**
+When `{{EXTERNALLY_DEFINED}}` is removed from an existing branch protection rule or ruleset configuration, the status checks in the existing rules in GitHub will revert to the checks that are defined in safe-settings. From this point onwards, all status checks configured through the GitHub UI will be reverted back to the safe-settings configuration.
+
+#### Status checks inheritance across scopes
+Refer to [Status checks](docs/status-checks.md).
 
 ### Performance
 When there are 1000s of repos to be managed -- and there is a global settings change -- safe-settings will have to work efficiently and only make the necessary API calls.

--- a/docs/status-checks.md
+++ b/docs/status-checks.md
@@ -1,0 +1,172 @@
+## Status checks inheritance across scopes
+
+### Rulesets
+
+The status checks between organisation and repository rulesets are independent of each together.
+
+In the following examples, a common ruleset name is used at all levels. Repo1 and Repo2 are managed at the Sub-org level.
+
+#### No custom checks
+```
+Org checks:
+  Org Check
+Sub-org checks:
+  Sub-org Check
+Repo checks for Repo2:
+  Repo Check
+```
+
+Status checks:
+  - Newly deployed rules:
+    - Org: Org Check
+    - Repo1: Sub-org Check
+    - Repo2: _Failed to deploy as required_status_checks can't be defined twice in both sub-org and repo level_
+  - Updating status checks via GitHub UI:
+    - Org: Status checks reverted back to safe settings
+    - Repo1: Status checks reverted back to safe settings
+    - Repo2: NA
+
+#### No custom checks 2
+```
+Org checks:
+  Org Check
+Sub-org checks:
+  Sub-org Check
+Repo checks for Repo2:
+  _NONE_
+```
+
+Status checks:
+  - Newly deployed rules:
+    - Org: Org Check
+    - Repo1: Sub-org Check
+    - Repo2: _NONE_
+  - Updating status checks via GitHub UI:
+    - Org: Status checks reverted back to safe settings
+    - Repo1: Status checks reverted back to safe settings
+    - Repo2: Custom status checks are retained
+
+**The remaining tests will leave Repo2 out of the Sub-org.**
+
+#### Custom checks enabled at the Org and Sub-org level
+```
+Org:
+  Org Check
+  {{EXTERNALLY_DEFINED}}
+Sub-org checks:
+  Sub-org Check
+  {{EXTERNALLY_DEFINED}}
+Repo checks for Repo2:
+  Repo Check
+```
+
+Status checks:
+  - Newly deployed rules:
+    - Org: []
+    - Repo1: []
+    - Repo2: Repo Check
+  - Updating status checks via GitHub UI:
+    - Org: Custom status checks are retained
+    - Repo1: Custom status checks are retained
+    - Repo2: Status checks reverted back to safe settings
+
+#### Custom checks enabled at the Repo level
+```
+Org:
+  Org Check
+Sub-org checks:
+  Sub-org Check
+Repo checks for Repo2:
+  Repo Check
+  {{EXTERNALLY_DEFINED}}
+```
+
+Status checks:
+  - Newly deployed rules:
+    - Org: Org Check
+    - Repo1: Sub-org Check
+    - Repo2: []
+  - Updating status checks via GitHub UI:
+    - Org: Status checks reverted back to safe settings
+    - Repo1: Status checks reverted back to safe settings
+    - Repo2: Custom status checks are retained
+
+
+### Branch protection rules
+
+In the following examples the `main` branch is protected at all levels. Repo1 and Repo2 are managed at the Sub-org level.
+
+#### No custom checks
+```
+Org checks:
+  Org Check
+Sub-org checks:
+  Sub-org Check
+Repo checks for Repo2:
+  Repo Check
+```
+
+Status checks:
+  - Newly deployed rules:
+    - Repo1: Org Check, Sub-org Check
+    - Repo2: Org Check, Sub-org Check, Repo Check
+  - Updating status checks via GitHub UI:
+    - Repo1: Status checks reverted back to safe settings
+    - Repo2: Status checks reverted back to safe settings
+
+#### Custom checks enabled at the Org level
+```
+Org:
+  Org Check
+  {{EXTERNALLY_DEFINED}}
+Sub-org checks:
+  Sub-org Check
+Repo checks for Repo2:
+  Repo Check
+```
+
+Status checks:
+  - Newly deployed rules:
+    - Repo1: []
+    - Repo2: []
+  - Updating status checks via GitHub UI:
+    - Repo1: Custom status checks are retained
+    - Repo2: Custom status checks are retained
+
+#### Custom checks enabled at the Sub-org level
+```
+Org:
+  Org Check
+Sub-org checks:
+  Sub-org Check
+  {{EXTERNALLY_DEFINED}}
+Repo checks for Repo2:
+  Repo Check
+```
+
+Status checks:
+  - Newly deployed rules:
+    - Repo1: []
+    - Repo2: []
+  - Updating status checks via GitHub UI:
+    - Repo1: Custom status checks are retained
+    - Repo2: Custom status checks are retained
+
+#### Custom checks enabled at the Repo level
+```
+Org:
+  Org Check
+Sub-org checks:
+  Sub-org Check
+Repo checks for Repo2:
+  Repo Check
+  {{EXTERNALLY_DEFINED}}
+```
+
+Status checks:
+  - Newly deployed rules:
+    - Repo1: Org Check, Sub-org Check
+    - Repo2: []
+  - Updating status checks via GitHub UI:
+    - Repo1: Status checks reverted back to safe settings
+    - Repo2: Custom status checks are retained

--- a/lib/plugins/branches.js
+++ b/lib/plugins/branches.js
@@ -3,6 +3,9 @@ const NopCommand = require('../nopcommand')
 const MergeDeep = require('../mergeDeep')
 const ignorableFields = []
 const previewHeaders = { accept: 'application/vnd.github.hellcat-preview+json,application/vnd.github.luke-cage-preview+json,application/vnd.github.zzzax-preview+json' }
+const overrides = [
+  'required_status_checks.contexts',
+]
 
 module.exports = class Branches extends ErrorStash {
   constructor (nop, github, repo, settings, log, errors) {
@@ -49,7 +52,7 @@ module.exports = class Branches extends ErrorStash {
               const params = Object.assign({}, p)
               return this.github.repos.getBranchProtection(params).then((result) => {
                 const mergeDeep = new MergeDeep(this.log, this.github, ignorableFields)
-                const changes = mergeDeep.compareDeep({ branch: { protection: this.reformatAndReturnBranchProtection(result.data) } }, { branch: { protection: branch.protection } })
+                const changes = mergeDeep.compareDeep({ branch: { protection: this.reformatAndReturnBranchProtection(result.data) } }, { branch: { protection: this.removeOverrides(branch.protection, result.data) } })
                 const results = { msg: `Followings changes will be applied to the branch protection for ${params.branch.name} branch`, additions: changes.additions, modifications: changes.modifications, deletions: changes.deletions }
                 this.log.debug(`Result of compareDeep = ${results}`)
 
@@ -76,7 +79,7 @@ module.exports = class Branches extends ErrorStash {
                 return this.github.repos.updateBranchProtection(params).then(res => this.log(`Branch protection applied successfully ${JSON.stringify(res.url)}`)).catch(e => { this.logError(`Error applying branch protection ${JSON.stringify(e)}`); return [] })
               }).catch((e) => {
                 if (e.status === 404) {
-                  Object.assign(params, branch.protection, { headers: previewHeaders })
+                  Object.assign(params, this.removeOverrides(branch.protection, {}), { headers: previewHeaders })
                   if (this.nop) {
                     resArray.push(new NopCommand(this.constructor.name, this.repo, this.github.repos.updateBranchProtection.endpoint(params), 'Add Branch Protection'))
                     return Promise.resolve(resArray)
@@ -121,5 +124,33 @@ module.exports = class Branches extends ErrorStash {
       }
     }
     return protection
+  }
+
+  getLastKey (obj, property) {
+    const keys = property.split('.')
+    for (let i = 0; i < keys.length - 1; i++) {
+      if (!obj[keys[i]]) return [obj, keys[i]]
+      obj = obj[keys[i]]
+    }
+    return [obj, keys[keys.length - 1]]
+  }
+
+  removeOverrides (source, target) {
+    if (source) {
+      overrides.forEach(override => {
+        let [obj, lastKey] = this.getLastKey(source, override)
+        if ((Array.isArray(obj[lastKey]) || typeof obj[lastKey] === 'string') && obj[lastKey].includes('{{EXTERNALLY_DEFINED}}')) {
+          let [obj2, lastKey2] = this.getLastKey(target, override)
+          if (obj2[lastKey2]) {
+            obj[lastKey] = obj2[lastKey2]
+          } else if (Array.isArray(obj[lastKey])) {
+            obj[lastKey] = []
+          } else {
+            obj[lastKey] = ''
+          }
+        }
+      })
+    }
+    return source
   }
 }

--- a/lib/plugins/branches.js
+++ b/lib/plugins/branches.js
@@ -4,9 +4,12 @@ const MergeDeep = require('../mergeDeep')
 const Overrides = require('./overrides')
 const ignorableFields = []
 const previewHeaders = { accept: 'application/vnd.github.hellcat-preview+json,application/vnd.github.luke-cage-preview+json,application/vnd.github.zzzax-preview+json' }
-const overrides = [
-  'contexts',
-]
+const overrides = {
+  'contexts': {
+    'action': 'reset',
+    'type': 'array'
+  },
+}
 
 module.exports = class Branches extends ErrorStash {
   constructor (nop, github, repo, settings, log, errors) {

--- a/lib/plugins/branches.js
+++ b/lib/plugins/branches.js
@@ -1,10 +1,11 @@
 const ErrorStash = require('./errorStash')
 const NopCommand = require('../nopcommand')
 const MergeDeep = require('../mergeDeep')
+const Overrides = require('./overrides')
 const ignorableFields = []
 const previewHeaders = { accept: 'application/vnd.github.hellcat-preview+json,application/vnd.github.luke-cage-preview+json,application/vnd.github.zzzax-preview+json' }
 const overrides = [
-  'required_status_checks.contexts',
+  'contexts',
 ]
 
 module.exports = class Branches extends ErrorStash {
@@ -52,7 +53,7 @@ module.exports = class Branches extends ErrorStash {
               const params = Object.assign({}, p)
               return this.github.repos.getBranchProtection(params).then((result) => {
                 const mergeDeep = new MergeDeep(this.log, this.github, ignorableFields)
-                const changes = mergeDeep.compareDeep({ branch: { protection: this.reformatAndReturnBranchProtection(result.data) } }, { branch: { protection: this.removeOverrides(branch.protection, result.data) } })
+                const changes = mergeDeep.compareDeep({ branch: { protection: this.reformatAndReturnBranchProtection(result.data) } }, { branch: { protection: Overrides.removeOverrides(overrides, branch.protection, result.data) } })
                 const results = { msg: `Followings changes will be applied to the branch protection for ${params.branch.name} branch`, additions: changes.additions, modifications: changes.modifications, deletions: changes.deletions }
                 this.log.debug(`Result of compareDeep = ${results}`)
 
@@ -79,7 +80,7 @@ module.exports = class Branches extends ErrorStash {
                 return this.github.repos.updateBranchProtection(params).then(res => this.log(`Branch protection applied successfully ${JSON.stringify(res.url)}`)).catch(e => { this.logError(`Error applying branch protection ${JSON.stringify(e)}`); return [] })
               }).catch((e) => {
                 if (e.status === 404) {
-                  Object.assign(params, this.removeOverrides(branch.protection, {}), { headers: previewHeaders })
+                  Object.assign(params, Overrides.removeOverrides(overrides, branch.protection, {}), { headers: previewHeaders })
                   if (this.nop) {
                     resArray.push(new NopCommand(this.constructor.name, this.repo, this.github.repos.updateBranchProtection.endpoint(params), 'Add Branch Protection'))
                     return Promise.resolve(resArray)
@@ -124,34 +125,5 @@ module.exports = class Branches extends ErrorStash {
       }
     }
     return protection
-  }
-
-  getLastKey (obj, property) {
-    const keys = property.split('.')
-    for (let i = 0; i < keys.length - 1; i++) {
-      if (!obj[keys[i]]) return [null, null]
-      obj = obj[keys[i]]
-    }
-    return [obj, keys[keys.length - 1]]
-  }
-
-  removeOverrides (source, existing) {
-    if (source) {
-      overrides.forEach(override => {
-        let [obj, lastKey] = this.getLastKey(source, override)
-        if (!obj) return
-        if ((Array.isArray(obj[lastKey]) || typeof obj[lastKey] === 'string') && obj[lastKey].includes('{{EXTERNALLY_DEFINED}}')) {
-          let [obj2, lastKey2] = this.getLastKey(existing, override)
-          if (obj2[lastKey2]) {
-            obj[lastKey] = obj2[lastKey2]
-          } else if (Array.isArray(obj[lastKey])) {
-            obj[lastKey] = []
-          } else {
-            obj[lastKey] = ''
-          }
-        }
-      })
-    }
-    return source
   }
 }

--- a/lib/plugins/branches.js
+++ b/lib/plugins/branches.js
@@ -129,18 +129,19 @@ module.exports = class Branches extends ErrorStash {
   getLastKey (obj, property) {
     const keys = property.split('.')
     for (let i = 0; i < keys.length - 1; i++) {
-      if (!obj[keys[i]]) return [obj, keys[i]]
+      if (!obj[keys[i]]) return [null, null]
       obj = obj[keys[i]]
     }
     return [obj, keys[keys.length - 1]]
   }
 
-  removeOverrides (source, target) {
+  removeOverrides (source, existing) {
     if (source) {
       overrides.forEach(override => {
         let [obj, lastKey] = this.getLastKey(source, override)
+        if (!obj) return
         if ((Array.isArray(obj[lastKey]) || typeof obj[lastKey] === 'string') && obj[lastKey].includes('{{EXTERNALLY_DEFINED}}')) {
-          let [obj2, lastKey2] = this.getLastKey(target, override)
+          let [obj2, lastKey2] = this.getLastKey(existing, override)
           if (obj2[lastKey2]) {
             obj[lastKey] = obj2[lastKey2]
           } else if (Array.isArray(obj[lastKey])) {

--- a/lib/plugins/branches.js
+++ b/lib/plugins/branches.js
@@ -13,7 +13,7 @@ module.exports = class Branches extends ErrorStash {
     super(errors)
     this.github = github
     this.repo = repo
-    this.branches = settings
+    this.branches = structuredClone(settings)
     this.log = log
     this.nop = nop
   }

--- a/lib/plugins/overrides.js
+++ b/lib/plugins/overrides.js
@@ -28,7 +28,7 @@ module.exports = class Overrides extends ErrorStash {
   static removeOverrides (overrides, source, existing) {
     overrides.forEach(override => {
       let sourceRefs = Overrides.getObjectRef(source, override)
-      let data = JSON.stringify(sourceRefs, null, 2)
+      let data = JSON.stringify(sourceRefs)
       if (data.includes('{{EXTERNALLY_DEFINED}}')) {
         let existingRefs = Overrides.getObjectRef(existing, override)
         sourceRefs.forEach(sourceRef => {

--- a/lib/plugins/overrides.js
+++ b/lib/plugins/overrides.js
@@ -1,0 +1,49 @@
+const ErrorStash = require('./errorStash')
+
+module.exports = class Overrides extends ErrorStash {
+  static getObjectRef (data, dataKey) {
+    const results = []
+    const traverse = (obj) => {
+      for (const key in obj) {
+        if (key === dataKey) {
+          results.push(obj)
+        } else if (Array.isArray(obj[key])) {
+          obj[key].forEach(element => traverse(element))
+        } else if (typeof obj[key] === 'object' && obj[key]) {
+          traverse(obj[key])
+        }
+      }
+    }
+    traverse(data)
+    return results
+  }
+
+  // When {{EXTERNALLY_DEFINED}} is found in the override value, retain the
+  // existing value from GitHub.
+  // Note:
+  //   - The admin settings could define multiple overrides, but the GitHub API
+  //     retains one only.
+  //   - The PUT method for rulesets (update) allows for multiple overrides.
+  //   - The POST method for rulesets (create) allows for one override only.
+  static removeOverrides (overrides, source, existing) {
+    overrides.forEach(override => {
+      let sourceRefs = Overrides.getObjectRef(source, override)
+      let data = JSON.stringify(sourceRefs, null, 2)
+      if (data.includes('{{EXTERNALLY_DEFINED}}')) {
+        let existingRefs = Overrides.getObjectRef(existing, override)
+        sourceRefs.forEach(sourceRef => {
+          if (existingRefs[0]) {
+            sourceRef[override] = existingRefs[0][override]
+          } else if (Array.isArray(sourceRef[override])) {
+            sourceRef[override] = []
+          } else if (typeof sourceRef[override] === 'object' && sourceRef[override]) {
+            sourceRef[override] = {}
+          } else {
+            sourceRef[override] = ''
+          }
+        })
+      }
+    })
+    return source
+  }
+}

--- a/lib/plugins/overrides.js
+++ b/lib/plugins/overrides.js
@@ -18,6 +18,46 @@ module.exports = class Overrides extends ErrorStash {
     return results
   }
 
+  static findParentObj (source, child, remove = false) {
+    let parent = null
+    const traverse = (obj, parentObj = null, parentKey = '') => {
+      for (const key in obj) {
+        if (obj[key] === child) {
+          parent = obj
+          if (remove && parentObj && parentKey) {
+            delete parentObj[parentKey]
+          }
+        } else if (Array.isArray(obj[key])) {
+          obj[key].forEach((element, index) => {
+            if (element === child) {
+              parent = obj[key]
+              if (remove) {
+                obj[key].splice(index, 1)
+              }
+            } else {
+              traverse(element)
+            }
+          })
+        } else if (typeof obj[key] === 'object' && obj[key]) {
+          traverse(obj[key], obj, key)
+        }
+      }
+    }
+    traverse(source)
+    return parent
+  }
+
+  static removeParentObj (source, child, levels) {
+    let parent = child
+    for (let i = 0; i < levels; i++) {
+      if (i + 1 === levels) {
+        parent = Overrides.findParentObj(source, parent, true)
+      } else {
+        parent = Overrides.findParentObj(source, parent, false)
+      }
+    }
+  }
+
   // When {{EXTERNALLY_DEFINED}} is found in the override value, retain the
   // existing value from GitHub.
   // Note:
@@ -26,7 +66,7 @@ module.exports = class Overrides extends ErrorStash {
   //   - The PUT method for rulesets (update) allows for multiple overrides.
   //   - The POST method for rulesets (create) allows for one override only.
   static removeOverrides (overrides, source, existing) {
-    overrides.forEach(override => {
+    Object.entries(overrides).forEach(([override, props]) => {
       let sourceRefs = Overrides.getObjectRef(source, override)
       let data = JSON.stringify(sourceRefs)
       if (data.includes('{{EXTERNALLY_DEFINED}}')) {
@@ -34,12 +74,14 @@ module.exports = class Overrides extends ErrorStash {
         sourceRefs.forEach(sourceRef => {
           if (existingRefs[0]) {
             sourceRef[override] = existingRefs[0][override]
-          } else if (Array.isArray(sourceRef[override])) {
+          } else if (props['action'] === 'delete') {
+            Overrides.removeParentObj(source, sourceRef[override], props['parents'])
+          } else if (props['type'] === 'array') {
             sourceRef[override] = []
-          } else if (typeof sourceRef[override] === 'object' && sourceRef[override]) {
+          } else if (props['type'] === 'dict') {
             sourceRef[override] = {}
           } else {
-            sourceRef[override] = ''
+            throw new Error(`Unknown type ${props['type']} for ${override}`)
           }
         })
       }

--- a/lib/plugins/overrides.js
+++ b/lib/plugins/overrides.js
@@ -21,8 +21,8 @@ module.exports = class Overrides extends ErrorStash {
   // When {{EXTERNALLY_DEFINED}} is found in the override value, retain the
   // existing value from GitHub.
   // Note:
-  //   - The admin settings could define multiple overrides, but the GitHub API
-  //     retains one only.
+  //   - The admin settings could define multiple status check rules for a
+  //     ruleset, but the GitHub API retains one only, i.e. the last one.
   //   - The PUT method for rulesets (update) allows for multiple overrides.
   //   - The POST method for rulesets (create) allows for one override only.
   static removeOverrides (overrides, source, existing) {

--- a/lib/plugins/overrides.js
+++ b/lib/plugins/overrides.js
@@ -1,7 +1,8 @@
 const ErrorStash = require('./errorStash')
 
 module.exports = class Overrides extends ErrorStash {
-  static getObjectRef (data, dataKey) {
+  // Find all object references for a given key from the source.
+  static getObjectRef (source, dataKey) {
     const results = []
     const traverse = (obj) => {
       for (const key in obj) {
@@ -14,11 +15,13 @@ module.exports = class Overrides extends ErrorStash {
         }
       }
     }
-    traverse(data)
+    traverse(source)
     return results
   }
 
-  static findParentObj (source, child, remove = false) {
+  // Find the parent object reference for a given child object and
+  // allow the option to remove the parent object from the source.
+  static getParentObjectRef (source, child, remove = false) {
     let parent = null
     const traverse = (obj, parentObj = null, parentKey = '') => {
       for (const key in obj) {
@@ -34,9 +37,9 @@ module.exports = class Overrides extends ErrorStash {
               if (remove) {
                 obj[key].splice(index, 1)
               }
-            } else {
-              traverse(element)
+              return
             }
+            traverse(element)
           })
         } else if (typeof obj[key] === 'object' && obj[key]) {
           traverse(obj[key], obj, key)
@@ -47,19 +50,23 @@ module.exports = class Overrides extends ErrorStash {
     return parent
   }
 
-  static removeParentObj (source, child, levels) {
+  // Traverse the source and remove the top level parent object
+  static removeTopLevelParent (source, child, levels) {
     let parent = child
     for (let i = 0; i < levels; i++) {
       if (i + 1 === levels) {
-        parent = Overrides.findParentObj(source, parent, true)
+        parent = Overrides.getParentObjectRef(source, parent, true)
       } else {
-        parent = Overrides.findParentObj(source, parent, false)
+        parent = Overrides.getParentObjectRef(source, parent, false)
       }
     }
   }
 
   // When {{EXTERNALLY_DEFINED}} is found in the override value, retain the
-  // existing value from GitHub.
+  // existing value from GitHub. If GitHub does not have a value, then
+  //   - A/ If the action is delete, then remove the top level parent object
+  //        and the override value from the source.
+  //   - B/ Otherwise, initialise the value to an appropriate value.
   // Note:
   //   - The admin settings could define multiple status check rules for a
   //     ruleset, but the GitHub API retains one only, i.e. the last one.
@@ -69,13 +76,15 @@ module.exports = class Overrides extends ErrorStash {
     Object.entries(overrides).forEach(([override, props]) => {
       let sourceRefs = Overrides.getObjectRef(source, override)
       let data = JSON.stringify(sourceRefs)
+
       if (data.includes('{{EXTERNALLY_DEFINED}}')) {
         let existingRefs = Overrides.getObjectRef(existing, override)
         sourceRefs.forEach(sourceRef => {
           if (existingRefs[0]) {
             sourceRef[override] = existingRefs[0][override]
           } else if (props['action'] === 'delete') {
-            Overrides.removeParentObj(source, sourceRef[override], props['parents'])
+            Overrides.removeTopLevelParent(source, sourceRef[override], props['parents'])
+            delete sourceRef[override]
           } else if (props['type'] === 'array') {
             sourceRef[override] = []
           } else if (props['type'] === 'dict') {

--- a/lib/plugins/rulesets.js
+++ b/lib/plugins/rulesets.js
@@ -3,9 +3,13 @@ const NopCommand = require('../nopcommand')
 const MergeDeep = require('../mergeDeep')
 const Overrides = require('./overrides')
 const ignorableFields = []
-const overrides = [
-  'required_status_checks',
-]
+const overrides = {
+  'required_status_checks': {
+    'action': 'delete',
+    'parents': 3,
+    'type': 'dict'
+  },
+}
 
 const version = {
   'X-GitHub-Api-Version': '2022-11-28'

--- a/lib/plugins/rulesets.js
+++ b/lib/plugins/rulesets.js
@@ -2,6 +2,9 @@ const Diffable = require('./diffable')
 const NopCommand = require('../nopcommand')
 const MergeDeep = require('../mergeDeep')
 const ignorableFields = []
+const overrides = [
+  'required_status_checks',
+]
 
 const version = {
   'X-GitHub-Api-Version': '2022-11-28'
@@ -92,6 +95,51 @@ module.exports = class Rulesets extends Diffable {
     return merged.hasChanges
   }
 
+  getObjectRef (data, dataKey) {
+    const results = []
+    const traverse = (obj) => {
+      for (const key in obj) {
+        if (key === dataKey) {
+          results.push(obj)
+        } else if (Array.isArray(obj[key])) {
+          obj[key].forEach(element => traverse(element))
+        } else if (typeof obj[key] === 'object' && obj[key]) {
+          traverse(obj[key])
+        }
+      }
+    }
+    traverse(data)
+    return results
+  }
+
+  // When {{EXTERNALLY_DEFINED}} is found in the override value, retain the
+  // existing value from GitHub.
+  // Note:
+  //   - The admin settings could define multiple overrides, but the GitHub API
+  //     retains one only.
+  //   - The PUT method for rulesets (update) allows for multiple overrides.
+  //   - The POST method for rulesets (create) allows for one override only.
+  removeOverrides (source, existing) {
+    overrides.forEach(override => {
+      let sourceRefs = this.getObjectRef(source, override)
+      let data = JSON.stringify(sourceRefs, null, 2)
+      if (data.includes('{{EXTERNALLY_DEFINED}}')) {
+        let existingRefs = this.getObjectRef(existing, override)
+        sourceRefs.forEach(sourceRef => {
+          if (existingRefs[0]) {
+            sourceRef[override] = existingRefs[0][override]
+          } else if (Array.isArray(sourceRef[override])) {
+            sourceRef[override] = []
+          } else if (typeof sourceRef[override] === 'object' && sourceRef[override]) {
+            sourceRef[override] = {}
+          } else {
+            sourceRef[override] = ''
+          }
+        })
+      }
+    })
+  }
+
   update (existing, attrs) {
     const parms = this.wrapAttrs(Object.assign({ id: existing.id }, attrs))
     if (this.scope === 'org') {
@@ -100,6 +148,7 @@ module.exports = class Rulesets extends Diffable {
           new NopCommand(this.constructor.name, this.repo, this.github.request.endpoint('PUT /orgs/{org}/rulesets/{id}', parms), 'Update Ruleset')
         ])
       }
+      this.removeOverrides(parms, existing)
       this.log.debug(`Updating Ruleset with the following values ${JSON.stringify(parms, null, 2)}`)
       return this.github.request('PUT /orgs/{org}/rulesets/{id}', parms).then(res => {
         this.log(`Ruleset updated successfully ${JSON.stringify(res.url)}`)
@@ -113,6 +162,7 @@ module.exports = class Rulesets extends Diffable {
           new NopCommand(this.constructor.name, this.repo, this.github.request.endpoint('PUT /repos/{owner}/{repo}/rulesets/{id}', parms), 'Update Ruleset')
         ])
       }
+      this.removeOverrides(parms, existing)
       this.log.debug(`Updating Ruleset with the following values ${JSON.stringify(parms, null, 2)}`)
       return this.github.request('PUT /repos/{owner}/{repo}/rulesets/{id}', parms).then(res => {
         this.log(`Ruleset updated successfully ${JSON.stringify(res.url)}`)
@@ -130,6 +180,7 @@ module.exports = class Rulesets extends Diffable {
           new NopCommand(this.constructor.name, this.repo, this.github.request.endpoint('POST /orgs/{org}/rulesets', this.wrapAttrs(attrs)), 'Create Ruleset')
         ])
       }
+      this.removeOverrides(attrs, {})
       this.log.debug(`Creating Rulesets with the following values ${JSON.stringify(attrs, null, 2)}`)
       return this.github.request('POST /orgs/{org}/rulesets', this.wrapAttrs(attrs)).then(res => {
         this.log(`Ruleset created successfully ${JSON.stringify(res.url)}`)
@@ -143,6 +194,7 @@ module.exports = class Rulesets extends Diffable {
           new NopCommand(this.constructor.name, this.repo, this.github.request.endpoint('POST /repos/{owner}/{repo}/rulesets', this.wrapAttrs(attrs)), 'Create Ruleset')
         ])
       }
+      this.removeOverrides(attrs, {})
       this.log.debug(`Creating Rulesets with the following values ${JSON.stringify(attrs, null, 2)}`)
       return this.github.request('POST /repos/{owner}/{repo}/rulesets', this.wrapAttrs(attrs)).then(res => {
         this.log(`Ruleset created successfully ${JSON.stringify(res.url)}`)

--- a/lib/plugins/rulesets.js
+++ b/lib/plugins/rulesets.js
@@ -1,6 +1,7 @@
 const Diffable = require('./diffable')
 const NopCommand = require('../nopcommand')
 const MergeDeep = require('../mergeDeep')
+const Overrides = require('./overrides')
 const ignorableFields = []
 const overrides = [
   'required_status_checks',
@@ -95,51 +96,6 @@ module.exports = class Rulesets extends Diffable {
     return merged.hasChanges
   }
 
-  getObjectRef (data, dataKey) {
-    const results = []
-    const traverse = (obj) => {
-      for (const key in obj) {
-        if (key === dataKey) {
-          results.push(obj)
-        } else if (Array.isArray(obj[key])) {
-          obj[key].forEach(element => traverse(element))
-        } else if (typeof obj[key] === 'object' && obj[key]) {
-          traverse(obj[key])
-        }
-      }
-    }
-    traverse(data)
-    return results
-  }
-
-  // When {{EXTERNALLY_DEFINED}} is found in the override value, retain the
-  // existing value from GitHub.
-  // Note:
-  //   - The admin settings could define multiple overrides, but the GitHub API
-  //     retains one only.
-  //   - The PUT method for rulesets (update) allows for multiple overrides.
-  //   - The POST method for rulesets (create) allows for one override only.
-  removeOverrides (source, existing) {
-    overrides.forEach(override => {
-      let sourceRefs = this.getObjectRef(source, override)
-      let data = JSON.stringify(sourceRefs, null, 2)
-      if (data.includes('{{EXTERNALLY_DEFINED}}')) {
-        let existingRefs = this.getObjectRef(existing, override)
-        sourceRefs.forEach(sourceRef => {
-          if (existingRefs[0]) {
-            sourceRef[override] = existingRefs[0][override]
-          } else if (Array.isArray(sourceRef[override])) {
-            sourceRef[override] = []
-          } else if (typeof sourceRef[override] === 'object' && sourceRef[override]) {
-            sourceRef[override] = {}
-          } else {
-            sourceRef[override] = ''
-          }
-        })
-      }
-    })
-  }
-
   update (existing, attrs) {
     const parms = this.wrapAttrs(Object.assign({ id: existing.id }, attrs))
     if (this.scope === 'org') {
@@ -148,7 +104,7 @@ module.exports = class Rulesets extends Diffable {
           new NopCommand(this.constructor.name, this.repo, this.github.request.endpoint('PUT /orgs/{org}/rulesets/{id}', parms), 'Update Ruleset')
         ])
       }
-      this.removeOverrides(parms, existing)
+      Overrides.removeOverrides(overrides, parms, existing)
       this.log.debug(`Updating Ruleset with the following values ${JSON.stringify(parms, null, 2)}`)
       return this.github.request('PUT /orgs/{org}/rulesets/{id}', parms).then(res => {
         this.log(`Ruleset updated successfully ${JSON.stringify(res.url)}`)
@@ -162,7 +118,7 @@ module.exports = class Rulesets extends Diffable {
           new NopCommand(this.constructor.name, this.repo, this.github.request.endpoint('PUT /repos/{owner}/{repo}/rulesets/{id}', parms), 'Update Ruleset')
         ])
       }
-      this.removeOverrides(parms, existing)
+      Overrides.removeOverrides(overrides, parms, existing)
       this.log.debug(`Updating Ruleset with the following values ${JSON.stringify(parms, null, 2)}`)
       return this.github.request('PUT /repos/{owner}/{repo}/rulesets/{id}', parms).then(res => {
         this.log(`Ruleset updated successfully ${JSON.stringify(res.url)}`)
@@ -180,7 +136,7 @@ module.exports = class Rulesets extends Diffable {
           new NopCommand(this.constructor.name, this.repo, this.github.request.endpoint('POST /orgs/{org}/rulesets', this.wrapAttrs(attrs)), 'Create Ruleset')
         ])
       }
-      this.removeOverrides(attrs, {})
+      Overrides.removeOverrides(overrides, attrs, {})
       this.log.debug(`Creating Rulesets with the following values ${JSON.stringify(attrs, null, 2)}`)
       return this.github.request('POST /orgs/{org}/rulesets', this.wrapAttrs(attrs)).then(res => {
         this.log(`Ruleset created successfully ${JSON.stringify(res.url)}`)
@@ -194,7 +150,7 @@ module.exports = class Rulesets extends Diffable {
           new NopCommand(this.constructor.name, this.repo, this.github.request.endpoint('POST /repos/{owner}/{repo}/rulesets', this.wrapAttrs(attrs)), 'Create Ruleset')
         ])
       }
-      this.removeOverrides(attrs, {})
+      Overrides.removeOverrides(overrides, attrs, {})
       this.log.debug(`Creating Rulesets with the following values ${JSON.stringify(attrs, null, 2)}`)
       return this.github.request('POST /repos/{owner}/{repo}/rulesets', this.wrapAttrs(attrs)).then(res => {
         this.log(`Ruleset created successfully ${JSON.stringify(res.url)}`)

--- a/test/unit/lib/plugins/branches.test.js
+++ b/test/unit/lib/plugins/branches.test.js
@@ -165,7 +165,7 @@ describe('Branches', () => {
       })
     })
 
-    describe('when {{EXTERNALLY_DEFINED}} is present in "required_status_checks" and no status checks exists in GitHub', () => {
+    describe('when {{EXTERNALLY_DEFINED}} is present in "required_status_checks" and no status checks exist in GitHub', () => {
       it('it initialises the status checks with an empty list', () => {
         const plugin = configure(
           [{
@@ -194,7 +194,7 @@ describe('Branches', () => {
       })
     })
 
-    describe('when {{EXTERNALLY_DEFINED}} is present in "required_status_checks" and status checks exists in GitHub', () => {
+    describe('when {{EXTERNALLY_DEFINED}} is present in "required_status_checks" and status checks exist in GitHub', () => {
       it('it retains the status checks from GitHub', () => {
         github.repos.getBranchProtection = jest.fn().mockResolvedValue({
           data: {

--- a/test/unit/lib/plugins/branches.test.js
+++ b/test/unit/lib/plugins/branches.test.js
@@ -181,7 +181,7 @@ describe('Branches', () => {
 
         return plugin.sync().then(() => {
           expect(github.repos.updateBranchProtection).toHaveBeenCalledWith({
-            owner: 'jitran',
+            owner: 'bkeepers',
             repo: 'test',
             branch: 'main',
             required_status_checks: {
@@ -220,7 +220,7 @@ describe('Branches', () => {
 
         return plugin.sync().then(() => {
           expect(github.repos.updateBranchProtection).toHaveBeenCalledWith({
-            owner: 'jitran',
+            owner: 'bkeepers',
             repo: 'test',
             branch: 'main',
             required_status_checks: {

--- a/test/unit/lib/plugins/rulesets.test.js
+++ b/test/unit/lib/plugins/rulesets.test.js
@@ -1,0 +1,257 @@
+/* eslint-disable no-undef */
+
+const { when } = require('jest-when')
+const Rulesets = require('../../../../lib/plugins/rulesets')
+const version = {
+  'X-GitHub-Api-Version': '2022-11-28'
+}
+
+function generateRequestRuleset(id, name, checks) {
+  return {
+    id: id,
+    name: name,
+    source_type: 'Repository',
+    target: 'branch',
+    enforcement: 'active',
+    conditions: {
+      ref_name: {
+        include: ['~ALL'],
+        exclude: []
+      }
+    },
+    rules: [
+      {
+        type: 'required_status_checks',
+        parameters: {
+          strict_required_status_checks_policy: true,
+          required_status_checks: checks
+        }
+      }
+    ]
+  }
+}
+
+function generateResponseRuleset(id, name, checks) {
+  return {
+    id: id,
+    name: name,
+    source_type: 'Repository',
+    target: 'branch',
+    enforcement: 'active',
+    conditions: {
+      ref_name: {
+        include: ['~ALL'],
+        exclude: []
+      }
+    },
+    owner: 'jitran',
+    repo: 'test',
+    rules: [
+      {
+        type: 'required_status_checks',
+        parameters: {
+          strict_required_status_checks_policy: true,
+          required_status_checks: checks
+        }
+      }
+    ],
+    headers: version,
+  }
+}
+
+describe('Rulesets', () => {
+  let github
+  const log = jest.fn()
+  log.debug = jest.fn()
+  log.error = jest.fn()
+
+  function configure (config) {
+    const noop = false
+    const errors = []
+    return new Rulesets(noop, github, { owner: 'jitran', repo: 'test' }, config, log, errors)
+  }
+
+  beforeEach(() => {
+    github = {
+      repos: {
+        get: jest.fn().mockResolvedValue({
+          data: {
+            default_branch: 'main'
+          }
+        })
+      },
+      request: jest.fn().mockImplementation(() => Promise.resolve('request')),
+    }
+    
+    github.request.endpoint = {
+      merge: jest.fn().mockReturnValue({
+        method: 'GET',
+        url: '/repos/jitran/test/rulesets',
+        headers: version
+        })
+      }
+  })
+
+  describe('sync', () => {
+    it('syncs ruleset settings', () => {
+      // Mock the GitHub API response
+      github.paginate = jest.fn().mockResolvedValue([])
+
+      // Initialise safe-settings
+      const plugin = configure(
+        [
+          generateRequestRuleset(
+            1,
+            'All branches',
+            [
+              { context: 'Status Check 1' },
+              { context: 'Status Check 2' }
+            ]
+          )
+        ]
+      )
+
+      return plugin.sync().then(() => {
+        expect(github.request).toHaveBeenLastCalledWith(
+          'POST /repos/{owner}/{repo}/rulesets',
+          generateResponseRuleset(
+            1,
+            'All branches',
+            [
+              { context: 'Status Check 1' },
+              { context: 'Status Check 2' }
+            ]
+          )
+        )
+      })
+    })
+  })
+
+  describe('when {{EXTERNALLY_DEFINED}} is present in "required_status_checks" and no status checks exists in GitHub', () => {
+    it('it initialises the status checks with an empty list', () => {
+      // Mock the GitHub API response
+      github.paginate = jest.fn().mockResolvedValue([])
+
+      // Initialise safe-settings
+      const plugin = configure(
+        [
+          generateRequestRuleset(
+            1,
+            'All branches',
+            [
+              { context: 'Status Check 1' },
+              { context: '{{EXTERNALLY_DEFINED}}' }
+            ]
+          )
+        ]
+      )
+
+      return plugin.sync().then(() => {
+        expect(github.request).toHaveBeenLastCalledWith(
+          'POST /repos/{owner}/{repo}/rulesets',
+          generateResponseRuleset(
+            1,
+            'All branches',
+            []
+          )
+        )
+      })
+    })
+  })
+
+  describe('when {{EXTERNALLY_DEFINED}} is present in "required_status_checks" and status checks exists in GitHub', () => {
+    it('it retains the status checks from GitHub and everything else is reset to the safe-settings', () => {
+      // Mock the GitHub API response
+      github.paginate = jest.fn().mockResolvedValue([
+        generateRequestRuleset(
+          1,
+          'All branches 1',
+          [
+            { context: 'Custom Check 1' },
+            { context: 'Custom Check 2' }
+          ]
+        ),
+        generateRequestRuleset(
+          2,
+          'All branches 2',
+          [
+            { context: 'Custom Check 3' },
+            { context: 'Custom Check 4' }
+          ]
+        ),
+        generateRequestRuleset(
+          3,
+          'All branches 3',
+          [
+            { context: 'Custom Check 5' },
+            { context: 'Custom Check 6' }
+          ]
+        )
+      ])
+
+      // Initialise safe-settings
+      const plugin = configure(
+        [
+          generateRequestRuleset(
+            1,
+            'All branches 1',
+            [
+              { context: 'Status Check 1' },
+              { context: '{{EXTERNALLY_DEFINED}}' }
+            ]
+          ),
+          generateRequestRuleset(
+            2,
+            'All branches 2',
+            [
+              { context: 'Status Check 1' },
+              { context: 'Status Check 2' }
+            ]
+          ),
+          generateRequestRuleset(
+            3,
+            'All branches 3',
+            []
+          )
+        ]
+      )
+
+      return plugin.sync().then(() => {
+        expect(github.request).toHaveBeenNthCalledWith(
+          1,
+          'PUT /repos/{owner}/{repo}/rulesets/{id}',
+          generateResponseRuleset(
+            1,
+            'All branches 1',
+            [
+              { context: 'Custom Check 1' },
+              { context: 'Custom Check 2' }
+            ]
+          )
+        )
+        expect(github.request).toHaveBeenNthCalledWith(
+          2,
+          'PUT /repos/{owner}/{repo}/rulesets/{id}',
+          generateResponseRuleset(
+            2,
+            'All branches 2',
+            [
+              { context: 'Status Check 1' },
+              { context: 'Status Check 2' }
+            ]
+          )
+        )
+        expect(github.request).toHaveBeenNthCalledWith(
+          3,
+          'PUT /repos/{owner}/{repo}/rulesets/{id}',
+          generateResponseRuleset(
+            3,
+            'All branches 3',
+            []
+          )
+        )
+      })
+    })
+  })
+  // TODO: Write tests for org rulesets
+})

--- a/test/unit/lib/plugins/rulesets.test.js
+++ b/test/unit/lib/plugins/rulesets.test.js
@@ -22,11 +22,10 @@ const org_conditions = {
   }
 }
 
-function generateRequestRuleset(id, name, conditions, checks) {
+function generateRequestRuleset(id, name, conditions, checks, org=false) {
   response = {
     id: id,
     name: name,
-    source_type: 'Repository',
     target: 'branch',
     enforcement: 'active',
     conditions: conditions,
@@ -40,6 +39,11 @@ function generateRequestRuleset(id, name, conditions, checks) {
       }
     ]
   }
+  if (org) {
+    response.source_type = 'Organization'
+  } else {
+    response.source_type = 'Repository'
+  }
   return response
 }
 
@@ -47,7 +51,6 @@ function generateResponseRuleset(id, name, conditions, checks, org=false) {
   response = {
     id: id,
     name: name,
-    source_type: 'Repository',
     target: 'branch',
     enforcement: 'active',
     conditions: conditions,
@@ -63,8 +66,10 @@ function generateResponseRuleset(id, name, conditions, checks, org=false) {
     headers: version,
   }
   if (org) {
+    response.source_type = 'Organization'
     response.org = 'jitran'
   } else {
+    response.source_type = 'Repository'
     response.owner = 'jitran'
     response.repo = 'test'
   }
@@ -100,8 +105,9 @@ describe('Rulesets', () => {
         method: 'GET',
         url: '/repos/jitran/test/rulesets',
         headers: version
-        })
-      }
+        }
+      )
+    }
   })
 
   describe('sync', () => {
@@ -141,7 +147,7 @@ describe('Rulesets', () => {
     })
   })
 
-  describe('when {{EXTERNALLY_DEFINED}} is present in "required_status_checks" and no status checks exists in GitHub', () => {
+  describe('when {{EXTERNALLY_DEFINED}} is present in "required_status_checks" and no status checks exist in GitHub', () => {
     it('it initialises the status checks with an empty list', () => {
       // Mock the GitHub API response
       github.paginate = jest.fn().mockResolvedValue([])
@@ -175,7 +181,7 @@ describe('Rulesets', () => {
     })
   })
 
-  describe('when {{EXTERNALLY_DEFINED}} is present in "required_status_checks" and status checks exists in GitHub', () => {
+  describe('when {{EXTERNALLY_DEFINED}} is present in "required_status_checks" and status checks exist in GitHub', () => {
     it('it retains the status checks from GitHub and everything else is reset to the safe-settings', () => {
       // Mock the GitHub API response
       github.paginate = jest.fn().mockResolvedValue([
@@ -294,7 +300,8 @@ describe('Rulesets', () => {
             [
               { context: 'Status Check 1' },
               { context: 'Status Check 2' }
-            ]
+            ],
+            true
           )
         ],
         'org'
@@ -318,7 +325,7 @@ describe('Rulesets', () => {
     })
   })
 
-  describe('[org] when {{EXTERNALLY_DEFINED}} is present in "required_status_checks" and no status checks exists in GitHub', () => {
+  describe('[org] when {{EXTERNALLY_DEFINED}} is present in "required_status_checks" and no status checks exist in GitHub', () => {
     it('it initialises the status checks with an empty list', () => {
       // Mock the GitHub API response
       github.paginate = jest.fn().mockResolvedValue([])
@@ -333,7 +340,8 @@ describe('Rulesets', () => {
             [
               { context: 'Status Check 1' },
               { context: '{{EXTERNALLY_DEFINED}}' }
-            ]
+            ],
+            true
           )
         ],
         'org'
@@ -354,7 +362,7 @@ describe('Rulesets', () => {
     })
   })
 
-  describe('[org] when {{EXTERNALLY_DEFINED}} is present in "required_status_checks" and status checks exists in GitHub', () => {
+  describe('[org] when {{EXTERNALLY_DEFINED}} is present in "required_status_checks" and status checks exist in GitHub', () => {
     it('it retains the status checks from GitHub', () => {
       // Mock the GitHub API response
       github.paginate = jest.fn().mockResolvedValue([
@@ -365,7 +373,8 @@ describe('Rulesets', () => {
           [
             { context: 'Custom Check 1' },
             { context: 'Custom Check 2' }
-          ]
+          ],
+          true
         )
       ])
 
@@ -379,7 +388,8 @@ describe('Rulesets', () => {
             [
               { context: 'Status Check 1' },
               { context: '{{EXTERNALLY_DEFINED}}' }
-            ]
+            ],
+            true
           )
         ],
         'org'

--- a/test/unit/lib/plugins/rulesets.test.js
+++ b/test/unit/lib/plugins/rulesets.test.js
@@ -23,7 +23,7 @@ const org_conditions = {
 }
 
 function generateRequestRuleset(id, name, conditions, checks, org=false) {
-  response = {
+  request = {
     id: id,
     name: name,
     target: 'branch',
@@ -40,11 +40,14 @@ function generateRequestRuleset(id, name, conditions, checks, org=false) {
     ]
   }
   if (org) {
-    response.source_type = 'Organization'
+    request.source_type = 'Organization'
   } else {
-    response.source_type = 'Repository'
+    request.source_type = 'Repository'
   }
-  return response
+  if (checks.length === 0) {
+    request.rules = []
+  }
+  return request
 }
 
 function generateResponseRuleset(id, name, conditions, checks, org=false) {
@@ -72,6 +75,9 @@ function generateResponseRuleset(id, name, conditions, checks, org=false) {
     response.source_type = 'Repository'
     response.owner = 'jitran'
     response.repo = 'test'
+  }
+  if (checks.length === 0) {
+    response.rules = []
   }
   return response
 }


### PR DESCRIPTION
### Background
There have been a number of requests from users who have implemented branch protection rules and rulesets across their organisations, but would like their PR status checks to be defined outside of safe settings.

When these rules are defined at the repository or suborg level, it's not so bad, as the safe settings PR status checks only affect a subset of repositories. Users have a bit more control over their safe settings configuration.

When the rules are defined at the org level, it's a bit more problematic, as the safe settings PR status checks affect all repositories in the org.

### Changes
- Added the ability for branch protection rules and rulesets' status checks to be managed outside of safe settings.
- When users specify `{{EXTERNALLY_DEFINED}}` in the status checks for their branch protection rules or rulesets, safe settings will not revert status checks in GitHub.
- Created an Overrides module to handle externally defined settings.
- Updated usage documentation in the README.
- Added unit tests for the new functionality.

### Tests
Ensured all unit tests pass.

#### Manual testing with rulesets (repo, suborg, and org levels)
The following was tested in sequential order:
1. Started with no rulesets in GitHub for a repository
1. Created a new safe setting for a ruleset that had `{{EXTERNALLY_DEFINED}}`defined  in the status checks
   - Ruleset was deployed with an empty list of status checks
1. Added custom status checks to the new ruleset via GitHub UI
   - The ruleset's custom status checks in GitHub were preserved
1. Updated the ruleset's status checks via the GitHub UI
   - The ruleset's  custom status checks in GitHub were preserved
1. Added a new status check to the existing ruleset in safe settings and left `{{EXTERNALLY_DEFINED}}` in the list
   - The ruleset's  custom status checks in GitHub were preserved
1. Removed all status checks from the ruleset via the GitHub UI
   - The ruleset's empty status checks in GitHub was preserved
1. Removed `{{EXTERNALLY_DEFINED}}` from the existing ruleset's status checks in safe settings
   - The ruleset's status checks in GitHub was reverted to the status checks from safe settings
1. Removed all status checks from the existing ruleset in safe settings
   - The ruleset's status checks in GitHub was reverted to the status checks from safe settings
1. Removed the ruleset from GitHub
   - Safe settings restored the ruleset
1. Added custom status checks to the ruleset via GitHub UI
   - The ruleset's status checks was reverted to the status checks from safe settings
1. Added a completely new ruleset (branch|tag|push) via GitHub UI
   - Safe settings removed all new rulesets

#### Manual testing with branch protection rules (repo, suborg, and org levels)
The following was tested in sequential order:
1. Deleted all branch protection rules from a repository
1. Created two branch protection rules in safe settings; the first rule had `{{EXTERNALLY_DEFINED}}` in the status checks, and the second rule had two status checks defined
   - Two branch protection rules were deployed into GitHub, where the first had no status checks, and the second had two status checks defined.
1. Updated the status checks for the first rule via GitHub UI
   - The custom status checks for the first rule in GitHub were preserved
1. Updated the status checks for the second rule via GitHub UI
   - The custom status checks for the second rule in GitHub were reverted back to the safe settings
