### PR TITLE
feat: add ruleset param for automatic_copilot_code_review_enabled

### DIFF
--- a/docs/sample-settings/settings.yml
+++ b/docs/sample-settings/settings.yml
@@ -322,6 +322,10 @@ rulesets:
           # All conversations on code must be resolved before a pull
           # request can be merged.
           required_review_thread_resolution: true
+          # Request Copilot code review for new pull requests 
+          # automatically if the author has access to Copilot code 
+          # review
+          automatic_copilot_code_review_enabled: true
 
       # Choose which status checks must pass before branches can be merged
       # into a branch that matches this rule. When enabled, commits must

--- a/docs/sample-settings/settings.yml
+++ b/docs/sample-settings/settings.yml
@@ -307,6 +307,10 @@ rulesets:
 
       - type: pull_request
         parameters:
+          # Request Copilot code review for new pull requests
+          # automatically if the author has access to Copilot code
+          # review
+          automatic_copilot_code_review_enabled: true
           # Reviewable commits pushed will dismiss previous pull
           # request review approvals.
           dismiss_stale_reviews_on_push: true
@@ -322,10 +326,6 @@ rulesets:
           # All conversations on code must be resolved before a pull
           # request can be merged.
           required_review_thread_resolution: true
-          # Request Copilot code review for new pull requests 
-          # automatically if the author has access to Copilot code 
-          # review
-          automatic_copilot_code_review_enabled: true
 
       # Choose which status checks must pass before branches can be merged
       # into a branch that matches this rule. When enabled, commits must

--- a/schema/dereferenced/settings.json
+++ b/schema/dereferenced/settings.json
@@ -1205,6 +1205,10 @@
                         "required_review_thread_resolution": {
                           "type": "boolean",
                           "description": "All conversations on code must be resolved before a pull request can be merged."
+                        },
+                        "automatic_copilot_code_review_enabled": {
+                          "type": "boolean",
+                          "description": "Request Copilot code review for new pull requests automatically if the author has access to Copilot code review."
                         }
                       },
                       "required": [

--- a/schema/dereferenced/settings.json
+++ b/schema/dereferenced/settings.json
@@ -1184,6 +1184,10 @@
                     "parameters": {
                       "type": "object",
                       "properties": {
+                        "automatic_copilot_code_review_enabled": {
+                          "type": "boolean",
+                          "description": "Request Copilot code review for new pull requests automatically if the author has access to Copilot code review."
+                        },
                         "dismiss_stale_reviews_on_push": {
                           "type": "boolean",
                           "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
@@ -1205,10 +1209,6 @@
                         "required_review_thread_resolution": {
                           "type": "boolean",
                           "description": "All conversations on code must be resolved before a pull request can be merged."
-                        },
-                        "automatic_copilot_code_review_enabled": {
-                          "type": "boolean",
-                          "description": "Request Copilot code review for new pull requests automatically if the author has access to Copilot code review."
                         }
                       },
                       "required": [


### PR DESCRIPTION
This is an optional parameter in the [ruleset REST API](https://docs.github.com/en/rest/orgs/rules?apiVersion=2022-11-28#update-an-organization-repository-ruleset)

Since it's an optional parameter, did not include it in the tests for `mergeDeep`

Description taken from the [REST API schema](https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2022-11-28.json#/paths/~1orgs~1{org}~1rulesets/post/requestBody/content/application~1json/schema)

Fixes #853 

P.S. Under `npm test`, `npm lint:es` & `npm test:me` were failing for me some other files and I couldn't find the docs for local setup on how to get these working - if you can point me to some docs on how to setup this repo on my local, I can try running `npm test`.

First PR here - if I missed anything let me know. Thanks!