### PR TITLE
fix: Add the missing include/exclude repo filters to team settings schema

### DIFF
--- a/docs/github-settings/4. teams.md
+++ b/docs/github-settings/4. teams.md
@@ -49,4 +49,32 @@ teams:
 ```
 
 </td></tr>
+<tr><td>
+<p>&emsp;<code>exclude</code><span style="color:gray;">&emsp;<i>array</i>&emsp;</span></p>
+<p>Exclude a list of repos for this team. The team is applied to every repo in scope except those whose names match one of these glob patterns.</p>
+</td><td style="vertical-align:top">
+
+```yaml
+teams:
+  - name: SuperFriends
+    permission: maintain
+    exclude:
+      - secret-repo
+```
+
+</td></tr>
+<tr><td>
+<p>&emsp;<code>include</code><span style="color:gray;">&emsp;<i>array</i>&emsp;</span></p>
+<p>Include a list of repos for this team. The team is applied only to repos whose names match one of these glob patterns.</p>
+</td><td style="vertical-align:top">
+
+```yaml
+teams:
+  - name: SuperFriends
+    permission: maintain
+    include:
+      - public-*
+```
+
+</td></tr>
 </table>

--- a/docs/sample-settings/settings.yml
+++ b/docs/sample-settings/settings.yml
@@ -161,6 +161,16 @@ teams:
   - name: globalteam
     permission: push
     visibility: closed
+  - name: docs-team
+    permission: pull
+    # You can include a list of repos for this team and only those repos would have this team
+    include:
+      - actions-demo
+  - name: ops-team
+    permission: push
+    # You can exclude a list of repos for this team and all repos except these repos would have this team
+    exclude:
+      - actions-demo
 
 # Branch protection rules
 # See https://docs.github.com/en/rest/branches/branch-protection?apiVersion=2026-03-10#update-branch-protection for available options

--- a/schema/dereferenced/repos.json
+++ b/schema/dereferenced/repos.json
@@ -400,53 +400,76 @@
       "type": "array",
       "items": {
         "description": "A team entry",
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The name of the team."
-          },
-          "description": {
-            "type": "string",
-            "description": "The description of the team."
-          },
-          "maintainers": {
-            "type": "array",
-            "description": "List GitHub usernames for organization members who will become team maintainers.",
-            "items": {
-              "type": "string"
-            }
-          },
-          "repo_names": {
-            "type": "array",
-            "description": "The full name (e.g., \"organization-name/repository-name\") of repositories to add the team to.",
-            "items": {
-              "type": "string"
-            }
-          },
-          "privacy": {
-            "type": "string",
-            "description": "The level of privacy this team should have. The options are:  \n**For a non-nested team:**  \n * `secret` - only visible to organization owners and members of this team.  \n * `closed` - visible to all members of this organization.  \nDefault: `secret`  \n**For a parent or child team:**  \n * `closed` - visible to all members of this organization.  \nDefault for child team: `closed`",
-            "enum": [
-              "secret",
-              "closed"
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the team."
+              },
+              "description": {
+                "type": "string",
+                "description": "The description of the team."
+              },
+              "maintainers": {
+                "type": "array",
+                "description": "List GitHub usernames for organization members who will become team maintainers.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "repo_names": {
+                "type": "array",
+                "description": "The full name (e.g., \"organization-name/repository-name\") of repositories to add the team to.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "privacy": {
+                "type": "string",
+                "description": "The level of privacy this team should have. The options are:  \n**For a non-nested team:**  \n * `secret` - only visible to organization owners and members of this team.  \n * `closed` - visible to all members of this organization.  \nDefault: `secret`  \n**For a parent or child team:**  \n * `closed` - visible to all members of this organization.  \nDefault for child team: `closed`",
+                "enum": [
+                  "secret",
+                  "closed"
+                ]
+              },
+              "notification_setting": {
+                "type": "string",
+                "description": "The notification setting the team has chosen. The options are:  \n * `notifications_enabled` - team members receive notifications when the team is @mentioned.  \n * `notifications_disabled` - no one receives notifications.  \nDefault: `notifications_enabled`",
+                "enum": [
+                  "notifications_enabled",
+                  "notifications_disabled"
+                ]
+              },
+              "parent_team_id": {
+                "type": "integer",
+                "description": "The ID of a team to set as the parent team."
+              }
+            },
+            "required": [
+              "name"
             ]
           },
-          "notification_setting": {
-            "type": "string",
-            "description": "The notification setting the team has chosen. The options are:  \n * `notifications_enabled` - team members receive notifications when the team is @mentioned.  \n * `notifications_disabled` - no one receives notifications.  \nDefault: `notifications_enabled`",
-            "enum": [
-              "notifications_enabled",
-              "notifications_disabled"
-            ]
-          },
-          "parent_team_id": {
-            "type": "integer",
-            "description": "The ID of a team to set as the parent team."
+          {
+            "type": "object",
+            "properties": {
+              "exclude": {
+                "description": "You can exclude a list of repos for this team and all repos except these repos would have this team",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "include": {
+                "description": "You can include a list of repos for this team and only those repos would have this team",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
           }
-        },
-        "required": [
-          "name"
         ]
       }
     },
@@ -1214,53 +1237,76 @@
     },
     "TeamSettings": {
       "description": "A team entry",
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "The name of the team."
-        },
-        "description": {
-          "type": "string",
-          "description": "The description of the team."
-        },
-        "maintainers": {
-          "type": "array",
-          "description": "List GitHub usernames for organization members who will become team maintainers.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "repo_names": {
-          "type": "array",
-          "description": "The full name (e.g., \"organization-name/repository-name\") of repositories to add the team to.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "privacy": {
-          "type": "string",
-          "description": "The level of privacy this team should have. The options are:  \n**For a non-nested team:**  \n * `secret` - only visible to organization owners and members of this team.  \n * `closed` - visible to all members of this organization.  \nDefault: `secret`  \n**For a parent or child team:**  \n * `closed` - visible to all members of this organization.  \nDefault for child team: `closed`",
-          "enum": [
-            "secret",
-            "closed"
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the team."
+            },
+            "description": {
+              "type": "string",
+              "description": "The description of the team."
+            },
+            "maintainers": {
+              "type": "array",
+              "description": "List GitHub usernames for organization members who will become team maintainers.",
+              "items": {
+                "type": "string"
+              }
+            },
+            "repo_names": {
+              "type": "array",
+              "description": "The full name (e.g., \"organization-name/repository-name\") of repositories to add the team to.",
+              "items": {
+                "type": "string"
+              }
+            },
+            "privacy": {
+              "type": "string",
+              "description": "The level of privacy this team should have. The options are:  \n**For a non-nested team:**  \n * `secret` - only visible to organization owners and members of this team.  \n * `closed` - visible to all members of this organization.  \nDefault: `secret`  \n**For a parent or child team:**  \n * `closed` - visible to all members of this organization.  \nDefault for child team: `closed`",
+              "enum": [
+                "secret",
+                "closed"
+              ]
+            },
+            "notification_setting": {
+              "type": "string",
+              "description": "The notification setting the team has chosen. The options are:  \n * `notifications_enabled` - team members receive notifications when the team is @mentioned.  \n * `notifications_disabled` - no one receives notifications.  \nDefault: `notifications_enabled`",
+              "enum": [
+                "notifications_enabled",
+                "notifications_disabled"
+              ]
+            },
+            "parent_team_id": {
+              "type": "integer",
+              "description": "The ID of a team to set as the parent team."
+            }
+          },
+          "required": [
+            "name"
           ]
         },
-        "notification_setting": {
-          "type": "string",
-          "description": "The notification setting the team has chosen. The options are:  \n * `notifications_enabled` - team members receive notifications when the team is @mentioned.  \n * `notifications_disabled` - no one receives notifications.  \nDefault: `notifications_enabled`",
-          "enum": [
-            "notifications_enabled",
-            "notifications_disabled"
-          ]
-        },
-        "parent_team_id": {
-          "type": "integer",
-          "description": "The ID of a team to set as the parent team."
+        {
+          "type": "object",
+          "properties": {
+            "exclude": {
+              "description": "You can exclude a list of repos for this team and all repos except these repos would have this team",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "include": {
+              "description": "You can include a list of repos for this team and only those repos would have this team",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
         }
-      },
-      "required": [
-        "name"
       ]
     },
     "MilestoneSettings": {

--- a/schema/dereferenced/settings.json
+++ b/schema/dereferenced/settings.json
@@ -421,62 +421,85 @@
       "type": "array",
       "items": {
         "description": "A team entry",
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The name of the team."
-          },
-          "description": {
-            "type": "string",
-            "description": "The description of the team."
-          },
-          "maintainers": {
-            "type": "array",
-            "description": "List GitHub usernames for organization members who will become team maintainers.",
-            "items": {
-              "type": "string"
-            }
-          },
-          "repo_names": {
-            "type": "array",
-            "description": "The full name (e.g., \"organization-name/repository-name\") of repositories to add the team to.",
-            "items": {
-              "type": "string"
-            }
-          },
-          "privacy": {
-            "type": "string",
-            "description": "The level of privacy this team should have. The options are:  \n**For a non-nested team:**  \n * `secret` - only visible to organization owners and members of this team.  \n * `closed` - visible to all members of this organization.  \nDefault: `secret`  \n**For a parent or child team:**  \n * `closed` - visible to all members of this organization.  \nDefault for child team: `closed`",
-            "enum": [
-              "secret",
-              "closed"
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the team."
+              },
+              "description": {
+                "type": "string",
+                "description": "The description of the team."
+              },
+              "maintainers": {
+                "type": "array",
+                "description": "List GitHub usernames for organization members who will become team maintainers.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "repo_names": {
+                "type": "array",
+                "description": "The full name (e.g., \"organization-name/repository-name\") of repositories to add the team to.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "privacy": {
+                "type": "string",
+                "description": "The level of privacy this team should have. The options are:  \n**For a non-nested team:**  \n * `secret` - only visible to organization owners and members of this team.  \n * `closed` - visible to all members of this organization.  \nDefault: `secret`  \n**For a parent or child team:**  \n * `closed` - visible to all members of this organization.  \nDefault for child team: `closed`",
+                "enum": [
+                  "secret",
+                  "closed"
+                ]
+              },
+              "notification_setting": {
+                "type": "string",
+                "description": "The notification setting the team has chosen. The options are:  \n * `notifications_enabled` - team members receive notifications when the team is @mentioned.  \n * `notifications_disabled` - no one receives notifications.  \nDefault: `notifications_enabled`",
+                "enum": [
+                  "notifications_enabled",
+                  "notifications_disabled"
+                ]
+              },
+              "permission": {
+                "type": "string",
+                "description": "**Closing down notice**. The permission that new repositories will be added to the team with when none is specified.",
+                "enum": [
+                  "pull",
+                  "push"
+                ],
+                "default": "pull"
+              },
+              "parent_team_id": {
+                "type": "integer",
+                "description": "The ID of a team to set as the parent team."
+              }
+            },
+            "required": [
+              "name"
             ]
           },
-          "notification_setting": {
-            "type": "string",
-            "description": "The notification setting the team has chosen. The options are:  \n * `notifications_enabled` - team members receive notifications when the team is @mentioned.  \n * `notifications_disabled` - no one receives notifications.  \nDefault: `notifications_enabled`",
-            "enum": [
-              "notifications_enabled",
-              "notifications_disabled"
-            ]
-          },
-          "permission": {
-            "type": "string",
-            "description": "**Closing down notice**. The permission that new repositories will be added to the team with when none is specified.",
-            "enum": [
-              "pull",
-              "push"
-            ],
-            "default": "pull"
-          },
-          "parent_team_id": {
-            "type": "integer",
-            "description": "The ID of a team to set as the parent team."
+          {
+            "type": "object",
+            "properties": {
+              "exclude": {
+                "description": "You can exclude a list of repos for this team and all repos except these repos would have this team",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "include": {
+                "description": "You can include a list of repos for this team and only those repos would have this team",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
           }
-        },
-        "required": [
-          "name"
         ]
       }
     },
@@ -2392,53 +2415,76 @@
     },
     "TeamSettings": {
       "description": "A team entry",
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "The name of the team."
-        },
-        "description": {
-          "type": "string",
-          "description": "The description of the team."
-        },
-        "maintainers": {
-          "type": "array",
-          "description": "List GitHub usernames for organization members who will become team maintainers.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "repo_names": {
-          "type": "array",
-          "description": "The full name (e.g., \"organization-name/repository-name\") of repositories to add the team to.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "privacy": {
-          "type": "string",
-          "description": "The level of privacy this team should have. The options are:  \n**For a non-nested team:**  \n * `secret` - only visible to organization owners and members of this team.  \n * `closed` - visible to all members of this organization.  \nDefault: `secret`  \n**For a parent or child team:**  \n * `closed` - visible to all members of this organization.  \nDefault for child team: `closed`",
-          "enum": [
-            "secret",
-            "closed"
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the team."
+            },
+            "description": {
+              "type": "string",
+              "description": "The description of the team."
+            },
+            "maintainers": {
+              "type": "array",
+              "description": "List GitHub usernames for organization members who will become team maintainers.",
+              "items": {
+                "type": "string"
+              }
+            },
+            "repo_names": {
+              "type": "array",
+              "description": "The full name (e.g., \"organization-name/repository-name\") of repositories to add the team to.",
+              "items": {
+                "type": "string"
+              }
+            },
+            "privacy": {
+              "type": "string",
+              "description": "The level of privacy this team should have. The options are:  \n**For a non-nested team:**  \n * `secret` - only visible to organization owners and members of this team.  \n * `closed` - visible to all members of this organization.  \nDefault: `secret`  \n**For a parent or child team:**  \n * `closed` - visible to all members of this organization.  \nDefault for child team: `closed`",
+              "enum": [
+                "secret",
+                "closed"
+              ]
+            },
+            "notification_setting": {
+              "type": "string",
+              "description": "The notification setting the team has chosen. The options are:  \n * `notifications_enabled` - team members receive notifications when the team is @mentioned.  \n * `notifications_disabled` - no one receives notifications.  \nDefault: `notifications_enabled`",
+              "enum": [
+                "notifications_enabled",
+                "notifications_disabled"
+              ]
+            },
+            "parent_team_id": {
+              "type": "integer",
+              "description": "The ID of a team to set as the parent team."
+            }
+          },
+          "required": [
+            "name"
           ]
         },
-        "notification_setting": {
-          "type": "string",
-          "description": "The notification setting the team has chosen. The options are:  \n * `notifications_enabled` - team members receive notifications when the team is @mentioned.  \n * `notifications_disabled` - no one receives notifications.  \nDefault: `notifications_enabled`",
-          "enum": [
-            "notifications_enabled",
-            "notifications_disabled"
-          ]
-        },
-        "parent_team_id": {
-          "type": "integer",
-          "description": "The ID of a team to set as the parent team."
+        {
+          "type": "object",
+          "properties": {
+            "exclude": {
+              "description": "You can exclude a list of repos for this team and all repos except these repos would have this team",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "include": {
+              "description": "You can include a list of repos for this team and only those repos would have this team",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
         }
-      },
-      "required": [
-        "name"
       ]
     },
     "MilestoneSettings": {

--- a/schema/dereferenced/suborgs.json
+++ b/schema/dereferenced/suborgs.json
@@ -434,53 +434,76 @@
       "type": "array",
       "items": {
         "description": "A team entry",
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The name of the team."
-          },
-          "description": {
-            "type": "string",
-            "description": "The description of the team."
-          },
-          "maintainers": {
-            "type": "array",
-            "description": "List GitHub usernames for organization members who will become team maintainers.",
-            "items": {
-              "type": "string"
-            }
-          },
-          "repo_names": {
-            "type": "array",
-            "description": "The full name (e.g., \"organization-name/repository-name\") of repositories to add the team to.",
-            "items": {
-              "type": "string"
-            }
-          },
-          "privacy": {
-            "type": "string",
-            "description": "The level of privacy this team should have. The options are:  \n**For a non-nested team:**  \n * `secret` - only visible to organization owners and members of this team.  \n * `closed` - visible to all members of this organization.  \nDefault: `secret`  \n**For a parent or child team:**  \n * `closed` - visible to all members of this organization.  \nDefault for child team: `closed`",
-            "enum": [
-              "secret",
-              "closed"
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the team."
+              },
+              "description": {
+                "type": "string",
+                "description": "The description of the team."
+              },
+              "maintainers": {
+                "type": "array",
+                "description": "List GitHub usernames for organization members who will become team maintainers.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "repo_names": {
+                "type": "array",
+                "description": "The full name (e.g., \"organization-name/repository-name\") of repositories to add the team to.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "privacy": {
+                "type": "string",
+                "description": "The level of privacy this team should have. The options are:  \n**For a non-nested team:**  \n * `secret` - only visible to organization owners and members of this team.  \n * `closed` - visible to all members of this organization.  \nDefault: `secret`  \n**For a parent or child team:**  \n * `closed` - visible to all members of this organization.  \nDefault for child team: `closed`",
+                "enum": [
+                  "secret",
+                  "closed"
+                ]
+              },
+              "notification_setting": {
+                "type": "string",
+                "description": "The notification setting the team has chosen. The options are:  \n * `notifications_enabled` - team members receive notifications when the team is @mentioned.  \n * `notifications_disabled` - no one receives notifications.  \nDefault: `notifications_enabled`",
+                "enum": [
+                  "notifications_enabled",
+                  "notifications_disabled"
+                ]
+              },
+              "parent_team_id": {
+                "type": "integer",
+                "description": "The ID of a team to set as the parent team."
+              }
+            },
+            "required": [
+              "name"
             ]
           },
-          "notification_setting": {
-            "type": "string",
-            "description": "The notification setting the team has chosen. The options are:  \n * `notifications_enabled` - team members receive notifications when the team is @mentioned.  \n * `notifications_disabled` - no one receives notifications.  \nDefault: `notifications_enabled`",
-            "enum": [
-              "notifications_enabled",
-              "notifications_disabled"
-            ]
-          },
-          "parent_team_id": {
-            "type": "integer",
-            "description": "The ID of a team to set as the parent team."
+          {
+            "type": "object",
+            "properties": {
+              "exclude": {
+                "description": "You can exclude a list of repos for this team and all repos except these repos would have this team",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "include": {
+                "description": "You can include a list of repos for this team and only those repos would have this team",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
           }
-        },
-        "required": [
-          "name"
         ]
       }
     },
@@ -1248,53 +1271,76 @@
     },
     "TeamSettings": {
       "description": "A team entry",
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "The name of the team."
-        },
-        "description": {
-          "type": "string",
-          "description": "The description of the team."
-        },
-        "maintainers": {
-          "type": "array",
-          "description": "List GitHub usernames for organization members who will become team maintainers.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "repo_names": {
-          "type": "array",
-          "description": "The full name (e.g., \"organization-name/repository-name\") of repositories to add the team to.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "privacy": {
-          "type": "string",
-          "description": "The level of privacy this team should have. The options are:  \n**For a non-nested team:**  \n * `secret` - only visible to organization owners and members of this team.  \n * `closed` - visible to all members of this organization.  \nDefault: `secret`  \n**For a parent or child team:**  \n * `closed` - visible to all members of this organization.  \nDefault for child team: `closed`",
-          "enum": [
-            "secret",
-            "closed"
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the team."
+            },
+            "description": {
+              "type": "string",
+              "description": "The description of the team."
+            },
+            "maintainers": {
+              "type": "array",
+              "description": "List GitHub usernames for organization members who will become team maintainers.",
+              "items": {
+                "type": "string"
+              }
+            },
+            "repo_names": {
+              "type": "array",
+              "description": "The full name (e.g., \"organization-name/repository-name\") of repositories to add the team to.",
+              "items": {
+                "type": "string"
+              }
+            },
+            "privacy": {
+              "type": "string",
+              "description": "The level of privacy this team should have. The options are:  \n**For a non-nested team:**  \n * `secret` - only visible to organization owners and members of this team.  \n * `closed` - visible to all members of this organization.  \nDefault: `secret`  \n**For a parent or child team:**  \n * `closed` - visible to all members of this organization.  \nDefault for child team: `closed`",
+              "enum": [
+                "secret",
+                "closed"
+              ]
+            },
+            "notification_setting": {
+              "type": "string",
+              "description": "The notification setting the team has chosen. The options are:  \n * `notifications_enabled` - team members receive notifications when the team is @mentioned.  \n * `notifications_disabled` - no one receives notifications.  \nDefault: `notifications_enabled`",
+              "enum": [
+                "notifications_enabled",
+                "notifications_disabled"
+              ]
+            },
+            "parent_team_id": {
+              "type": "integer",
+              "description": "The ID of a team to set as the parent team."
+            }
+          },
+          "required": [
+            "name"
           ]
         },
-        "notification_setting": {
-          "type": "string",
-          "description": "The notification setting the team has chosen. The options are:  \n * `notifications_enabled` - team members receive notifications when the team is @mentioned.  \n * `notifications_disabled` - no one receives notifications.  \nDefault: `notifications_enabled`",
-          "enum": [
-            "notifications_enabled",
-            "notifications_disabled"
-          ]
-        },
-        "parent_team_id": {
-          "type": "integer",
-          "description": "The ID of a team to set as the parent team."
+        {
+          "type": "object",
+          "properties": {
+            "exclude": {
+              "description": "You can exclude a list of repos for this team and all repos except these repos would have this team",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "include": {
+              "description": "You can include a list of repos for this team and only those repos would have this team",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
         }
-      },
-      "required": [
-        "name"
       ]
     },
     "MilestoneSettings": {

--- a/schema/repos.json
+++ b/schema/repos.json
@@ -190,7 +190,30 @@
     },
     "TeamSettings": {
       "description": "A team entry",
-      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2026-03-10.json#/paths/~1orgs~1{org}~1teams/post/requestBody/content/application~1json/schema"
+      "allOf": [
+        {
+          "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2026-03-10.json#/paths/~1orgs~1{org}~1teams/post/requestBody/content/application~1json/schema"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "exclude": {
+              "description": "You can exclude a list of repos for this team and all repos except these repos would have this team",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "include": {
+              "description": "You can include a list of repos for this team and only those repos would have this team",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ]
     },
     "MilestoneSettings": {
       "description": "A milestone entry",

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -197,7 +197,30 @@
     },
     "TeamSettings": {
       "description": "A team entry",
-      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2026-03-10.json#/paths/~1orgs~1{org}~1teams/post/requestBody/content/application~1json/schema"
+      "allOf": [
+        {
+          "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2026-03-10.json#/paths/~1orgs~1{org}~1teams/post/requestBody/content/application~1json/schema"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "exclude": {
+              "description": "You can exclude a list of repos for this team and all repos except these repos would have this team",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "include": {
+              "description": "You can include a list of repos for this team and only those repos would have this team",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ]
     },
     "MilestoneSettings": {
       "description": "A milestone entry",

--- a/schema/suborgs.json
+++ b/schema/suborgs.json
@@ -224,7 +224,30 @@
     },
     "TeamSettings": {
       "description": "A team entry",
-      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2026-03-10.json#/paths/~1orgs~1{org}~1teams/post/requestBody/content/application~1json/schema"
+      "allOf": [
+        {
+          "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2026-03-10.json#/paths/~1orgs~1{org}~1teams/post/requestBody/content/application~1json/schema"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "exclude": {
+              "description": "You can exclude a list of repos for this team and all repos except these repos would have this team",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "include": {
+              "description": "You can include a list of repos for this team and only those repos would have this team",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ]
     },
     "MilestoneSettings": {
       "description": "A milestone entry",

--- a/test/unit/lib/plugins/teams.test.js
+++ b/test/unit/lib/plugins/teams.test.js
@@ -103,4 +103,51 @@ describe('Teams', () => {
       )
     }
   })
+
+  describe('filtering teams by include/exclude', () => {
+    beforeEach(() => {
+      github.rest.repos.listTeams.mockResolvedValue({ data: [] })
+    })
+
+    it('does not add a team when the repo matches an exclude glob', async () => {
+      const plugin = configure([
+        { name: addedTeamName, permission: 'pull', exclude: ['test*'] }
+      ])
+
+      await plugin.sync()
+
+      expect(github.rest.teams.addOrUpdateRepoPermissionsInOrg).not.toHaveBeenCalled()
+    })
+
+    it('does not add a team when the repo is not in an include glob', async () => {
+      const plugin = configure([
+        { name: addedTeamName, permission: 'pull', include: ['other-*'] }
+      ])
+
+      await plugin.sync()
+
+      expect(github.rest.teams.addOrUpdateRepoPermissionsInOrg).not.toHaveBeenCalled()
+    })
+
+    it('adds a team when the repo matches an include glob', async () => {
+      when(github.rest.teams.getByName)
+        .calledWith({ org, team_slug: addedTeamName })
+        .mockResolvedValue({ data: { id: addedTeamId } })
+
+      const plugin = configure([
+        { name: addedTeamName, permission: 'pull', include: ['test*'] }
+      ])
+
+      await plugin.sync()
+
+      expect(github.rest.teams.addOrUpdateRepoPermissionsInOrg).toHaveBeenCalledWith({
+        org,
+        team_id: addedTeamId,
+        team_slug: addedTeamName,
+        owner: org,
+        repo: 'test',
+        permission: 'pull'
+      })
+    })
+  })
 })


### PR DESCRIPTION
Team entries are filtered by the same Diffable include/exclude logic that collaborators use, but unlike collaborators those keys were never part of the `TeamSettings` schema or documented, so editors and linters can't validate them.

Mirror the `allOf` pattern of `CollaboratorSettings` to declare include and exclude on TeamSettings, document both in the teams guide with examples, add a sample, and cover the filter path with unit tests.

**No runtime changes in the logic**

Solves #1011 