### PR TITLE
Fix devcontainer configuration and update dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.195.0/containers/javascript-node/.devcontainer/base.Dockerfile
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
-ARG VARIANT=20-bookworm
+ARG VARIANT=22-bookworm
 FROM mcr.microsoft.com/devcontainers/javascript-node:1-${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.
@@ -23,7 +23,8 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "aws
   rm -rf ./aws && \
   rm awscliv2.zip
 # Install sam cli
-RUN curl -L "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-$(dpkg --print-architecture).zip" -o "aws-sam-cli.zip" && \
+RUN ARCH=$(uname -m) && \
+  curl -L "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-${ARCH}.zip" -o "aws-sam-cli.zip" && \
   unzip aws-sam-cli.zip -d sam-installation && \
   sudo ./sam-installation/install && \
   rm -rf ./sam-installation && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,7 +23,9 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "aws
   rm -rf ./aws && \
   rm awscliv2.zip
 # Install sam cli
-RUN ARCH=$(uname -m) && \
+RUN ARCH_RAW=$(uname -m) && \
+  ARCH=$ARCH_RAW && \
+  if [ "$ARCH_RAW" = "aarch64" ]; then ARCH="arm64"; fi && \
   curl -L "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-${ARCH}.zip" -o "aws-sam-cli.zip" && \
   unzip aws-sam-cli.zip -d sam-installation && \
   sudo ./sam-installation/install && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.195.0/containers/javascript-node/.devcontainer/base.Dockerfile
-# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+# [Choice] Node.js version/variant (use -bookworm variants on local arm64/Apple Silicon): e.g. 22-bookworm, 20-bookworm, 18-bookworm
 ARG VARIANT=22-bookworm
 FROM mcr.microsoft.com/devcontainers/javascript-node:1-${VARIANT}
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,9 +4,9 @@
 	"name": "Node.js",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick a Node version: 16, 14, 12.
-		// Append -bullseye or -buster to pin to an OS version.
-		// Use -bullseye variants on local arm64/Apple Silicon.
+		// Update 'VARIANT' to pick a Node version, e.g. 22, 20, 18.
+		// Append -bookworm or -bullseye to pin to an OS version.
+		// Use -bookworm variants on local arm64/Apple Silicon.
 		"args": { "VARIANT": "22-bookworm" }
 	},
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 		// Update 'VARIANT' to pick a Node version: 16, 14, 12.
 		// Append -bullseye or -buster to pin to an OS version.
 		// Use -bullseye variants on local arm64/Apple Silicon.
-		"args": { "VARIANT": "20-bookworm" }
+		"args": { "VARIANT": "22-bookworm" }
 	},
 
 	"settings": {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "eta": "^3.5.0",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
-        "minimatch": "^10.0.1",
+        "minimatch": "^10.2.1",
         "node-cron": "^4.2.1",
         "octokit": "^5.0.2",
         "probot": "^14.2.4",


### PR DESCRIPTION
Update the Node.js version in the devcontainer configuration and adjust the installation script for the AWS SAM CLI. Also, update the `minimatch` dependency version in the package lock file.