### PR TITLE
fix: prevent race conditions by creating new objects for repository configurations

### DIFF
--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -7,7 +7,6 @@ const ignorableFields = [
   'id',
   'node_id',
   'full_name',
-  'name',
   'private',
   'fork',
   'created_at',

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -7,6 +7,7 @@ const ignorableFields = [
   'id',
   'node_id',
   'full_name',
+  'name',
   'private',
   'fork',
   'created_at',

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -327,11 +327,11 @@ ${this.results.reduce((x, y) => {
 
   async updateRepos (repo) {
     this.subOrgConfigs = this.subOrgConfigs || await this.getSubOrgConfigs()
-    // Keeping this as is instead of doing an object assign as that would cause `Cannot read properties of undefined (reading 'startsWith')` error
-    // Copilot code review would recoommend using object assign but that would cause the error
+    // Create a new object to avoid mutating the shared this.config.repository
+    // This prevents race conditions when multiple repos are processed concurrently via Promise.all
     let repoConfig = this.config.repository
     if (repoConfig) {
-      repoConfig = Object.assign(repoConfig, { name: repo.repo, org: repo.owner })
+      repoConfig = Object.assign({}, repoConfig, { name: repo.repo, org: repo.owner })
     }
 
     const subOrgConfig = this.getSubOrgConfig(repo.repo)
@@ -347,7 +347,8 @@ ${this.results.reduce((x, y) => {
     if (subOrgConfig) {
       let suborgRepoConfig = subOrgConfig.repository
       if (suborgRepoConfig) {
-        suborgRepoConfig = Object.assign(suborgRepoConfig, { name: repo.repo, org: repo.owner })
+        // Create a new object to avoid mutating the shared subOrgConfig.repository
+        suborgRepoConfig = Object.assign({}, suborgRepoConfig, { name: repo.repo, org: repo.owner })
         repoConfig = this.mergeDeep.mergeDeep({}, repoConfig, suborgRepoConfig)
       }
     }


### PR DESCRIPTION
## Summary

Fixes a race condition where `repository.name` could leak between repos during concurrent processing, and prevents `name` from appearing in dry-run diffs when not explicitly configured.

## Problem

1. **Race condition**: `Object.assign(repoConfig, {...})` mutates the shared `this.config.repository` object. When `updateRepos()` processes multiple repos concurrently via `Promise.all`, one repo's name can overwrite another's between async yields.

2. **Spurious diffs**: `name` always appears in dry-run diffs because Safe-Settings injects it internally but it's not in `ignorableFields`.

## Changes

- `lib/settings.js`: Use `Object.assign({}, repoConfig, {...})` to create new objects instead of mutating shared references
- `lib/plugins/repository.js`: Add `'name'` to `ignorableFields` to hide it from diffs unless explicitly configured for renaming

## Testing

All 112 unit tests pass.


Related to https://github.com/github/safe-settings/issues/944