### PR TITLE
Replace npm install with npm ci in workflow

### DIFF
--- a/.github/workflows/create-pre-release.yml
+++ b/.github/workflows/create-pre-release.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           node-version: 22.x
           cache: 'npm'
-      - run: npm install
+      - run: npm ci
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
       - name: Log in to the Container registry

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: 22.x
           cache: "npm"
-      - run: npm install
+      - run: npm ci
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
       - name: Log in to the Container registry


### PR DESCRIPTION
This pull request makes a minor update to the release workflow by switching the Node.js dependency installation command from `npm install` to `npm ci`. This change ensures more reliable and reproducible builds by using the exact versions specified in the lockfile.