### PR TITLE
fix: prevent error on null input in appendToResults

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -858,13 +858,15 @@ ${this.results.reduce((x, y) => {
     }
   }
 
-  appendToResults(res) {
-    if (this.nop) {
-      //Remove nulls and undefined from the results
-      const results = res.flat(3).filter(r => r)
-      
-      this.results = this.results.concat(results)
+  appendToResults (res) {
+    if (!this.nop || !res) {
+      return
     }
+
+    const input = (!Array.isArray(res) && this.isObject(res)) ? [res] : res
+    const results = input.flat(3).filter(Boolean)
+
+    this.results = this.results.concat(results)
   }
 
   async getReposForTeam(teamslug) {


### PR DESCRIPTION
## Description

Fixes #744

- Add null check in appendToResults to prevent runtime errors when handling null inputs.

I think this is also related to #734 (PR linked #738) since currently Milestones and Custom Properties plugins doesn't return nop results.



### Questions

@decyjphr Do you know why do we use `flat(3)` specifically? I haven't investigated much, but wondering if we could use `flat(Infinity)` instead (though we might need a guard clause) or something else more clear.
