### PR TITLE
Fix lodash code injection vulnerability (Dependabot #116)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "deepmerge": "^4.3.1",
         "eta": "^3.5.0",
         "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "minimatch": "^10.2.1",
         "node-cron": "^4.2.1",
         "octokit": "^5.0.2",
@@ -10228,10 +10228,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "deepmerge": "^4.3.1",
     "eta": "^3.5.0",
     "js-yaml": "^4.1.0",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.1",
     "minimatch": "^10.2.1",
     "node-cron": "^4.2.1",
     "octokit": "^5.0.2",


### PR DESCRIPTION
Dependabot alert #116 flagged a high-severity code injection vulnerability in lodash's `_.template` function that allows attackers to inject arbitrary code through crafted import key names. The fix requires lodash >= 4.18.0.

This PR updates the `lodash` dependency from `^4.17.21` to `^4.18.1` (the latest patched release) and regenerates the lockfile to ensure the resolved version is 4.18.1.