### PR TITLE
feat: add a simple in-memory cache for suborg/repo config fetches

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -10,7 +10,11 @@ const env = require('./env')
 const CONFIG_PATH = env.CONFIG_PATH
 const eta = new Eta({ views: path.join(__dirname) })
 const SCOPE = { ORG: 'org', REPO: 'repo' } // Determine if the setting is a org setting or repo setting
+const yaml = require('js-yaml');
+
 class Settings {
+  static fileCache = {};
+
   static async syncAll (nop, context, repo, config, ref) {
     const settings = new Settings(nop, context, repo, config, ref)
     try {
@@ -758,7 +762,7 @@ ${this.results.reduce((x, y) => {
           }
           )) {
             delete subOrgConfigs[key]
-          } 
+          }
         }
       }
       return subOrgConfigs
@@ -788,12 +792,33 @@ ${this.results.reduce((x, y) => {
    * @param params Params to fetch the file with
    * @return The parsed YAML file
    */
-  async loadYaml (filePath) {
+  async loadYaml(filePath) {
     try {
       const repo = { owner: this.repo.owner, repo: env.ADMIN_REPO }
-      const params = Object.assign(repo, { path: filePath, ref: this.ref })
+      const params = Object.assign(repo, {
+        path: filePath,
+        ref: this.ref
+      })
+      const namespacedFilepath = `${this.repo.owner}/${filePath}`;
+
+      // If the filepath already exists in the fileCache, add the etag to the params
+      // to check if the file has changed
+      if (Settings.fileCache[namespacedFilepath]) {
+        params.headers = {
+          'If-None-Match': Settings.fileCache[namespacedFilepath].etag
+        }
+      }
+
       const response = await this.github.repos.getContent(params).catch(e => {
+        if (e.status === 304) {
+          this.log.debug(`Cache hit for file ${filePath}`)
+          return {
+            ...Settings.fileCache[namespacedFilepath],
+            cached: true
+          }
+        }
         this.log.error(`Error getting settings ${e}`)
+        throw e
       })
 
       // Ignore in case path is a folder
@@ -808,8 +833,19 @@ ${this.results.reduce((x, y) => {
       if (typeof response.data.content !== 'string') {
         return
       }
-      const yaml = require('js-yaml')
-      return yaml.load(Buffer.from(response.data.content, 'base64').toString()) || {}
+
+      const content = yaml.load(Buffer.from(response.data.content, 'base64').toString()) || {}
+
+      // Cache the content, as its either new or changed
+      if (!response.cached) {
+        this.log.debug(`Cache miss for file ${filePath}`)
+        Settings.fileCache[namespacedFilepath] = {
+          etag: response.headers.etag,
+          data: response.data
+        }
+      }
+
+      return content
     } catch (e) {
       if (e.status === 404) {
         return null
@@ -862,7 +898,7 @@ ${this.results.reduce((x, y) => {
       throw new Error(`Failed to filter repositories for property ${name}: ${error.message}`)
     }
   }
-  
+
 
   async getSubOrgRepositories (subOrgProperties) {
     const organizationName = this.repo.owner


### PR DESCRIPTION
Fixes #816 

This PR adds a simple in-memory cache in the `loadYaml` function, that stores the response + [etag](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2022-11-28#use-conditional-requests-if-appropriate) of calls to the `getContent` call. Then, future calls are made with the `If-None-Match` header set to that etag, so that we can optimistically just return from the cache instead and save ourselves the api call. In our instance of safe settings, this ends up saving about **96%** of our api calls for our app. (We've made 3.4M api calls in the last week, of which 3.248M were cached - about 95.5%)

Because safe settings attempts to load all of the repo configs & suborg configs every time a sync is done, that api call usage tends to grow explosively on large orgs. We run this in an org with around 8500 repos in it, and because we have 140-ish suborgs, that ends up being 140 suborg calls against our api limit every time a setting is changed!

With this change, we store the response of each of those calls in memory, and only make an api call if github knows the file contents have changed.

This is a VERY simple cache, so it has some limitations:
- There's not a method for expiring from this cache, which means it could grow very large. However, it should be bounded by the total size of all the configs you expect to load while safe-settings is running. For our 8500-repo org, that ends up being around 10kb of memory. Given the amount of memory we have free in our container, we don't really see this growing to be a problem.
- This is just an in-memory cache, so it's not durable to container restarts or anything. The downside for us is that means we burn 140-ish api calls to re-initialize the cache the first time a sync is run, which is an acceptable cost compared to the server cost of running a separate caching instance.
