### PR TITLE
Bump example GHA versions in docs to latest safe settings release

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -166,7 +166,7 @@ Follow the instructions [here](#build-the-docker-container) on how to do it.
 
 
 > [!NOTE]
-> If you want a reproducible build then you should specify a non floating tag for the image `ghcr.io/github/safe-settings:2.1.10` .
+> If you want a reproducible build then you should specify a non floating tag for the image `ghcr.io/github/safe-settings:2.1.13` .
 
 Once you built the image and pushed it to your registry you can specify it in your `values` file like this:
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Version/tag of github/safe-settings repo to use:
-      SAFE_SETTINGS_VERSION: 2.1.13
+      SAFE_SETTINGS_VERSION: 2.1.17
 
       # Path on GHA runner box where safe-settings code downloaded to:
       SAFE_SETTINGS_CODE_DIR: ${{ github.workspace }}/.safe-settings-code


### PR DESCRIPTION
This pull request updates version references in the documentation to ensure consistency and accuracy with the latest release on the repo.

Version updates in documentation:

* [`docs/deploy.md`](diffhunk://#diff-36d595788def52423b10ad225bb2a7310de3aa66dd60c6de3d6268a3d23a5e7eL169-R169): Updated the example image tag for reproducible builds from `2.1.10` to `2.1.13`.
* [`docs/github-action.md`](diffhunk://#diff-5565610d10fa90d1b0be11c7f459812e0ddf7015e2d76c364d41d166b06dd43dL29-R29): Updated the `SAFE_SETTINGS_VERSION` environment variable from `2.1.13` to `2.1.17`.

I ignored the [safe-settings.yml](https://github.com/github/safe-settings/blob/061bf84455785e833c69f633a3386d074bb39f57/safe-settings.yaml#L23) as that is for this repo, though the maintainers may wish to bump to the latest release to eat their own down food. Happy to make that edit as well, though it felt out of scope for a simple doc update PR 👍 

Hope my old GH friends are doing well! :octocat: :