### PR TITLE
Fix labels.exclude schema: object with name

### DIFF
--- a/docs/github-settings/8. labels.md
+++ b/docs/github-settings/8. labels.md
@@ -10,9 +10,13 @@ You can use the REST API to manage labels for a repository and add or remove lab
 ```yaml
 # These settings are synced to GitHub by https://github.com/github/safe-settings
 labels:
-  - name: bug
-    color: CC0000
-    description: An issue with the system
+  include:
+    - name: bug
+      color: CC0000
+      description: An issue with the system
+  exclude:
+    # don't delete any labels that start with "release"
+    - name: ^release
 ```
 
 ## Team API Spec

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -75,7 +75,12 @@
           "description": "Ignore any labels matching these regexes (don't delete them)",
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
The labels.exclude property takes an array of objects with `name` properties.

See usage: https://github.com/github/safe-settings/blob/17e6d5cb5892af8e67390807c7edca24a65eeaff/lib/plugins/labels.js#L20

Possibly fixes #764