### PR TITLE
fix: prevent prototype pollution in mergeDeep

### DIFF
--- a/lib/mergeDeep.js
+++ b/lib/mergeDeep.js
@@ -309,7 +309,17 @@ class MergeDeep {
     if (Array.isArray(source)) {
       target = Array.isArray(target) ? target.concat(source) : source
     } else {
-      target = Object.assign({}, source)
+      // Manual copy instead of Object.assign({}, source) so that a source
+      // with `__proto__` or `constructor` as an own enumerable property
+      // (e.g. from YAML or JSON.parse) cannot redirect the new target's
+      // prototype chain via the setter invoked by Object.assign.
+      target = {}
+      for (const key in source) {
+        if (key === '__proto__' || key === 'constructor') {
+          continue
+        }
+        target[key] = source[key]
+      }
     }
     return target
   }
@@ -325,6 +335,10 @@ class MergeDeep {
       }
 
       for (const key in source) {
+        // Skip prototype pollution vectors
+        if (key === '__proto__' || key === 'constructor') {
+          continue
+        }
         // If the attribute of the object or the element of the array is not a simple primitive
         if (this.isObjectNotArray(source[key]) || Array.isArray(source[key])) {
           // Deep merge Array so that if the same element is there in source and target,

--- a/test/unit/lib/mergeDeep.test.js
+++ b/test/unit/lib/mergeDeep.test.js
@@ -1882,4 +1882,31 @@ branches:
     expect(same.additions).toEqual({})
     expect(same.modifications).toEqual({})
   })
+
+  it('mergeDeep does not allow prototype pollution', () => {
+    const mockGitHub = jest.fn().mockReturnValue({ request: () => {} })
+    const mergeDeep = new MergeDeep(log, mockGitHub, [])
+
+    // js-yaml parses `__proto__:` as an own property and existing call sites
+    // (e.g. configManager.loadGlobalSettingsYaml -> Settings.syncAll -> mergeDeep)
+    // pass the parsed config straight into mergeDeep. Using JSON.parse here
+    // produces the same own-property shape without depending on js-yaml.
+    const malicious = JSON.parse('{"__proto__":{"polluted":"yes"},"constructor":{"poisoned":"yes"}}')
+
+    // Sanity: a fresh object must not already have these props.
+    expect({}.polluted).toBeUndefined()
+    expect({}.poisoned).toBeUndefined()
+
+    const merged = mergeDeep.mergeDeep({}, malicious)
+
+    // Object.prototype must remain clean.
+    expect({}.polluted).toBeUndefined()
+    expect({}.poisoned).toBeUndefined()
+    expect(Object.prototype.polluted).toBeUndefined()
+    expect(Object.prototype.poisoned).toBeUndefined()
+
+    // The merged result also should not carry the pollution payload.
+    expect(merged.polluted).toBeUndefined()
+    expect(merged.poisoned).toBeUndefined()
+  })
 })


### PR DESCRIPTION
## Summary

PR #712 added a `__proto__` / `constructor` guard to `MergeDeep.compareDeep` (`lib/mergeDeep.js:95-97`). The sibling function `MergeDeep.mergeDeep` — which performs the same kind of recursive object merging and is the one that actually applies the parsed YAML / JSON config into the running target — did not receive the matching guard. This PR closes that gap.

## Where the gap was

`MergeDeep.mergeDeep` had two places where a `__proto__` key on a parsed config object could redirect the merged target's prototype chain:

1. **`mergeEmptyTarget`** (`lib/mergeDeep.js:312` pre-PR): used `target = Object.assign({}, source)`. When `source` is the result of `JSON.parse` or `js-yaml`'s loader and contains `__proto__` as an own enumerable property, `Object.assign` invokes the `__proto__` setter on the new target and rewrites its prototype. Replaced with a manual copy that skips both reserved keys.

2. **`mergeDeep` main loop** (`lib/mergeDeep.js:327` pre-PR): iterated every key on `source`, including `__proto__` and `constructor`, before recursing into `this.mergeDeep(target[key], source[key])`. Added the same guard that already exists in `compareDeep`.

## Test

Added `mergeDeep does not allow prototype pollution` in `test/unit/lib/mergeDeep.test.js`. It feeds a JSON-parsed `__proto__` / `constructor` payload through `mergeDeep`, then asserts:

- `Object.prototype` is not modified;
- a fresh `{}` does not carry the payload;
- the returned merged object does not carry the payload.

I confirmed the regression test fails on `main-enterprise` with only the second fix applied (the first hop pollutes via `mergeEmptyTarget` before the loop guard runs), and passes once both fixes are in place.

## Verification

```
npm ci
npx jest test/unit/lib/mergeDeep.test.js      # 26 / 26 passed (was 25)
npx jest --roots=lib --roots=test/unit         # 117 / 117 passed, 14 skipped
```

Both fixes preserve existing behavior for all non-`__proto__` / non-`constructor` keys, so the rest of the suite is unchanged.

## Notes

I treated this as a defense-in-depth follow-up to PR #712 rather than as a separately reportable issue: configs are sourced from the admin repo, and the realistic write paths into them are already privileged. The patch matches the pattern the project already chose for `compareDeep`, so the two recursive merge functions behave consistently.