### PR TITLE
feat: Add support for tags in deployment branch policies

### DIFF
--- a/docs/github-settings/6. deployment-environments.md
+++ b/docs/github-settings/6. deployment-environments.md
@@ -27,10 +27,14 @@ environments:
       - type: User
         id: 139262123
     deployment_branch_policy:
-      protected_branches: true
-      custom_branch_policies: false
+      protected_branches: false
+      custom_branch_policies:
+        - names: ['main','dev']
+          type: branch
+        - names: ['v*.*.*']
+          type: tag
     deployment_protection_rules:
-      - app_id: 25112  
+      - app_id: 25112
     variables:
       - name: MY_AWESOME_VAR
         value: '845705'
@@ -43,7 +47,8 @@ environments:
 >[!TIP]
 >GitHub's API documentation defines these inputs and types:
 >1. [Create or update an environment](https://docs.github.com/en/rest/deployments/environments?apiVersion=2022-11-28#create-or-update-an-environment)
->2. [Create an environment variable](https://docs.github.com/en/rest/actions/variables?apiVersion=2022-11-28#create-an-environment-variable)
+>2. [Create a deployment branch policy](https://docs.github.com/en/rest/deployments/branch-policies?apiVersion=2022-11-28#create-a-deployment-branch-policy)
+>3. [Create an environment variable](https://docs.github.com/en/rest/actions/variables?apiVersion=2022-11-28#create-an-environment-variable)
 
 <table>
 <tr><td>
@@ -126,11 +131,11 @@ environments:
 
 <details><summary>Properties of <code>deployment_branch_policy</code></summary>
 <br>
-<p>&emsp;<code>protected_branches</code><span style="color:gray;">&emsp;<i>string</i>&emsp;</span><span style="color:orange;">${\text{\color{orange}Required}}$</span></p>
-<p>&emsp;&emsp;Whether only branches with branch protection rules can deploy<br>&emsp;&emsp;to this environment. If <code>protected_branches</code> is <code>true</code>,<br>&emsp;&emsp;<code>custom_branch_policies</code> must be <code>false</code>; if <code>protected_branches</code><br>&emsp;&emsp;is <code>false</code>, <code>custom_branch_policies</code> must be <code>true</code>.</p>
+<p>&emsp;<code>protected_branches</code><span style="color:gray;">&emsp;<i>boolean</i>&emsp;</span><span style="color:orange;">${\text{\color{orange}Required}}$</span></p>
+<p>&emsp;&emsp;Whether only branches with branch protection rules can deploy<br>&emsp;&emsp;to this environment. If <code>protected_branches</code> is <code>true</code>,<br>&emsp;&emsp;<code>custom_branch_policies</code> must be <code>false</code>; if <code>protected_branches</code><br>&emsp;&emsp;is <code>false</code>, <code>custom_branch_policies</code> must be an object.</p>
 
-<p>&emsp;<code>id</code><span style="color:gray;">&emsp;<i>integer</i>&emsp;</span></p>
-<p>&emsp;&emsp;Whether only branches that match the specified name patterns<br>&emsp;&emsp;can deploy to this environment. If <code>custom_branch_policies</code><br>&emsp;&emsp;is <code>true</code>, <code>protected_branches</code> must be <code>false</code>; if<br>&emsp;&emsp;<code>custom_branch_policies</code> is <code>false</code>, <code>protected_branches</code><br>&emsp;&emsp;must be <code>true</code>.</p>
+<p>&emsp;<code>custom_branch_policies</code><span style="color:gray;">&emsp;<i>boolean or object</i>&emsp;</span></p>
+<p>&emsp;&emsp;Whether only branches that match the specified name patterns<br>&emsp;&emsp;can deploy to this environment. If <code>custom_branch_policies</code><br>&emsp;&emsp;is <code>false</code>, <code>protected_branches</code> must be <code>true</code>; if<br>&emsp;&emsp;<code>custom_branch_policies</code> is an object, <code>protected_branches</code><br>&emsp;&emsp;must be <code>false</code>.</p>
 
 </details>
 
@@ -142,8 +147,12 @@ environments:
   - name: production
     ...
     deployment_branch_policy:
-      protected_branches: true
-      custom_branch_policies: false
+      protected_branches: false
+      custom_branch_policies:
+        - names: ['main','dev']
+          type: branch
+        - names: ['v*.*.*']
+          type: tag
 ...
 ```
 

--- a/lib/plugins/environments.js
+++ b/lib/plugins/environments.js
@@ -14,6 +14,16 @@ module.exports = class Environments extends Diffable {
             variable.name = variable.name.toLowerCase()
           })
         }
+        // Expand custom_branch_policies to match GitHub schema.
+        if (environment.deployment_branch_policy && environment.deployment_branch_policy.custom_branch_policies) {
+          const policies = []
+          environment.deployment_branch_policy.custom_branch_policies.forEach(policy => {
+            policy.names.forEach(name => {
+              policies.push({ name: name, type: policy.type })
+            })
+          })
+          environment.deployment_branch_policy.custom_branch_policies = policies
+        }
       })
     }
   }
@@ -52,7 +62,8 @@ module.exports = class Environments extends Diffable {
                 repo: this.repo.repo,
                 environment_name: environment.name
               })).data.branch_policies.map(policy => ({
-                name: policy.name
+                name: policy.name,
+                type: policy.type
               }))
             },
         variables: (await this.github.request('GET /repos/:org/:repo/environments/:environment_name/variables', {
@@ -93,11 +104,11 @@ module.exports = class Environments extends Diffable {
 
     let existingCustomBranchPolicies = existing.deployment_branch_policy === null ? null : existing.deployment_branch_policy.custom_branch_policies
     if (typeof (existingCustomBranchPolicies) === 'object' && existingCustomBranchPolicies !== null) {
-      existingCustomBranchPolicies = existingCustomBranchPolicies.sort()
+      existingCustomBranchPolicies = existingCustomBranchPolicies.sort((x1, x2) => x1.name.localeCompare(x2.name))
     }
     let attrsCustomBranchPolicies = attrs.deployment_branch_policy === null ? null : attrs.deployment_branch_policy.custom_branch_policies
     if (typeof (attrsCustomBranchPolicies) === 'object' && attrsCustomBranchPolicies !== null) {
-      attrsCustomBranchPolicies = attrsCustomBranchPolicies.sort()
+      attrsCustomBranchPolicies = attrsCustomBranchPolicies.sort((x1, x2) => x1.name.localeCompare(x2.name))
     }
     let deploymentBranchPolicy
     if (existing.deployment_branch_policy === attrs.deployment_branch_policy) {
@@ -163,7 +174,8 @@ module.exports = class Environments extends Diffable {
         await this.nopifyRequest(
           'POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', {
             ...baseRequestOptions,
-            name: policy
+            name: policy.name,
+            type: policy.type
           }, 'Create deployment branch policy')
       }
     }
@@ -256,7 +268,8 @@ module.exports = class Environments extends Diffable {
         await this.nopifyRequest(
           'POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', {
             ...baseRequestOptions,
-            name: policy.name
+            name: policy.name,
+            type: policy.type
           }, 'Create deployment branch policy'
         )
       }

--- a/lib/plugins/environments.js
+++ b/lib/plugins/environments.js
@@ -18,9 +18,14 @@ module.exports = class Environments extends Diffable {
         if (environment.deployment_branch_policy && environment.deployment_branch_policy.custom_branch_policies) {
           const policies = []
           environment.deployment_branch_policy.custom_branch_policies.forEach(policy => {
-            policy.names.forEach(name => {
-              policies.push({ name: name, type: policy.type })
-            })
+            if (typeof policy === 'string') {
+              // Convert string policy to object with type 'branch'
+              policies.push({ name: policy, type: 'branch' })
+            } else if (typeof policy === 'object' && Array.isArray(policy.names)) {
+              policy.names.forEach(name => {
+                policies.push({ name: name, type: policy.type })
+              })
+            }
           })
           environment.deployment_branch_policy.custom_branch_policies = policies
         }

--- a/test/unit/lib/plugins/environments.test.js
+++ b/test/unit/lib/plugins/environments.test.js
@@ -302,8 +302,14 @@ describe('Environments Plugin test suite', () => {
           deployment_branch_policy: {
             protected_branches: false,
             custom_branch_policies: [
-              'master',
-              'dev'
+              {
+                names: ['main','dev'],
+                type: 'branch'
+              },
+              {
+                names: ['v*.*.*'],
+                type: 'tag'
+              }
             ]
           }
         }
@@ -342,13 +348,22 @@ describe('Environments Plugin test suite', () => {
           org,
           repo,
           environment_name: environmentName,
-          name: 'master'
+          name: 'main',
+          type: 'branch'
         }))
         expect(github.request).toHaveBeenCalledWith('POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', expect.objectContaining({
           org,
           repo,
           environment_name: environmentName,
-          name: 'dev'
+          name: 'dev',
+          type: 'branch'
+        }))
+        expect(github.request).toHaveBeenCalledWith('POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', expect.objectContaining({
+          org,
+          repo,
+          environment_name: environmentName,
+          name: 'v*.*.*',
+          type: 'tag'
         }))
       })
     })
@@ -753,8 +768,14 @@ describe('Environments Plugin test suite', () => {
           deployment_branch_policy: {
             protected_branches: false,
             custom_branch_policies: [
-              'master',
-              'dev'
+              {
+                names: ['main','dev'],
+                type: 'branch'
+              },
+              {
+                names: ['v*.*.*'],
+                type: 'tag'
+              }
             ]
           }
         },
@@ -890,14 +911,24 @@ describe('Environments Plugin test suite', () => {
           org,
           repo,
           environment_name: 'deployment-branch-policy-custom_environment',
-          name: 'master'
+          name: 'main',
+          type: 'branch'
         }))
 
         expect(github.request).toHaveBeenCalledWith('POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', expect.objectContaining({
           org,
           repo,
           environment_name: 'deployment-branch-policy-custom_environment',
-          name: 'dev'
+          name: 'dev',
+          type: 'branch'
+        }))
+
+        expect(github.request).toHaveBeenCalledWith('POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', expect.objectContaining({
+          org,
+          repo,
+          environment_name: 'deployment-branch-policy-custom_environment',
+          name: 'v*.*.*',
+          type: 'tag'
         }))
 
         expect(github.request).toHaveBeenCalledWith('POST /repos/:org/:repo/environments/:environment_name/variables', expect.objectContaining({
@@ -957,8 +988,14 @@ describe('Environments Plugin test suite', () => {
           deployment_branch_policy: {
             protected_branches: false,
             custom_branch_policies: [
-              'master',
-              'dev'
+              {
+                names: ['main','dev'],
+                type: 'branch'
+              },
+              {
+                names: ['v*.*.*'],
+                type: 'tag'
+              }
             ]
           }
         },
@@ -1012,8 +1049,14 @@ describe('Environments Plugin test suite', () => {
           deployment_branch_policy: {
             protected_branches: false,
             custom_branch_policies: [
-              'master',
-              'dev'
+              {
+                names: ['main','dev'],
+                type: 'branch'
+              },
+              {
+                names: ['v*.*.*'],
+                type: 'tag'
+              }
             ]
           }
         },
@@ -1149,14 +1192,24 @@ describe('Environments Plugin test suite', () => {
           org,
           repo,
           environment_name: 'deployment-branch-policy-custom_environment',
-          name: 'master'
+          name: 'main',
+          type: 'branch'
         }))
 
         expect(github.request).toHaveBeenCalledWith('POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', expect.objectContaining({
           org,
           repo,
           environment_name: 'deployment-branch-policy-custom_environment',
-          name: 'dev'
+          name: 'dev',
+          type: 'branch'
+        }))
+
+        expect(github.request).toHaveBeenCalledWith('POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', expect.objectContaining({
+          org,
+          repo,
+          environment_name: 'deployment-branch-policy-custom_environment',
+          name: 'v*.*.*',
+          type: 'tag'
         }))
 
         expect(github.request).toHaveBeenCalledWith('POST /repos/:org/:repo/environments/:environment_name/variables', expect.objectContaining({

--- a/test/unit/lib/plugins/environments.test.js
+++ b/test/unit/lib/plugins/environments.test.js
@@ -7,8 +7,8 @@ describe('Environments Plugin test suite', () => {
   let environmentName = ''
   const org = 'bkeepers'
   const repo = 'test'
-  const PrimaryEnvironmentNamesBeingTested = ['wait-timer_environment', 'wait-timer_2_environment', 'reviewers_environment', 'prevent-self-review_environment', 'deployment-branch-policy_environment', 'deployment-branch-policy-custom_environment', 'variables_environment', 'deployment-protection-rules_environment', 'new_environment', 'old_environment']
-  const EnvironmentNamesForTheNewEnvironmentsTest = ['new-wait-timer', 'new-reviewers', 'new-prevent-self-review', 'new-deployment-branch-policy', 'new-deployment-branch-policy-custom', 'new-variables', 'new-deployment-protection-rules']
+  const PrimaryEnvironmentNamesBeingTested = ['wait-timer_environment', 'wait-timer_2_environment', 'reviewers_environment', 'prevent-self-review_environment', 'deployment-branch-policy_environment', 'deployment-branch-policy-custom_environment', 'deployment-branch-policy-custom_environment_legacy', 'variables_environment', 'deployment-protection-rules_environment', 'new_environment', 'old_environment']
+  const EnvironmentNamesForTheNewEnvironmentsTest = ['new-wait-timer', 'new-reviewers', 'new-prevent-self-review', 'new-deployment-branch-policy', 'new-deployment-branch-policy-custom', 'new-deployment-branch-policy-custom-legacy', 'new-variables', 'new-deployment-protection-rules']
   const AllEnvironmentNamesBeingTested = PrimaryEnvironmentNamesBeingTested.concat(EnvironmentNamesForTheNewEnvironmentsTest)
   const log = { debug: jest.fn(), error: console.error }
   const errors = []
@@ -51,6 +51,15 @@ describe('Environments Plugin test suite', () => {
 
     when(github.request)
       .calledWith('GET /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', { org, repo, environment_name: 'deployment-branch-policy-custom_environment' })
+      .mockResolvedValue({
+        data: {
+          branch_policies: []
+        }
+      }
+      )
+
+    when(github.request)
+      .calledWith('GET /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', { org, repo, environment_name: 'deployment-branch-policy-custom_environment_legacy' })
       .mockResolvedValue({
         data: {
           branch_policies: []
@@ -364,6 +373,69 @@ describe('Environments Plugin test suite', () => {
           environment_name: environmentName,
           name: 'v*.*.*',
           type: 'tag'
+        }))
+      })
+    })
+  })
+
+  // custom deployment branch policy with string array
+  describe('When there is no existing deployment branch policy and the config sets a custom policy as a string array', () => {
+    it('detect divergence and set the custom deployment branch policy from the config', async () => {
+      // arrange
+      environmentName = 'deployment-branch-policy-custom_environment_legacy'
+      // represent config with a custom branch policy
+      const plugin = new Environments(undefined, github, { owner: org, repo }, [
+        {
+          name: environmentName,
+          deployment_branch_policy: {
+            protected_branches: false,
+            custom_branch_policies: ["main", "dev"]
+          }
+        }
+      ], log, errors)
+
+      // model an existing environment with no branch policies
+      when(github.request)
+        .calledWith('GET /repos/:org/:repo/environments', { org, repo })
+        .mockResolvedValue({
+          data: {
+            environments: [
+              fillEnvironment({
+                name: environmentName,
+                deployment_branch_policy: null
+              })
+            ]
+          }
+        })
+
+      // act - run sync() in environments.js
+      await plugin.sync().then(() => {
+        // assert - update the custom branch policies
+        expect(github.request).toHaveBeenCalledWith('GET /repos/:org/:repo/environments', { org, repo })
+        expect(github.request).toHaveBeenCalledWith('GET /repos/:org/:repo/environments/:environment_name/variables', { org, repo, environment_name: environmentName })
+        expect(github.request).toHaveBeenCalledWith('GET /repos/:org/:repo/environments/:environment_name/deployment_protection_rules', { org, repo, environment_name: environmentName })
+        expect(github.request).toHaveBeenCalledWith('PUT /repos/:org/:repo/environments/:environment_name', expect.objectContaining({
+          org,
+          repo,
+          environment_name: environmentName,
+          deployment_branch_policy: {
+            protected_branches: false,
+            custom_branch_policies: true
+          }
+        }))
+        expect(github.request).toHaveBeenCalledWith('POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', expect.objectContaining({
+          org,
+          repo,
+          environment_name: environmentName,
+          name: 'main',
+          type: 'branch'
+        }))
+        expect(github.request).toHaveBeenCalledWith('POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', expect.objectContaining({
+          org,
+          repo,
+          environment_name: environmentName,
+          name: 'dev',
+          type: 'branch'
         }))
       })
     })
@@ -780,6 +852,13 @@ describe('Environments Plugin test suite', () => {
           }
         },
         {
+          name: 'deployment-branch-policy-custom_environment_legacy',
+          deployment_branch_policy: {
+            protected_branches: false,
+            custom_branch_policies: ["main", "dev"]
+          }
+        },
+        {
           name: 'variables_environment',
           variables: [
             {
@@ -827,6 +906,10 @@ describe('Environments Plugin test suite', () => {
                 deployment_branch_policy: null
               }),
               fillEnvironment({
+                name: 'deployment-branch-policy-custom_environment_legacy',
+                deployment_branch_policy: null
+              }),
+              fillEnvironment({
                 name: 'variables_environment',
                 variables: []
               }),
@@ -844,7 +927,7 @@ describe('Environments Plugin test suite', () => {
 
         expect(github.request).toHaveBeenCalledWith('GET /repos/:org/:repo/environments', { org, repo });
 
-        ['wait-timer_environment', 'reviewers_environment', 'prevent-self-review_environment', 'deployment-branch-policy_environment', 'deployment-branch-policy-custom_environment', 'variables_environment', 'deployment-protection-rules_environment'].forEach((environmentName) => {
+        ['wait-timer_environment', 'reviewers_environment', 'prevent-self-review_environment', 'deployment-branch-policy_environment', 'deployment-branch-policy-custom_environment', 'deployment-branch-policy-custom_environment_legacy', 'variables_environment', 'deployment-protection-rules_environment'].forEach((environmentName) => {
           expect(github.request).toHaveBeenCalledWith('GET /repos/:org/:repo/environments/:environment_name/variables', { org, repo, environment_name: environmentName })
 
           expect(github.request).toHaveBeenCalledWith('GET /repos/:org/:repo/environments/:environment_name/deployment_protection_rules', { org, repo, environment_name: environmentName })
@@ -929,6 +1012,32 @@ describe('Environments Plugin test suite', () => {
           environment_name: 'deployment-branch-policy-custom_environment',
           name: 'v*.*.*',
           type: 'tag'
+        }))
+
+        expect(github.request).toHaveBeenCalledWith('PUT /repos/:org/:repo/environments/:environment_name', expect.objectContaining({
+          org,
+          repo,
+          environment_name: 'deployment-branch-policy-custom_environment_legacy',
+          deployment_branch_policy: {
+            protected_branches: false,
+            custom_branch_policies: true
+          }
+        }))
+
+        expect(github.request).toHaveBeenCalledWith('POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', expect.objectContaining({
+          org,
+          repo,
+          environment_name: 'deployment-branch-policy-custom_environment_legacy',
+          name: 'main',
+          type: 'branch'
+        }))
+
+        expect(github.request).toHaveBeenCalledWith('POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', expect.objectContaining({
+          org,
+          repo,
+          environment_name: 'deployment-branch-policy-custom_environment_legacy',
+          name: 'dev',
+          type: 'branch'
         }))
 
         expect(github.request).toHaveBeenCalledWith('POST /repos/:org/:repo/environments/:environment_name/variables', expect.objectContaining({
@@ -1000,6 +1109,13 @@ describe('Environments Plugin test suite', () => {
           }
         },
         {
+          name: 'deployment-branch-policy-custom_environment_legacy',
+          deployment_branch_policy: {
+            protected_branches: false,
+            custom_branch_policies: ["main", "dev"]
+          }
+        },
+        {
           name: 'variables_environment',
           variables: [
             {
@@ -1061,6 +1177,13 @@ describe('Environments Plugin test suite', () => {
           }
         },
         {
+          name: 'new-deployment-branch-policy-custom-legacy',
+          deployment_branch_policy: {
+            protected_branches: false,
+            custom_branch_policies: ["main", "dev"]
+          }
+        },
+        {
           name: 'new-variables',
           variables: [
             {
@@ -1105,6 +1228,10 @@ describe('Environments Plugin test suite', () => {
               }),
               fillEnvironment({
                 name: 'deployment-branch-policy-custom_environment',
+                deployment_branch_policy: null
+              }),
+              fillEnvironment({
+                name: 'deployment-branch-policy-custom_environment_legacy',
                 deployment_branch_policy: null
               }),
               fillEnvironment({
@@ -1210,6 +1337,32 @@ describe('Environments Plugin test suite', () => {
           environment_name: 'deployment-branch-policy-custom_environment',
           name: 'v*.*.*',
           type: 'tag'
+        }))
+
+        expect(github.request).toHaveBeenCalledWith('PUT /repos/:org/:repo/environments/:environment_name', expect.objectContaining({
+          org,
+          repo,
+          environment_name: 'deployment-branch-policy-custom_environment_legacy',
+          deployment_branch_policy: {
+            protected_branches: false,
+            custom_branch_policies: true
+          }
+        }))
+
+        expect(github.request).toHaveBeenCalledWith('POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', expect.objectContaining({
+          org,
+          repo,
+          environment_name: 'deployment-branch-policy-custom_environment_legacy',
+          name: 'main',
+          type: 'branch'
+        }))
+
+        expect(github.request).toHaveBeenCalledWith('POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', expect.objectContaining({
+          org,
+          repo,
+          environment_name: 'deployment-branch-policy-custom_environment_legacy',
+          name: 'dev',
+          type: 'branch'
         }))
 
         expect(github.request).toHaveBeenCalledWith('POST /repos/:org/:repo/environments/:environment_name/variables', expect.objectContaining({


### PR DESCRIPTION
1. Add support for `tag` type in environments' deployment branch policies - see https://docs.github.com/en/rest/deployments/branch-policies?apiVersion=2022-11-28#create-a-deployment-branch-policy
2. Update docs.
3. Update unit tests for environments.