### PR TITLE
feat: separate runtime and deployment configs

### DIFF
--- a/lib/deploymentConfig.js
+++ b/lib/deploymentConfig.js
@@ -2,50 +2,43 @@ const yaml = require('js-yaml')
 const fs = require('fs')
 const env = require('./env')
 
+function isNonEmptyArray (obj) {
+  return Array.isArray(obj) && obj.length > 0
+}
+
 /**
  * Class representing a deployment config.
- * It is a singleton (class object) for the deployment settings.
- * The settings are loaded from the deployment-settings.yml file during initialization and stored as static properties.
+ * The settings are loaded from the deployment-settings.yml file.
  */
-class DeploymentConfig {
-  // static config
-  static configvalidators = {}
-  static overridevalidators = {}
+module.exports = class DeploymentConfig {
+  constructor (context, configPath) {
+    const deploymentConfigPath = configPath ?? env.DEPLOYMENT_CONFIG_FILE
 
-  static {
-    const deploymentConfigPath = process.env.DEPLOYMENT_CONFIG_FILE ? process.env.DEPLOYMENT_CONFIG_FILE : 'deployment-settings.yml'
+    let deploymentConfig = {}
     if (fs.existsSync(deploymentConfigPath)) {
-      this.config = yaml.load(fs.readFileSync(deploymentConfigPath)) || {}
+      deploymentConfig = yaml.load(fs.readFileSync(deploymentConfigPath)) ?? {}
     } else {
-      this.config = { restrictedRepos: ['admin', '.github', 'safe-settings'] }
+      context.log.info(`No deployment settings found at ${deploymentConfigPath}`)
     }
 
-    const overridevalidators = this.config.overridevalidators || []
-    if (this.isNonEmptyArray(overridevalidators)) {
-      for (const validator of overridevalidators) {
+    this.overridevalidators = {}
+    if (isNonEmptyArray(deploymentConfig.overridevalidators)) {
+      for (const validator of deploymentConfig.overridevalidators) {
         // eslint-disable-next-line no-new-func
         const f = new Function('baseconfig', 'overrideconfig', 'githubContext', validator.script)
         this.overridevalidators[validator.plugin] = { canOverride: f, error: validator.error }
       }
     }
-    const configvalidators = this.config.configvalidators || []
-    if (this.isNonEmptyArray(configvalidators)) {
-      for (const validator of configvalidators) {
+
+    this.configvalidators = {}
+    if (isNonEmptyArray(deploymentConfig.configvalidators)) {
+      for (const validator of deploymentConfig.configvalidators) {
         // eslint-disable-next-line no-new-func
         const f = new Function('baseconfig', 'githubContext', validator.script)
         this.configvalidators[validator.plugin] = { isValid: f, error: validator.error }
       }
     }
-  }
 
-  static isNonEmptyArray (obj) {
-    return Array.isArray(obj) && obj.length > 0
-  }
-
-  // eslint-disable-next-line no-useless-constructor
-  constructor (nop, context, repo, config, ref, suborg) {
+    this.restrictedRepos = deploymentConfig.restrictedRepos ?? ['admin', '.github', 'safe-settings']
   }
 }
-DeploymentConfig.FILE_NAME = `${env.CONFIG_PATH}/settings.yml`
-
-module.exports = DeploymentConfig

--- a/lib/mergeDeep.js
+++ b/lib/mergeDeep.js
@@ -6,12 +6,14 @@ const NAME_USERNAME_PROPERTY = item => NAME_FIELDS.find(prop => Object.prototype
 const GET_NAME_USERNAME_PROPERTY = item => { if (NAME_USERNAME_PROPERTY(item)) return item[NAME_USERNAME_PROPERTY(item)] }
 
 class MergeDeep {
-  constructor (log, github, ignorableFields = [], configvalidators = {}, overridevalidators = {}) {
+  constructor (log, github, ignorableFields = []) {
     this.log = log
     this.github = github
     this.ignorableFields = ignorableFields
-    this.configvalidators = DeploymentConfig.configvalidators
-    this.overridevalidators = DeploymentConfig.overridevalidators
+
+    const deploymentConfig = new DeploymentConfig({ log })
+    this.configvalidators = deploymentConfig.configvalidators
+    this.overridevalidators = deploymentConfig.overridevalidators
   }
 
   isObjectNotArray (item) {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -10,6 +10,7 @@ const env = require('./env')
 const CONFIG_PATH = env.CONFIG_PATH
 const eta = new Eta({ views: path.join(__dirname) })
 const SCOPE = { ORG: 'org', REPO: 'repo' } // Determine if the setting is a org setting or repo setting
+
 class Settings {
   static async syncAll (nop, context, repo, config, ref) {
     const settings = new Settings(nop, context, repo, config, ref)
@@ -65,7 +66,6 @@ class Settings {
     this.installation_id = context.payload.installation.id
     this.github = context.octokit
     this.repo = repo
-    this.config = config
     this.nop = nop
     this.suborgChange = !!suborg
     // If suborg config has been updated, do not load the entire suborg config, and only process repos restricted to it.
@@ -75,26 +75,15 @@ class Settings {
     this.log = context.log
     this.results = []
     this.errors = []
-    this.configvalidators = {}
-    this.overridevalidators = {}
-    const overridevalidators = config.overridevalidators
-    if (this.isIterable(overridevalidators)) {
-      for (const validator of overridevalidators) {
-        // eslint-disable-next-line no-new-func
-        const f = new Function('baseconfig', 'overrideconfig', 'githubContext', validator.script)
-        this.overridevalidators[validator.plugin] = { canOverride: f, error: validator.error }
-      }
-    }
-    const configvalidators = config.configvalidators
-    if (this.isIterable(configvalidators)) {
-      for (const validator of configvalidators) {
-        this.log.debug(`Logging each script: ${typeof validator.script}`)
-        // eslint-disable-next-line no-new-func
-        const f = new Function('baseconfig', 'githubContext', validator.script)
-        this.configvalidators[validator.plugin] = { isValid: f, error: validator.error }
-      }
-    }
-    this.mergeDeep = new MergeDeep(this.log, this.github, [], this.configvalidators, this.overridevalidators)
+
+    this.mergeDeep = new MergeDeep(this.log, this.github, [])
+
+    this.config = config.runtimeConfig
+
+    // these can only be defined in the deployment config
+    this.overridevalidators = config.deploymentConfig.overridevalidators
+    this.configvalidators = config.deploymentConfig.configvalidators
+    this.restrictedRepos = config.deploymentConfig.restrictedRepos
   }
 
   // Create a check in the Admin repo for safe-settings.
@@ -449,7 +438,7 @@ ${this.results.reduce((x, y) => {
   }
 
   isRestricted(repoName) {
-    const restrictedRepos = this.config.restrictedRepos
+    const restrictedRepos = this.restrictedRepos
     // Skip configuring any restricted repos
     if (Array.isArray(restrictedRepos)) {
       // For backward compatibility support the old format
@@ -890,14 +879,6 @@ ${this.results.reduce((x, y) => {
 
   isObject (item) {
     return (item && typeof item === 'object' && !Array.isArray(item))
-  }
-
-  isIterable(obj) {
-    // checks for null and undefined
-    if (obj == null) {
-      return false
-    }
-    return typeof obj[Symbol.iterator] === 'function'
   }
 }
 

--- a/test/unit/lib/deploymentConfig.test.js
+++ b/test/unit/lib/deploymentConfig.test.js
@@ -1,0 +1,62 @@
+const DeploymentConfig = require('../../../lib/deploymentConfig')
+
+const defaultConfig = {
+  configvalidators: {},
+  overridevalidators: {},
+  restrictedRepos: ['admin', '.github', 'safe-settings']
+}
+
+const context = { log: { info: jest.fn() } }
+
+describe('no deploymentConfig', () => {
+  const deploymentConfig = new DeploymentConfig(context, 'nonexistent.yml')
+
+  test('matches default config', () => {
+    expect(deploymentConfig).toMatchObject(defaultConfig)
+  })
+
+  test('outputs info message', () => {
+    expect(context.log.info).toHaveBeenCalledWith('No deployment settings found at nonexistent.yml')
+  })
+})
+
+describe('sample deploymentConfig', () => {
+  const deploymentConfig = new DeploymentConfig(context, './docs/sample-settings/sample-deployment-settings.yml')
+
+  test('matches snapshot', () => {
+    expect(deploymentConfig).toMatchInlineSnapshot(`
+DeploymentConfig {
+  "configvalidators": {
+    "collaborators": {
+      "error": "\`Admin cannot be assigned to collaborators\`
+",
+      "isValid": [Function],
+    },
+  },
+  "overridevalidators": {
+    "branches": {
+      "canOverride": [Function],
+      "error": "\`Branch protection required_approving_review_count cannot be overidden to a lower value\`
+",
+    },
+    "labels": {
+      "canOverride": [Function],
+      "error": "Some error
+",
+    },
+  },
+  "restrictedRepos": {
+    "exclude": [
+      "^admin$",
+      "^\\.github$",
+      "^safe-settings$",
+      ".*-test",
+    ],
+    "include": [
+      "^test$",
+    ],
+  },
+}
+`)
+  })
+})

--- a/test/unit/lib/plugins/autolinks.test.js
+++ b/test/unit/lib/plugins/autolinks.test.js
@@ -5,7 +5,7 @@ describe('Autolinks', () => {
   let github
 
   function configure (config) {
-    const log = { debug: jest.fn(), error: console.error }
+    const log = { ...console, debug: jest.fn() }
     const nop = false
     const errors = []
     return new Autolinks(nop, github, repo, config, log, errors)

--- a/test/unit/lib/plugins/branches.test.js
+++ b/test/unit/lib/plugins/branches.test.js
@@ -6,6 +6,7 @@ const Branches = require('../../../../lib/plugins/branches')
 describe('Branches', () => {
   let github
   const log = jest.fn()
+  log.info = jest.fn()
   log.debug = jest.fn()
   log.error = jest.fn()
 

--- a/test/unit/lib/plugins/collaborators.test.js
+++ b/test/unit/lib/plugins/collaborators.test.js
@@ -4,7 +4,7 @@ describe('Collaborators', () => {
   let github
 
   function configure (config) {
-    const log = { debug: jest.fn(), error: console.error }
+    const log = { ...console, debug: jest.fn() }
     return new Collaborators(undefined, github, { owner: 'bkeepers', repo: 'test' }, config, log)
   }
 

--- a/test/unit/lib/plugins/custom_properties.test.js
+++ b/test/unit/lib/plugins/custom_properties.test.js
@@ -19,7 +19,7 @@ describe('CustomProperties', () => {
       //     ]
       // })
     }
-    log = { debug: jest.fn(), error: console.error }
+    log = { ...console, debug: jest.fn() }
   })
 
   describe('sync', () => {

--- a/test/unit/lib/plugins/labels.test.js
+++ b/test/unit/lib/plugins/labels.test.js
@@ -26,7 +26,7 @@ describe('Labels', () => {
         updateLabel: jest.fn().mockImplementation(() => Promise.resolve())
       }
     }
-    log = { debug: jest.fn(), error: console.error }
+    log = { ...console, debug: jest.fn() }
   })
 
   describe('sync', () => {

--- a/test/unit/lib/plugins/repository.test.js
+++ b/test/unit/lib/plugins/repository.test.js
@@ -13,6 +13,7 @@ describe('Repository', () => {
     }
   }
   const log = jest.fn()
+  log.info = jest.fn()
   log.debug = jest.fn()
   log.error = jest.fn()
 

--- a/test/unit/lib/plugins/rulesets.test.js
+++ b/test/unit/lib/plugins/rulesets.test.js
@@ -85,6 +85,7 @@ function generateResponseRuleset(id, name, conditions, checks, org=false) {
 describe('Rulesets', () => {
   let github
   const log = jest.fn()
+  log.info = jest.fn()
   log.debug = jest.fn()
   log.error = jest.fn()
 

--- a/test/unit/lib/plugins/teams.test.js
+++ b/test/unit/lib/plugins/teams.test.js
@@ -15,7 +15,7 @@ describe('Teams', () => {
   const org = 'bkeepers'
 
   function configure (config) {
-    const log = { debug: jest.fn(), error: console.error }
+    const log = { ...console, debug: jest.fn() }
     const errors = []
     return new Teams(undefined, github, { owner: 'bkeepers', repo: 'test' }, config, log, errors)
   }

--- a/test/unit/lib/settings.test.js
+++ b/test/unit/lib/settings.test.js
@@ -8,6 +8,8 @@ const yaml = require('js-yaml')
 //   return OriginalSettings
 // })
 
+let settings
+
 describe('Settings Tests', () => {
   let stubContext
   let mockRepo
@@ -18,7 +20,7 @@ describe('Settings Tests', () => {
 
   function createSettings(config) {
     const settings = new Settings(false, stubContext, mockRepo, config, mockRef, mockSubOrg)
-    return settings;
+    return settings
   }
 
   beforeEach(() => {
@@ -51,7 +53,7 @@ repository:
   # A comma-separated list of topics to set on the repository
   topics:
   - frontend
-     `).toString('base64');
+     `).toString('base64')
     mockOctokit.repos = {
       getContent: jest.fn().mockResolvedValue({ data: { content } })
     }
@@ -82,18 +84,17 @@ repository:
       }
     }
 
-
-
     mockRepo = { owner: 'test', repo: 'test-repo' }
     mockRef = 'main'
     mockSubOrg = 'frontend'
   })
 
   describe('restrictedRepos', () => {
-    describe('restrictedRepos not defined', () => {
+    describe('restrictedRepos is empty object', () => {
       beforeEach(() => {
         stubConfig = {
-          restrictedRepos: {
+          deploymentConfig: {
+            restrictedRepos: {}
           }
         }
       })
@@ -112,11 +113,74 @@ repository:
       })
     })
 
+    describe('restrictedRepos is not present', () => {
+      beforeEach(() => {
+        stubConfig = {
+          deploymentConfig: {}
+        }
+      })
+
+      it('throws TypeError', () => {
+        settings = createSettings(stubConfig)
+        expect(() => settings.isRestricted('my-repo')).toThrow('Cannot read properties of undefined (reading \'include\')')
+      })
+    })
+
+    describe('restrictedRepos is null', () => {
+      beforeEach(() => {
+        stubConfig = {
+          deploymentConfig: {
+            restrictedRepos: null
+          }
+        }
+      })
+
+      it('throws TypeError', () => {
+        settings = createSettings(stubConfig)
+        expect(() => settings.isRestricted('my-repo')).toThrow('Cannot read properties of null (reading \'include\')')
+      })
+    })
+
+    describe('restrictedRepos is empty array', () => {
+      beforeEach(() => {
+        stubConfig = {
+          deploymentConfig: {
+            restrictedRepos: []
+          }
+        }
+      })
+
+      it('allows all repositories', () => {
+        settings = createSettings(stubConfig)
+        expect(settings.isRestricted('my-repo')).toEqual(false)
+      })
+    })
+
+    describe('restrictedRepos also defined in runtimeConfig', () => {
+      beforeEach(() => {
+        stubConfig = {
+          deploymentConfig: {
+            restrictedRepos: ['admin', '.github', 'safe-settings']
+          },
+          runtimeConfig: {
+            restrictedRepos: ['foo', 'bar']
+          }
+        }
+      })
+
+      it('ignores restrictedRepos from runtimeConfig', () => {
+        settings = createSettings(stubConfig)
+        expect(settings.restrictedRepos).toMatchObject(['admin', '.github', 'safe-settings'])
+      })
+    })
+
     describe('restrictedRepos.exclude defined', () => {
       beforeEach(() => {
         stubConfig = {
-          restrictedRepos: {
-            exclude: ['foo', '.*-test$', '^personal-.*$']
+          deploymentConfig: {
+            restrictedRepos: {
+              exclude: ['foo', '.*-test$', '^personal-.*$']
+            }
           }
         }
       })
@@ -142,8 +206,10 @@ repository:
     describe('restrictedRepos.include defined', () => {
       beforeEach(() => {
         stubConfig = {
-          restrictedRepos: {
-            include: ['foo', '.*-test$', '^personal-.*$']
+          deploymentConfig: {
+            restrictedRepos: {
+              include: ['foo', '.*-test$', '^personal-.*$']
+            }
           }
         }
       })
@@ -163,30 +229,6 @@ repository:
         settings = createSettings(stubConfig)
         expect(settings.isRestricted('my-repo-test-data')).toEqual(true)
         expect(settings.isRestricted('personalization-repo')).toEqual(true)
-      })
-    })
-
-    describe('restrictedRepos not defined', () => {
-      it('Throws TypeError if restrictedRepos not defined', () => {
-        stubConfig = {}
-        settings = createSettings(stubConfig)
-        expect(() => settings.isRestricted('my-repo')).toThrow('Cannot read properties of undefined (reading \'include\')')
-      })
-
-      it('Throws TypeError if restrictedRepos is null', () => {
-        stubConfig = {
-          restrictedRepos: null
-        }
-        settings = createSettings(stubConfig)
-        expect(() => settings.isRestricted('my-repo')).toThrow('Cannot read properties of null (reading \'include\')')
-      })
-
-      it('Allowing all repositories if restrictedRepos is empty', () => {
-        stubConfig = {
-          restrictedRepos: []
-        }
-        settings = createSettings(stubConfig)
-        expect(settings.isRestricted('my-repo')).toEqual(false)
       })
     })
   }) // restrictedRepos
@@ -236,7 +278,8 @@ repository:
     describe('load suborg configs', () => {
       beforeEach(() => {
         stubConfig = {
-          restrictedRepos: {
+          deploymentConfig: {
+            restrictedRepos: {}
           }
         }
         subOrgConfig = yaml.load(`

--- a/test/unit/lib/settings.test.js
+++ b/test/unit/lib/settings.test.js
@@ -237,6 +237,7 @@ repository:
     describe('repository defined in a file using the .yaml extension', () => {
       beforeEach(() => {
         stubConfig = {
+          deploymentConfig: {},
           repoConfigs: {
             'repository.yaml': { repository: { name: 'repository', config: 'config1' } }
           }
@@ -257,6 +258,7 @@ repository:
     describe('repository defined in a file using the .yml extension', () => {
       beforeEach(() => {
         stubConfig = {
+          deploymentConfig: {},
           repoConfigs: {
             'repository.yml': { repository: { name: 'repository', config: 'config1' } }
           }

--- a/test/unit/lib/validator.test.js
+++ b/test/unit/lib/validator.test.js
@@ -4,6 +4,8 @@ const MergeDeep = require('../../../lib/mergeDeep')
 const YAML = require('js-yaml')
 const log = require('pino')('test.log')
 
+jest.mock('../../../lib/deploymentConfig')
+
 describe('Validator Tests', () => {
   it('Branch override validator test', () => {
     const overrideMock = jest.fn((baseconfig, overrideconfig) => {
@@ -20,8 +22,10 @@ describe('Validator Tests', () => {
       console.log(`Branch config validator, baseconfig ${baseconfig}`)
       return false
     })
-    DeploymentConfig.overridevalidators = { branches: { canOverride: overrideMock, error: 'Branch overrideValidators.error' } }
-    DeploymentConfig.configvalidators = { branches: { isValid: configMock, error: 'Branch configValidators.error' } }
+    DeploymentConfig.mockImplementation(() => ({
+      overridevalidators: { branches: { canOverride: overrideMock, error: 'Branch overrideValidators.error' } },
+      configvalidators: { branches: { isValid: configMock, error: 'Branch configValidators.error' } }
+    }))
 
     const overrideconfig = YAML.load(`
           branches:
@@ -77,8 +81,10 @@ describe('Validator Tests', () => {
       console.log(`Repo config validator, baseconfig ${baseconfig}`)
       return false
     })
-    DeploymentConfig.overridevalidators = { repository: { canOverride: overrideMock, error: 'Repo overrideValidators.error' } }
-    DeploymentConfig.configvalidators = { repository: { isValid: configMock, error: 'Repo configValidators.error' } }
+    DeploymentConfig.mockImplementation(() => ({
+      overridevalidators: { repository: { canOverride: overrideMock, error: 'Repo overrideValidators.error' } },
+      configvalidators: { branches: { isValid: configMock, error: 'Branch configValidators.error' } }
+    }))
 
     const overrideconfig = YAML.load(`
   repository:
@@ -132,8 +138,10 @@ describe('Validator Tests', () => {
       console.log(`Repo config validator, baseconfig ${baseconfig}`)
       return false
     })
-    DeploymentConfig.overridevalidators = { repository: { canOverride: overrideMock, error: 'Repo overrideValidators.error' } }
-    DeploymentConfig.configvalidators = { repository: { isValid: configMock, error: 'Repo configValidators.error' } }
+    DeploymentConfig.mockImplementation(() => ({
+      overridevalidators: { repository: { canOverride: overrideMock, error: 'Repo overrideValidators.error' } },
+      configvalidators: { repository: { isValid: configMock, error: 'Repo configValidators.error' } }
+    }))
 
     const overrideconfig = YAML.load(`
   repository:


### PR DESCRIPTION
Because the settings and deploymentConfig objects are combined to a single object, the organization settings can override/set values that are intended to only come from the deploymentConfig.

This PR separates them so that they dont collide.
