### PR TITLE
fix(schema): OpenAPI 3.1 bump + schema fixes

### DIFF
--- a/schema/dereferenced/repos.json
+++ b/schema/dereferenced/repos.json
@@ -499,8 +499,13 @@
           "protection": {
             "anyOf": [
               {
-                "type": "null",
-                "description": "Set to `null` to delete the existing branch protection"
+                "enum": [
+                  null,
+                  {},
+                  [],
+                  false
+                ],
+                "description": "An empty value deletes the existing branch protection"
               },
               {
                 "type": "object",
@@ -2406,8 +2411,13 @@
         "protection": {
           "anyOf": [
             {
-              "type": "null",
-              "description": "Set to `null` to delete the existing branch protection"
+              "enum": [
+                null,
+                {},
+                [],
+                false
+              ],
+              "description": "An empty value deletes the existing branch protection"
             },
             {
               "type": "object",

--- a/schema/dereferenced/repos.json
+++ b/schema/dereferenced/repos.json
@@ -36,9 +36,11 @@
               ]
             },
             "security_and_analysis": {
-              "type": "object",
+              "type": [
+                "object",
+                "null"
+              ],
               "description": "Specify which security and analysis features to enable or disable for the repository.\n\nTo use this parameter, you must have admin permissions for the repository or be an owner or security manager for the organization that owns the repository. For more information, see \"[Managing security managers in your organization](https://docs.github.com/organizations/managing-peoples-access-to-your-organization-with-roles/managing-security-managers-in-your-organization).\"\n\nFor example, to enable GitHub Advanced Security, use this data in the body of the `PATCH` request:\n`{ \"security_and_analysis\": {\"advanced_security\": { \"status\": \"enabled\" } } }`.\n\nYou can check which security and analysis features are currently enabled by using a `GET /repos/{owner}/{repo}` request.",
-              "nullable": true,
               "properties": {
                 "advanced_security": {
                   "type": "object",
@@ -176,6 +178,19 @@
               "type": "boolean",
               "description": "Either `true` to enable the wiki for this repository or `false` to disable it.",
               "default": true
+            },
+            "has_pull_requests": {
+              "type": "boolean",
+              "description": "Either `true` to allow pull requests for this repository or `false` to prevent pull requests.",
+              "default": true
+            },
+            "pull_request_creation_policy": {
+              "type": "string",
+              "description": "The policy that controls who can create pull requests for this repository: `all` or `collaborators_only`.",
+              "enum": [
+                "all",
+                "collaborators_only"
+              ]
             },
             "is_template": {
               "type": "boolean",
@@ -485,9 +500,11 @@
             "type": "object",
             "properties": {
               "required_status_checks": {
-                "type": "object",
+                "type": [
+                  "object",
+                  "null"
+                ],
                 "description": "Require status checks to pass before merging. Set to `null` to disable.",
-                "nullable": true,
                 "properties": {
                   "strict": {
                     "type": "boolean",
@@ -528,14 +545,18 @@
                 ]
               },
               "enforce_admins": {
-                "type": "boolean",
-                "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable.",
-                "nullable": true
+                "type": [
+                  "boolean",
+                  "null"
+                ],
+                "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable."
               },
               "required_pull_request_reviews": {
-                "type": "object",
+                "type": [
+                  "object",
+                  "null"
+                ],
                 "description": "Require at least one approving review on a pull request, before merging. Set to `null` to disable.",
-                "nullable": true,
                 "properties": {
                   "dismissal_restrictions": {
                     "type": "object",
@@ -611,9 +632,11 @@
                 }
               },
               "restrictions": {
-                "type": "object",
+                "type": [
+                  "object",
+                  "null"
+                ],
                 "description": "Restrict who can push to the protected branch. User, app, and team `restrictions` are only available for organization-owned repositories. Set to `null` to disable.",
-                "nullable": true,
                 "properties": {
                   "users": {
                     "type": "array",
@@ -647,9 +670,11 @@
                 "description": "Enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch. Set to `true` to enforce a linear commit history. Set to `false` to disable a linear commit Git history. Your repository must allow squash merging or rebase merging before you can enable a linear commit history. Default: `false`. For more information, see \"[Requiring a linear commit history](https://docs.github.com/github/administering-a-repository/requiring-a-linear-commit-history)\" in the GitHub Help documentation."
               },
               "allow_force_pushes": {
-                "type": "boolean",
-                "description": "Permits force pushes to the protected branch by anyone with write access to the repository. Set to `true` to allow force pushes. Set to `false` or `null` to block force pushes. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation.\"",
-                "nullable": true
+                "type": [
+                  "boolean",
+                  "null"
+                ],
+                "description": "Permits force pushes to the protected branch by anyone with write access to the repository. Set to `true` to allow force pushes. Set to `false` or `null` to block force pushes. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation.\""
               },
               "allow_deletions": {
                 "type": "boolean",
@@ -857,9 +882,11 @@
               ]
             },
             "security_and_analysis": {
-              "type": "object",
+              "type": [
+                "object",
+                "null"
+              ],
               "description": "Specify which security and analysis features to enable or disable for the repository.\n\nTo use this parameter, you must have admin permissions for the repository or be an owner or security manager for the organization that owns the repository. For more information, see \"[Managing security managers in your organization](https://docs.github.com/organizations/managing-peoples-access-to-your-organization-with-roles/managing-security-managers-in-your-organization).\"\n\nFor example, to enable GitHub Advanced Security, use this data in the body of the `PATCH` request:\n`{ \"security_and_analysis\": {\"advanced_security\": { \"status\": \"enabled\" } } }`.\n\nYou can check which security and analysis features are currently enabled by using a `GET /repos/{owner}/{repo}` request.",
-              "nullable": true,
               "properties": {
                 "advanced_security": {
                   "type": "object",
@@ -997,6 +1024,19 @@
               "type": "boolean",
               "description": "Either `true` to enable the wiki for this repository or `false` to disable it.",
               "default": true
+            },
+            "has_pull_requests": {
+              "type": "boolean",
+              "description": "Either `true` to allow pull requests for this repository or `false` to prevent pull requests.",
+              "default": true
+            },
+            "pull_request_creation_policy": {
+              "type": "string",
+              "description": "The policy that controls who can create pull requests for this repository: `all` or `collaborators_only`.",
+              "enum": [
+                "all",
+                "collaborators_only"
+              ]
             },
             "is_template": {
               "type": "boolean",
@@ -1291,9 +1331,11 @@
           "type": "object",
           "properties": {
             "required_status_checks": {
-              "type": "object",
+              "type": [
+                "object",
+                "null"
+              ],
               "description": "Require status checks to pass before merging. Set to `null` to disable.",
-              "nullable": true,
               "properties": {
                 "strict": {
                   "type": "boolean",
@@ -1334,14 +1376,18 @@
               ]
             },
             "enforce_admins": {
-              "type": "boolean",
-              "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable.",
-              "nullable": true
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable."
             },
             "required_pull_request_reviews": {
-              "type": "object",
+              "type": [
+                "object",
+                "null"
+              ],
               "description": "Require at least one approving review on a pull request, before merging. Set to `null` to disable.",
-              "nullable": true,
               "properties": {
                 "dismissal_restrictions": {
                   "type": "object",
@@ -1417,9 +1463,11 @@
               }
             },
             "restrictions": {
-              "type": "object",
+              "type": [
+                "object",
+                "null"
+              ],
               "description": "Restrict who can push to the protected branch. User, app, and team `restrictions` are only available for organization-owned repositories. Set to `null` to disable.",
-              "nullable": true,
               "properties": {
                 "users": {
                   "type": "array",
@@ -1453,9 +1501,11 @@
               "description": "Enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch. Set to `true` to enforce a linear commit history. Set to `false` to disable a linear commit Git history. Your repository must allow squash merging or rebase merging before you can enable a linear commit history. Default: `false`. For more information, see \"[Requiring a linear commit history](https://docs.github.com/github/administering-a-repository/requiring-a-linear-commit-history)\" in the GitHub Help documentation."
             },
             "allow_force_pushes": {
-              "type": "boolean",
-              "description": "Permits force pushes to the protected branch by anyone with write access to the repository. Set to `true` to allow force pushes. Set to `false` or `null` to block force pushes. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation.\"",
-              "nullable": true
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "description": "Permits force pushes to the protected branch by anyone with write access to the repository. Set to `true` to allow force pushes. Set to `false` or `null` to block force pushes. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation.\""
             },
             "allow_deletions": {
               "type": "boolean",
@@ -1561,9 +1611,11 @@
             ],
             "properties": {
               "actor_id": {
-                "type": "integer",
-                "nullable": true,
-                "description": "The ID of the actor that can bypass a ruleset. Required for `Integration`, `RepositoryRole`, and `Team` actor types. If `actor_type` is `OrganizationAdmin`, `actor_id` is ignored. If `actor_type` is `DeployKey`, this should be null. `OrganizationAdmin` is not applicable for personal repositories."
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "The ID of the actor that can bypass a ruleset. Required for `Integration`, `RepositoryRole`, `Team`, and `User` actor types. If `actor_type` is `OrganizationAdmin`, `actor_id` is ignored. If `actor_type` is `DeployKey`, this should be null. `OrganizationAdmin` is not applicable for personal repositories."
               },
               "actor_type": {
                 "type": "string",
@@ -1572,7 +1624,8 @@
                   "OrganizationAdmin",
                   "RepositoryRole",
                   "Team",
-                  "DeployKey"
+                  "DeployKey",
+                  "User"
                 ],
                 "description": "The type of actor that can bypass a ruleset."
               },
@@ -1996,6 +2049,49 @@
                       "dismiss_stale_reviews_on_push": {
                         "type": "boolean",
                         "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
+                      },
+                      "dismissal_restriction": {
+                        "title": "DismissalRestriction",
+                        "description": "Specify people, teams, or apps allowed to dismiss pull request reviews.",
+                        "type": "object",
+                        "properties": {
+                          "allowed_actors": {
+                            "type": "array",
+                            "description": "Specify people, teams, or apps allowed to dismiss pull request reviews.",
+                            "items": {
+                              "title": "Actor",
+                              "description": "An actor allowed to dismiss pull request reviews",
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "integer",
+                                  "description": "ID of the actor that can dismiss reviews."
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "description": "The type of the actor",
+                                  "enum": [
+                                    "User",
+                                    "Team",
+                                    "IntegrationInstallation",
+                                    "RepositoryRole"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "type"
+                              ]
+                            }
+                          },
+                          "enabled": {
+                            "type": "boolean",
+                            "description": "Whether to restrict review dismissal to specific actors."
+                          }
+                        },
+                        "required": [
+                          "enabled"
+                        ]
                       },
                       "require_code_owner_review": {
                         "type": "boolean",

--- a/schema/dereferenced/repos.json
+++ b/schema/dereferenced/repos.json
@@ -753,6 +753,1074 @@
         }
       }
     },
+    "rulesets": {
+      "description": "Repository rulesets applied to this repository",
+      "type": "array",
+      "items": {
+        "description": "A repository ruleset entry",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the ruleset."
+          },
+          "target": {
+            "type": "string",
+            "description": "The target of the ruleset",
+            "enum": [
+              "branch",
+              "tag",
+              "push"
+            ],
+            "default": "branch"
+          },
+          "enforcement": {
+            "type": "string",
+            "description": "The enforcement level of the ruleset. `evaluate` allows admins to test rules before enforcing them. Admins can view insights on the Rule Insights page (`evaluate` is only available with GitHub Enterprise).",
+            "enum": [
+              "disabled",
+              "active",
+              "evaluate"
+            ]
+          },
+          "bypass_actors": {
+            "type": "array",
+            "description": "The actors that can bypass the rules in this ruleset",
+            "items": {
+              "title": "Repository Ruleset Bypass Actor",
+              "type": "object",
+              "description": "An actor that can bypass rules in a ruleset",
+              "required": [
+                "actor_type"
+              ],
+              "properties": {
+                "actor_id": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "description": "The ID of the actor that can bypass a ruleset. Required for `Integration`, `RepositoryRole`, `Team`, and `User` actor types. If `actor_type` is `OrganizationAdmin`, `actor_id` is ignored. If `actor_type` is `DeployKey`, this should be null. `OrganizationAdmin` is not applicable for personal repositories."
+                },
+                "actor_type": {
+                  "type": "string",
+                  "enum": [
+                    "Integration",
+                    "OrganizationAdmin",
+                    "RepositoryRole",
+                    "Team",
+                    "DeployKey",
+                    "User"
+                  ],
+                  "description": "The type of actor that can bypass a ruleset."
+                },
+                "bypass_mode": {
+                  "type": "string",
+                  "description": "When the specified actor can bypass the ruleset. `pull_request` means that an actor can only bypass rules on pull requests. `pull_request` is not applicable for the `DeployKey` actor type. Also, `pull_request` is only applicable to branch rulesets. When `bypass_mode` is `exempt`, rules will not be run for that actor and a bypass audit entry will not be created.",
+                  "enum": [
+                    "always",
+                    "pull_request",
+                    "exempt"
+                  ],
+                  "default": "always"
+                }
+              }
+            }
+          },
+          "conditions": {
+            "title": "Repository ruleset conditions for ref names",
+            "type": "object",
+            "description": "Parameters for a repository ruleset ref name condition",
+            "properties": {
+              "ref_name": {
+                "type": "object",
+                "properties": {
+                  "include": {
+                    "type": "array",
+                    "description": "Array of ref names or patterns to include. One of these patterns must match for the condition to pass. Also accepts `~DEFAULT_BRANCH` to include the default branch or `~ALL` to include all branches.",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "exclude": {
+                    "type": "array",
+                    "description": "Array of ref names or patterns to exclude. The condition will not pass if any of these patterns match.",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "rules": {
+            "type": "array",
+            "description": "An array of rules within the ruleset.",
+            "items": {
+              "title": "Repository Rule",
+              "type": "object",
+              "description": "A repository rule.",
+              "oneOf": [
+                {
+                  "title": "creation",
+                  "description": "Only allow users with bypass permission to create matching refs.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "creation"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "update",
+                  "description": "Only allow users with bypass permission to update matching refs.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "update"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "update_allows_fetch_and_merge": {
+                          "type": "boolean",
+                          "description": "Branch can pull changes from its upstream repository"
+                        }
+                      },
+                      "required": [
+                        "update_allows_fetch_and_merge"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "deletion",
+                  "description": "Only allow users with bypass permissions to delete matching refs.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "deletion"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "required_linear_history",
+                  "description": "Prevent merge commits from being pushed to matching refs.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "required_linear_history"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "merge_queue",
+                  "description": "Merges must be performed via a merge queue.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "merge_queue"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "check_response_timeout_minutes": {
+                          "type": "integer",
+                          "description": "Maximum time for a required status check to report a conclusion. After this much time has elapsed, checks that have not reported a conclusion will be assumed to have failed",
+                          "minimum": 1,
+                          "maximum": 360
+                        },
+                        "grouping_strategy": {
+                          "type": "string",
+                          "description": "When set to ALLGREEN, the merge commit created by merge queue for each PR in the group must pass all required checks to merge. When set to HEADGREEN, only the commit at the head of the merge group, i.e. the commit containing changes from all of the PRs in the group, must pass its required checks to merge.",
+                          "enum": [
+                            "ALLGREEN",
+                            "HEADGREEN"
+                          ]
+                        },
+                        "max_entries_to_build": {
+                          "type": "integer",
+                          "description": "Limit the number of queued pull requests requesting checks and workflow runs at the same time.",
+                          "minimum": 0,
+                          "maximum": 100
+                        },
+                        "max_entries_to_merge": {
+                          "type": "integer",
+                          "description": "The maximum number of PRs that will be merged together in a group.",
+                          "minimum": 0,
+                          "maximum": 100
+                        },
+                        "merge_method": {
+                          "type": "string",
+                          "description": "Method to use when merging changes from queued pull requests.",
+                          "enum": [
+                            "MERGE",
+                            "SQUASH",
+                            "REBASE"
+                          ]
+                        },
+                        "min_entries_to_merge": {
+                          "type": "integer",
+                          "description": "The minimum number of PRs that will be merged together in a group.",
+                          "minimum": 0,
+                          "maximum": 100
+                        },
+                        "min_entries_to_merge_wait_minutes": {
+                          "type": "integer",
+                          "description": "The time merge queue should wait after the first PR is added to the queue for the minimum group size to be met. After this time has elapsed, the minimum group size will be ignored and a smaller group will be merged.",
+                          "minimum": 0,
+                          "maximum": 360
+                        }
+                      },
+                      "required": [
+                        "check_response_timeout_minutes",
+                        "grouping_strategy",
+                        "max_entries_to_build",
+                        "max_entries_to_merge",
+                        "merge_method",
+                        "min_entries_to_merge",
+                        "min_entries_to_merge_wait_minutes"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "required_deployments",
+                  "description": "Choose which environments must be successfully deployed to before refs can be pushed into a ref that matches this rule.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "required_deployments"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "required_deployment_environments": {
+                          "type": "array",
+                          "description": "The environments that must be successfully deployed to before branches can be merged.",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "required_deployment_environments"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "required_signatures",
+                  "description": "Commits pushed to matching refs must have verified signatures.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "required_signatures"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "pull_request",
+                  "description": "Require all commits be made to a non-target branch and submitted via a pull request before they can be merged.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "pull_request"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "allowed_merge_methods": {
+                          "type": "array",
+                          "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled.",
+                          "items": {
+                            "type": "string",
+                            "enum": [
+                              "merge",
+                              "squash",
+                              "rebase"
+                            ]
+                          }
+                        },
+                        "dismiss_stale_reviews_on_push": {
+                          "type": "boolean",
+                          "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
+                        },
+                        "dismissal_restriction": {
+                          "title": "DismissalRestriction",
+                          "description": "Specify people, teams, or apps allowed to dismiss pull request reviews.",
+                          "type": "object",
+                          "properties": {
+                            "allowed_actors": {
+                              "type": "array",
+                              "description": "Specify people, teams, or apps allowed to dismiss pull request reviews.",
+                              "items": {
+                                "title": "Actor",
+                                "description": "An actor allowed to dismiss pull request reviews",
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "integer",
+                                    "description": "ID of the actor that can dismiss reviews."
+                                  },
+                                  "type": {
+                                    "type": "string",
+                                    "description": "The type of the actor",
+                                    "enum": [
+                                      "User",
+                                      "Team",
+                                      "IntegrationInstallation",
+                                      "RepositoryRole"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "id",
+                                  "type"
+                                ]
+                              }
+                            },
+                            "enabled": {
+                              "type": "boolean",
+                              "description": "Whether to restrict review dismissal to specific actors."
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ]
+                        },
+                        "require_code_owner_review": {
+                          "type": "boolean",
+                          "description": "Require an approving review in pull requests that modify files that have a designated code owner."
+                        },
+                        "require_last_push_approval": {
+                          "type": "boolean",
+                          "description": "Whether the most recent reviewable push must be approved by someone other than the person who pushed it."
+                        },
+                        "required_approving_review_count": {
+                          "type": "integer",
+                          "description": "The number of approving reviews that are required before a pull request can be merged.",
+                          "minimum": 0,
+                          "maximum": 10
+                        },
+                        "required_review_thread_resolution": {
+                          "type": "boolean",
+                          "description": "All conversations on code must be resolved before a pull request can be merged."
+                        },
+                        "required_reviewers": {
+                          "type": "array",
+                          "description": "> [!NOTE]\n> `required_reviewers` is in beta and subject to change.\n\nA collection of reviewers and associated file patterns. Each reviewer has a list of file patterns which determine the files that reviewer is required to review.",
+                          "items": {
+                            "title": "RequiredReviewerConfiguration",
+                            "description": "A reviewing team, and file patterns describing which files they must approve changes to.",
+                            "type": "object",
+                            "properties": {
+                              "file_patterns": {
+                                "type": "array",
+                                "description": "Array of file patterns. Pull requests which change matching files must be approved by the specified team. File patterns use fnmatch syntax.",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "minimum_approvals": {
+                                "type": "integer",
+                                "description": "Minimum number of approvals required from the specified team. If set to zero, the team will be added to the pull request but approval is optional."
+                              },
+                              "reviewer": {
+                                "title": "Reviewer",
+                                "description": "A required reviewing team",
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "integer",
+                                    "description": "ID of the reviewer which must review changes to matching files."
+                                  },
+                                  "type": {
+                                    "type": "string",
+                                    "description": "The type of the reviewer",
+                                    "enum": [
+                                      "Team"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "id",
+                                  "type"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "file_patterns",
+                              "minimum_approvals",
+                              "reviewer"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "dismiss_stale_reviews_on_push",
+                        "require_code_owner_review",
+                        "require_last_push_approval",
+                        "required_approving_review_count",
+                        "required_review_thread_resolution"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "required_status_checks",
+                  "description": "Choose which status checks must pass before the ref is updated. When enabled, commits must first be pushed to another ref where the checks pass.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "required_status_checks"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "do_not_enforce_on_create": {
+                          "type": "boolean",
+                          "description": "Allow repositories and branches to be created if a check would otherwise prohibit it."
+                        },
+                        "required_status_checks": {
+                          "type": "array",
+                          "description": "Status checks that are required.",
+                          "items": {
+                            "title": "StatusCheckConfiguration",
+                            "description": "Required status check",
+                            "type": "object",
+                            "properties": {
+                              "context": {
+                                "type": "string",
+                                "description": "The status check context name that must be present on the commit."
+                              },
+                              "integration_id": {
+                                "type": "integer",
+                                "description": "The optional integration ID that this status check must originate from."
+                              }
+                            },
+                            "required": [
+                              "context"
+                            ]
+                          }
+                        },
+                        "strict_required_status_checks_policy": {
+                          "type": "boolean",
+                          "description": "Whether pull requests targeting a matching branch must be tested with the latest code. This setting will not take effect unless at least one status check is enabled."
+                        }
+                      },
+                      "required": [
+                        "required_status_checks",
+                        "strict_required_status_checks_policy"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "non_fast_forward",
+                  "description": "Prevent users with push access from force pushing to refs.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "non_fast_forward"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "commit_message_pattern",
+                  "description": "Parameters to be used for the commit_message_pattern rule",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "commit_message_pattern"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "How this rule appears when configuring it."
+                        },
+                        "negate": {
+                          "type": "boolean",
+                          "description": "If true, the rule will fail if the pattern matches."
+                        },
+                        "operator": {
+                          "type": "string",
+                          "description": "The operator to use for matching.",
+                          "enum": [
+                            "starts_with",
+                            "ends_with",
+                            "contains",
+                            "regex"
+                          ]
+                        },
+                        "pattern": {
+                          "type": "string",
+                          "description": "The pattern to match with."
+                        }
+                      },
+                      "required": [
+                        "operator",
+                        "pattern"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "commit_author_email_pattern",
+                  "description": "Parameters to be used for the commit_author_email_pattern rule",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "commit_author_email_pattern"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "How this rule appears when configuring it."
+                        },
+                        "negate": {
+                          "type": "boolean",
+                          "description": "If true, the rule will fail if the pattern matches."
+                        },
+                        "operator": {
+                          "type": "string",
+                          "description": "The operator to use for matching.",
+                          "enum": [
+                            "starts_with",
+                            "ends_with",
+                            "contains",
+                            "regex"
+                          ]
+                        },
+                        "pattern": {
+                          "type": "string",
+                          "description": "The pattern to match with."
+                        }
+                      },
+                      "required": [
+                        "operator",
+                        "pattern"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "committer_email_pattern",
+                  "description": "Parameters to be used for the committer_email_pattern rule",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "committer_email_pattern"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "How this rule appears when configuring it."
+                        },
+                        "negate": {
+                          "type": "boolean",
+                          "description": "If true, the rule will fail if the pattern matches."
+                        },
+                        "operator": {
+                          "type": "string",
+                          "description": "The operator to use for matching.",
+                          "enum": [
+                            "starts_with",
+                            "ends_with",
+                            "contains",
+                            "regex"
+                          ]
+                        },
+                        "pattern": {
+                          "type": "string",
+                          "description": "The pattern to match with."
+                        }
+                      },
+                      "required": [
+                        "operator",
+                        "pattern"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "branch_name_pattern",
+                  "description": "Parameters to be used for the branch_name_pattern rule",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "branch_name_pattern"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "How this rule appears when configuring it."
+                        },
+                        "negate": {
+                          "type": "boolean",
+                          "description": "If true, the rule will fail if the pattern matches."
+                        },
+                        "operator": {
+                          "type": "string",
+                          "description": "The operator to use for matching.",
+                          "enum": [
+                            "starts_with",
+                            "ends_with",
+                            "contains",
+                            "regex"
+                          ]
+                        },
+                        "pattern": {
+                          "type": "string",
+                          "description": "The pattern to match with."
+                        }
+                      },
+                      "required": [
+                        "operator",
+                        "pattern"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "tag_name_pattern",
+                  "description": "Parameters to be used for the tag_name_pattern rule",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "tag_name_pattern"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "How this rule appears when configuring it."
+                        },
+                        "negate": {
+                          "type": "boolean",
+                          "description": "If true, the rule will fail if the pattern matches."
+                        },
+                        "operator": {
+                          "type": "string",
+                          "description": "The operator to use for matching.",
+                          "enum": [
+                            "starts_with",
+                            "ends_with",
+                            "contains",
+                            "regex"
+                          ]
+                        },
+                        "pattern": {
+                          "type": "string",
+                          "description": "The pattern to match with."
+                        }
+                      },
+                      "required": [
+                        "operator",
+                        "pattern"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "workflows",
+                  "description": "Require all changes made to a targeted branch to pass the specified workflows before they can be merged.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "workflows"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "do_not_enforce_on_create": {
+                          "type": "boolean",
+                          "description": "Allow repositories and branches to be created if a check would otherwise prohibit it."
+                        },
+                        "workflows": {
+                          "type": "array",
+                          "description": "Workflows that must pass for this rule to pass.",
+                          "items": {
+                            "title": "WorkflowFileReference",
+                            "description": "A workflow that must run for this rule to pass",
+                            "type": "object",
+                            "properties": {
+                              "path": {
+                                "type": "string",
+                                "description": "The path to the workflow file"
+                              },
+                              "ref": {
+                                "type": "string",
+                                "description": "The ref (branch or tag) of the workflow file to use"
+                              },
+                              "repository_id": {
+                                "type": "integer",
+                                "description": "The ID of the repository where the workflow is defined"
+                              },
+                              "sha": {
+                                "type": "string",
+                                "description": "The commit SHA of the workflow file to use"
+                              }
+                            },
+                            "required": [
+                              "path",
+                              "repository_id"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "workflows"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "code_scanning",
+                  "description": "Choose which tools must provide code scanning results before the reference is updated. When configured, code scanning must be enabled and have results for both the commit and the reference being updated.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "code_scanning"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "code_scanning_tools": {
+                          "type": "array",
+                          "description": "Tools that must provide code scanning results for this rule to pass.",
+                          "items": {
+                            "title": "CodeScanningTool",
+                            "description": "A tool that must provide code scanning results for this rule to pass.",
+                            "type": "object",
+                            "properties": {
+                              "alerts_threshold": {
+                                "type": "string",
+                                "description": "The severity level at which code scanning results that raise alerts block a reference update. For more information on alert severity levels, see \"[About code scanning alerts](https://docs.github.com/code-security/code-scanning/managing-code-scanning-alerts/about-code-scanning-alerts#about-alert-severity-and-security-severity-levels).\"",
+                                "enum": [
+                                  "none",
+                                  "errors",
+                                  "errors_and_warnings",
+                                  "all"
+                                ]
+                              },
+                              "security_alerts_threshold": {
+                                "type": "string",
+                                "description": "The severity level at which code scanning results that raise security alerts block a reference update. For more information on security severity levels, see \"[About code scanning alerts](https://docs.github.com/code-security/code-scanning/managing-code-scanning-alerts/about-code-scanning-alerts#about-alert-severity-and-security-severity-levels).\"",
+                                "enum": [
+                                  "none",
+                                  "critical",
+                                  "high_or_higher",
+                                  "medium_or_higher",
+                                  "all"
+                                ]
+                              },
+                              "tool": {
+                                "type": "string",
+                                "description": "The name of a code scanning tool"
+                              }
+                            },
+                            "required": [
+                              "alerts_threshold",
+                              "security_alerts_threshold",
+                              "tool"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "code_scanning_tools"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "copilot_code_review",
+                  "description": "Request Copilot code review for new pull requests automatically if the author has access to Copilot code review and their premium requests quota has not reached the limit.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "copilot_code_review"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "review_draft_pull_requests": {
+                          "type": "boolean",
+                          "description": "Copilot automatically reviews draft pull requests before they are marked as ready for review."
+                        },
+                        "review_on_push": {
+                          "type": "boolean",
+                          "description": "Copilot automatically reviews each new push to the pull request."
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "title": "license_compliance_scanning",
+                  "description": "Enforce any added or changed dependencies to comply with the organization's license policy.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "license_compliance_scanning"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "file_path_restriction",
+                  "description": "Prevent commits that include changes in specified file and folder paths from being pushed to the commit graph. This includes absolute paths that contain file names.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "file_path_restriction"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "restricted_file_paths": {
+                          "type": "array",
+                          "description": "The file paths that are restricted from being pushed to the commit graph.",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "restricted_file_paths"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "max_file_path_length",
+                  "description": "Prevent commits that include file paths that exceed the specified character limit from being pushed to the commit graph.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "max_file_path_length"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "max_file_path_length": {
+                          "type": "integer",
+                          "description": "The maximum amount of characters allowed in file paths.",
+                          "minimum": 1,
+                          "maximum": 32767
+                        }
+                      },
+                      "required": [
+                        "max_file_path_length"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "file_extension_restriction",
+                  "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "file_extension_restriction"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "restricted_file_extensions": {
+                          "type": "array",
+                          "description": "The file extensions that are restricted from being pushed to the commit graph.",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "restricted_file_extensions"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "max_file_size",
+                  "description": "Prevent commits with individual files that exceed the specified limit from being pushed to the commit graph.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "max_file_size"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "max_file_size": {
+                          "type": "integer",
+                          "description": "The maximum file size allowed in megabytes. This limit does not apply to Git Large File Storage (Git LFS).",
+                          "minimum": 1,
+                          "maximum": 100
+                        }
+                      },
+                      "required": [
+                        "max_file_size"
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "required": [
+          "name",
+          "enforcement"
+        ]
+      }
+    },
     "environments": {
       "description": "Deployment environments",
       "type": "array",
@@ -1588,7 +2656,7 @@
       }
     },
     "RulesetSettings": {
-      "description": "A ruleset entry",
+      "description": "A repository ruleset entry",
       "type": "object",
       "properties": {
         "name": {
@@ -1601,8 +2669,7 @@
           "enum": [
             "branch",
             "tag",
-            "push",
-            "repository"
+            "push"
           ],
           "default": "branch"
         },
@@ -1659,248 +2726,30 @@
           }
         },
         "conditions": {
-          "title": "Organization ruleset conditions",
+          "title": "Repository ruleset conditions for ref names",
           "type": "object",
-          "description": "Conditions for an organization ruleset.\nThe branch and tag rulesets conditions object should contain both `repository_name` and `ref_name` properties, or both `repository_id` and `ref_name` properties, or both `repository_property` and `ref_name` properties.\nThe push rulesets conditions object does not require the `ref_name` property.\nFor repository policy rulesets, the conditions object should only contain the `repository_name`, the `repository_id`, or the `repository_property`.",
-          "oneOf": [
-            {
+          "description": "Parameters for a repository ruleset ref name condition",
+          "properties": {
+            "ref_name": {
               "type": "object",
-              "title": "repository_name_and_ref_name",
-              "description": "Conditions to target repositories by name and refs by name",
-              "allOf": [
-                {
-                  "title": "Repository ruleset conditions for ref names",
-                  "type": "object",
-                  "description": "Parameters for a repository ruleset ref name condition",
-                  "properties": {
-                    "ref_name": {
-                      "type": "object",
-                      "properties": {
-                        "include": {
-                          "type": "array",
-                          "description": "Array of ref names or patterns to include. One of these patterns must match for the condition to pass. Also accepts `~DEFAULT_BRANCH` to include the default branch or `~ALL` to include all branches.",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "exclude": {
-                          "type": "array",
-                          "description": "Array of ref names or patterns to exclude. The condition will not pass if any of these patterns match.",
-                          "items": {
-                            "type": "string"
-                          }
-                        }
-                      }
-                    }
+              "properties": {
+                "include": {
+                  "type": "array",
+                  "description": "Array of ref names or patterns to include. One of these patterns must match for the condition to pass. Also accepts `~DEFAULT_BRANCH` to include the default branch or `~ALL` to include all branches.",
+                  "items": {
+                    "type": "string"
                   }
                 },
-                {
-                  "title": "Repository ruleset conditions for repository names",
-                  "type": "object",
-                  "description": "Parameters for a repository name condition",
-                  "properties": {
-                    "repository_name": {
-                      "type": "object",
-                      "properties": {
-                        "include": {
-                          "type": "array",
-                          "description": "Array of repository names or patterns to include. One of these patterns must match for the condition to pass. Also accepts `~ALL` to include all repositories.",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "exclude": {
-                          "type": "array",
-                          "description": "Array of repository names or patterns to exclude. The condition will not pass if any of these patterns match.",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "protected": {
-                          "type": "boolean",
-                          "description": "Whether renaming of target repositories is prevented."
-                        }
-                      }
-                    }
-                  },
-                  "required": [
-                    "repository_name"
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "object",
-              "title": "repository_id_and_ref_name",
-              "description": "Conditions to target repositories by id and refs by name",
-              "allOf": [
-                {
-                  "title": "Repository ruleset conditions for ref names",
-                  "type": "object",
-                  "description": "Parameters for a repository ruleset ref name condition",
-                  "properties": {
-                    "ref_name": {
-                      "type": "object",
-                      "properties": {
-                        "include": {
-                          "type": "array",
-                          "description": "Array of ref names or patterns to include. One of these patterns must match for the condition to pass. Also accepts `~DEFAULT_BRANCH` to include the default branch or `~ALL` to include all branches.",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "exclude": {
-                          "type": "array",
-                          "description": "Array of ref names or patterns to exclude. The condition will not pass if any of these patterns match.",
-                          "items": {
-                            "type": "string"
-                          }
-                        }
-                      }
-                    }
+                "exclude": {
+                  "type": "array",
+                  "description": "Array of ref names or patterns to exclude. The condition will not pass if any of these patterns match.",
+                  "items": {
+                    "type": "string"
                   }
-                },
-                {
-                  "title": "Repository ruleset conditions for repository IDs",
-                  "type": "object",
-                  "description": "Parameters for a repository ID condition",
-                  "properties": {
-                    "repository_id": {
-                      "type": "object",
-                      "properties": {
-                        "repository_ids": {
-                          "type": "array",
-                          "description": "The repository IDs that the ruleset applies to. One of these IDs must match for the condition to pass.",
-                          "items": {
-                            "type": "integer"
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "required": [
-                    "repository_id"
-                  ]
                 }
-              ]
-            },
-            {
-              "type": "object",
-              "title": "repository_property_and_ref_name",
-              "description": "Conditions to target repositories by property and refs by name",
-              "allOf": [
-                {
-                  "title": "Repository ruleset conditions for ref names",
-                  "type": "object",
-                  "description": "Parameters for a repository ruleset ref name condition",
-                  "properties": {
-                    "ref_name": {
-                      "type": "object",
-                      "properties": {
-                        "include": {
-                          "type": "array",
-                          "description": "Array of ref names or patterns to include. One of these patterns must match for the condition to pass. Also accepts `~DEFAULT_BRANCH` to include the default branch or `~ALL` to include all branches.",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "exclude": {
-                          "type": "array",
-                          "description": "Array of ref names or patterns to exclude. The condition will not pass if any of these patterns match.",
-                          "items": {
-                            "type": "string"
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                {
-                  "title": "Repository ruleset conditions for repository properties",
-                  "type": "object",
-                  "description": "Parameters for a repository property condition",
-                  "properties": {
-                    "repository_property": {
-                      "type": "object",
-                      "properties": {
-                        "include": {
-                          "type": "array",
-                          "description": "The repository properties and values to include. All of these properties must match for the condition to pass.",
-                          "items": {
-                            "title": "Repository ruleset property targeting definition",
-                            "type": "object",
-                            "description": "Parameters for a targeting a repository property",
-                            "properties": {
-                              "name": {
-                                "type": "string",
-                                "description": "The name of the repository property to target"
-                              },
-                              "property_values": {
-                                "type": "array",
-                                "description": "The values to match for the repository property",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "source": {
-                                "type": "string",
-                                "description": "The source of the repository property. Defaults to 'custom' if not specified.",
-                                "enum": [
-                                  "custom",
-                                  "system"
-                                ]
-                              }
-                            },
-                            "required": [
-                              "name",
-                              "property_values"
-                            ]
-                          }
-                        },
-                        "exclude": {
-                          "type": "array",
-                          "description": "The repository properties and values to exclude. The condition will not pass if any of these properties match.",
-                          "items": {
-                            "title": "Repository ruleset property targeting definition",
-                            "type": "object",
-                            "description": "Parameters for a targeting a repository property",
-                            "properties": {
-                              "name": {
-                                "type": "string",
-                                "description": "The name of the repository property to target"
-                              },
-                              "property_values": {
-                                "type": "array",
-                                "description": "The values to match for the repository property",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "source": {
-                                "type": "string",
-                                "description": "The source of the repository property. Defaults to 'custom' if not specified.",
-                                "enum": [
-                                  "custom",
-                                  "system"
-                                ]
-                              }
-                            },
-                            "required": [
-                              "name",
-                              "property_values"
-                            ]
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "required": [
-                    "repository_property"
-                  ]
-                }
-              ]
+              }
             }
-          ]
+          }
         },
         "rules": {
           "type": "array",
@@ -1982,6 +2831,83 @@
                     "type": "string",
                     "enum": [
                       "required_linear_history"
+                    ]
+                  }
+                }
+              },
+              {
+                "title": "merge_queue",
+                "description": "Merges must be performed via a merge queue.",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "merge_queue"
+                    ]
+                  },
+                  "parameters": {
+                    "type": "object",
+                    "properties": {
+                      "check_response_timeout_minutes": {
+                        "type": "integer",
+                        "description": "Maximum time for a required status check to report a conclusion. After this much time has elapsed, checks that have not reported a conclusion will be assumed to have failed",
+                        "minimum": 1,
+                        "maximum": 360
+                      },
+                      "grouping_strategy": {
+                        "type": "string",
+                        "description": "When set to ALLGREEN, the merge commit created by merge queue for each PR in the group must pass all required checks to merge. When set to HEADGREEN, only the commit at the head of the merge group, i.e. the commit containing changes from all of the PRs in the group, must pass its required checks to merge.",
+                        "enum": [
+                          "ALLGREEN",
+                          "HEADGREEN"
+                        ]
+                      },
+                      "max_entries_to_build": {
+                        "type": "integer",
+                        "description": "Limit the number of queued pull requests requesting checks and workflow runs at the same time.",
+                        "minimum": 0,
+                        "maximum": 100
+                      },
+                      "max_entries_to_merge": {
+                        "type": "integer",
+                        "description": "The maximum number of PRs that will be merged together in a group.",
+                        "minimum": 0,
+                        "maximum": 100
+                      },
+                      "merge_method": {
+                        "type": "string",
+                        "description": "Method to use when merging changes from queued pull requests.",
+                        "enum": [
+                          "MERGE",
+                          "SQUASH",
+                          "REBASE"
+                        ]
+                      },
+                      "min_entries_to_merge": {
+                        "type": "integer",
+                        "description": "The minimum number of PRs that will be merged together in a group.",
+                        "minimum": 0,
+                        "maximum": 100
+                      },
+                      "min_entries_to_merge_wait_minutes": {
+                        "type": "integer",
+                        "description": "The time merge queue should wait after the first PR is added to the queue for the minimum group size to be met. After this time has elapsed, the minimum group size will be ignored and a smaller group will be merged.",
+                        "minimum": 0,
+                        "maximum": 360
+                      }
+                    },
+                    "required": [
+                      "check_response_timeout_minutes",
+                      "grouping_strategy",
+                      "max_entries_to_build",
+                      "max_entries_to_merge",
+                      "merge_method",
+                      "min_entries_to_merge",
+                      "min_entries_to_merge_wait_minutes"
                     ]
                   }
                 }
@@ -2494,128 +3420,6 @@
                 }
               },
               {
-                "title": "file_path_restriction",
-                "description": "Prevent commits that include changes in specified file and folder paths from being pushed to the commit graph. This includes absolute paths that contain file names.",
-                "type": "object",
-                "required": [
-                  "type"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "file_path_restriction"
-                    ]
-                  },
-                  "parameters": {
-                    "type": "object",
-                    "properties": {
-                      "restricted_file_paths": {
-                        "type": "array",
-                        "description": "The file paths that are restricted from being pushed to the commit graph.",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "required": [
-                      "restricted_file_paths"
-                    ]
-                  }
-                }
-              },
-              {
-                "title": "max_file_path_length",
-                "description": "Prevent commits that include file paths that exceed the specified character limit from being pushed to the commit graph.",
-                "type": "object",
-                "required": [
-                  "type"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "max_file_path_length"
-                    ]
-                  },
-                  "parameters": {
-                    "type": "object",
-                    "properties": {
-                      "max_file_path_length": {
-                        "type": "integer",
-                        "description": "The maximum amount of characters allowed in file paths.",
-                        "minimum": 1,
-                        "maximum": 32767
-                      }
-                    },
-                    "required": [
-                      "max_file_path_length"
-                    ]
-                  }
-                }
-              },
-              {
-                "title": "file_extension_restriction",
-                "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph.",
-                "type": "object",
-                "required": [
-                  "type"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "file_extension_restriction"
-                    ]
-                  },
-                  "parameters": {
-                    "type": "object",
-                    "properties": {
-                      "restricted_file_extensions": {
-                        "type": "array",
-                        "description": "The file extensions that are restricted from being pushed to the commit graph.",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "required": [
-                      "restricted_file_extensions"
-                    ]
-                  }
-                }
-              },
-              {
-                "title": "max_file_size",
-                "description": "Prevent commits with individual files that exceed the specified limit from being pushed to the commit graph.",
-                "type": "object",
-                "required": [
-                  "type"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "max_file_size"
-                    ]
-                  },
-                  "parameters": {
-                    "type": "object",
-                    "properties": {
-                      "max_file_size": {
-                        "type": "integer",
-                        "description": "The maximum file size allowed in megabytes. This limit does not apply to Git Large File Storage (Git LFS).",
-                        "minimum": 1,
-                        "maximum": 100
-                      }
-                    },
-                    "required": [
-                      "max_file_size"
-                    ]
-                  }
-                }
-              },
-              {
                 "title": "workflows",
                 "description": "Require all changes made to a targeted branch to pass the specified workflows before they can be merged.",
                 "type": "object",
@@ -2765,6 +3569,144 @@
                         "description": "Copilot automatically reviews each new push to the pull request."
                       }
                     }
+                  }
+                }
+              },
+              {
+                "title": "license_compliance_scanning",
+                "description": "Enforce any added or changed dependencies to comply with the organization's license policy.",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "license_compliance_scanning"
+                    ]
+                  }
+                }
+              },
+              {
+                "title": "file_path_restriction",
+                "description": "Prevent commits that include changes in specified file and folder paths from being pushed to the commit graph. This includes absolute paths that contain file names.",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "file_path_restriction"
+                    ]
+                  },
+                  "parameters": {
+                    "type": "object",
+                    "properties": {
+                      "restricted_file_paths": {
+                        "type": "array",
+                        "description": "The file paths that are restricted from being pushed to the commit graph.",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": [
+                      "restricted_file_paths"
+                    ]
+                  }
+                }
+              },
+              {
+                "title": "max_file_path_length",
+                "description": "Prevent commits that include file paths that exceed the specified character limit from being pushed to the commit graph.",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "max_file_path_length"
+                    ]
+                  },
+                  "parameters": {
+                    "type": "object",
+                    "properties": {
+                      "max_file_path_length": {
+                        "type": "integer",
+                        "description": "The maximum amount of characters allowed in file paths.",
+                        "minimum": 1,
+                        "maximum": 32767
+                      }
+                    },
+                    "required": [
+                      "max_file_path_length"
+                    ]
+                  }
+                }
+              },
+              {
+                "title": "file_extension_restriction",
+                "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph.",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "file_extension_restriction"
+                    ]
+                  },
+                  "parameters": {
+                    "type": "object",
+                    "properties": {
+                      "restricted_file_extensions": {
+                        "type": "array",
+                        "description": "The file extensions that are restricted from being pushed to the commit graph.",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": [
+                      "restricted_file_extensions"
+                    ]
+                  }
+                }
+              },
+              {
+                "title": "max_file_size",
+                "description": "Prevent commits with individual files that exceed the specified limit from being pushed to the commit graph.",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "max_file_size"
+                    ]
+                  },
+                  "parameters": {
+                    "type": "object",
+                    "properties": {
+                      "max_file_size": {
+                        "type": "integer",
+                        "description": "The maximum file size allowed in megabytes. This limit does not apply to Git Large File Storage (Git LFS).",
+                        "minimum": 1,
+                        "maximum": 100
+                      }
+                    },
+                    "required": [
+                      "max_file_size"
+                    ]
                   }
                 }
               }

--- a/schema/dereferenced/repos.json
+++ b/schema/dereferenced/repos.json
@@ -497,213 +497,221 @@
             "type": "string"
           },
           "protection": {
-            "type": "object",
-            "properties": {
-              "required_status_checks": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "description": "Require status checks to pass before merging. Set to `null` to disable.",
+            "anyOf": [
+              {
+                "type": "null",
+                "description": "Set to `null` to delete the existing branch protection"
+              },
+              {
+                "type": "object",
                 "properties": {
-                  "strict": {
-                    "type": "boolean",
-                    "description": "Require branches to be up to date before merging."
+                  "required_status_checks": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "description": "Require status checks to pass before merging. Set to `null` to disable.",
+                    "properties": {
+                      "strict": {
+                        "type": "boolean",
+                        "description": "Require branches to be up to date before merging."
+                      },
+                      "contexts": {
+                        "type": "array",
+                        "deprecated": true,
+                        "description": "**Closing down notice**: The list of status checks to require in order to merge into this branch. If any of these checks have recently been set by a particular GitHub App, they will be required to come from that app in future for the branch to merge. Use `checks` instead of `contexts` for more fine-grained control.",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "checks": {
+                        "type": "array",
+                        "description": "The list of status checks to require in order to merge into this branch.",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "context"
+                          ],
+                          "properties": {
+                            "context": {
+                              "type": "string",
+                              "description": "The name of the required check"
+                            },
+                            "app_id": {
+                              "type": "integer",
+                              "description": "The ID of the GitHub App that must provide this check. Omit this field to automatically select the GitHub App that has recently provided this check, or any app if it was not set by a GitHub App. Pass -1 to explicitly allow any app to set the status."
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "required": [
+                      "strict",
+                      "contexts"
+                    ]
                   },
-                  "contexts": {
-                    "type": "array",
-                    "deprecated": true,
-                    "description": "**Closing down notice**: The list of status checks to require in order to merge into this branch. If any of these checks have recently been set by a particular GitHub App, they will be required to come from that app in future for the branch to merge. Use `checks` instead of `contexts` for more fine-grained control.",
-                    "items": {
-                      "type": "string"
-                    }
+                  "enforce_admins": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
+                    "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable."
                   },
-                  "checks": {
-                    "type": "array",
-                    "description": "The list of status checks to require in order to merge into this branch.",
-                    "items": {
-                      "type": "object",
-                      "required": [
-                        "context"
-                      ],
-                      "properties": {
-                        "context": {
-                          "type": "string",
-                          "description": "The name of the required check"
-                        },
-                        "app_id": {
-                          "type": "integer",
-                          "description": "The ID of the GitHub App that must provide this check. Omit this field to automatically select the GitHub App that has recently provided this check, or any app if it was not set by a GitHub App. Pass -1 to explicitly allow any app to set the status."
+                  "required_pull_request_reviews": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "description": "Require at least one approving review on a pull request, before merging. Set to `null` to disable.",
+                    "properties": {
+                      "dismissal_restrictions": {
+                        "type": "object",
+                        "description": "Specify which users, teams, and apps can dismiss pull request reviews. Pass an empty `dismissal_restrictions` object to disable. User and team `dismissal_restrictions` are only available for organization-owned repositories. Omit this parameter for personal repositories.",
+                        "properties": {
+                          "users": {
+                            "type": "array",
+                            "description": "The list of user `login`s with dismissal access",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "teams": {
+                            "type": "array",
+                            "description": "The list of team `slug`s with dismissal access",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "apps": {
+                            "type": "array",
+                            "description": "The list of app `slug`s with dismissal access",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "dismiss_stale_reviews": {
+                        "type": "boolean",
+                        "description": "Set to `true` if you want to automatically dismiss approving reviews when someone pushes a new commit."
+                      },
+                      "require_code_owner_reviews": {
+                        "type": "boolean",
+                        "description": "Blocks merging pull requests until [code owners](https://docs.github.com/articles/about-code-owners/) review them."
+                      },
+                      "required_approving_review_count": {
+                        "type": "integer",
+                        "description": "Specify the number of reviewers required to approve pull requests. Use a number between 1 and 6 or 0 to not require reviewers."
+                      },
+                      "require_last_push_approval": {
+                        "type": "boolean",
+                        "description": "Whether the most recent push must be approved by someone other than the person who pushed it. Default: `false`.",
+                        "default": false
+                      },
+                      "bypass_pull_request_allowances": {
+                        "type": "object",
+                        "description": "Allow specific users, teams, or apps to bypass pull request requirements.",
+                        "properties": {
+                          "users": {
+                            "type": "array",
+                            "description": "The list of user `login`s allowed to bypass pull request requirements.",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "teams": {
+                            "type": "array",
+                            "description": "The list of team `slug`s allowed to bypass pull request requirements.",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "apps": {
+                            "type": "array",
+                            "description": "The list of app `slug`s allowed to bypass pull request requirements.",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
-                  }
-                },
-                "required": [
-                  "strict",
-                  "contexts"
-                ]
-              },
-              "enforce_admins": {
-                "type": [
-                  "boolean",
-                  "null"
-                ],
-                "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable."
-              },
-              "required_pull_request_reviews": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "description": "Require at least one approving review on a pull request, before merging. Set to `null` to disable.",
-                "properties": {
-                  "dismissal_restrictions": {
-                    "type": "object",
-                    "description": "Specify which users, teams, and apps can dismiss pull request reviews. Pass an empty `dismissal_restrictions` object to disable. User and team `dismissal_restrictions` are only available for organization-owned repositories. Omit this parameter for personal repositories.",
+                  },
+                  "restrictions": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "description": "Restrict who can push to the protected branch. User, app, and team `restrictions` are only available for organization-owned repositories. Set to `null` to disable.",
                     "properties": {
                       "users": {
                         "type": "array",
-                        "description": "The list of user `login`s with dismissal access",
+                        "description": "The list of user `login`s with push access",
                         "items": {
                           "type": "string"
                         }
                       },
                       "teams": {
                         "type": "array",
-                        "description": "The list of team `slug`s with dismissal access",
+                        "description": "The list of team `slug`s with push access",
                         "items": {
                           "type": "string"
                         }
                       },
                       "apps": {
                         "type": "array",
-                        "description": "The list of app `slug`s with dismissal access",
+                        "description": "The list of app `slug`s with push access",
                         "items": {
                           "type": "string"
                         }
                       }
-                    }
+                    },
+                    "required": [
+                      "users",
+                      "teams"
+                    ]
                   },
-                  "dismiss_stale_reviews": {
+                  "required_linear_history": {
                     "type": "boolean",
-                    "description": "Set to `true` if you want to automatically dismiss approving reviews when someone pushes a new commit."
+                    "description": "Enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch. Set to `true` to enforce a linear commit history. Set to `false` to disable a linear commit Git history. Your repository must allow squash merging or rebase merging before you can enable a linear commit history. Default: `false`. For more information, see \"[Requiring a linear commit history](https://docs.github.com/github/administering-a-repository/requiring-a-linear-commit-history)\" in the GitHub Help documentation."
                   },
-                  "require_code_owner_reviews": {
+                  "allow_force_pushes": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
+                    "description": "Permits force pushes to the protected branch by anyone with write access to the repository. Set to `true` to allow force pushes. Set to `false` or `null` to block force pushes. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation.\""
+                  },
+                  "allow_deletions": {
                     "type": "boolean",
-                    "description": "Blocks merging pull requests until [code owners](https://docs.github.com/articles/about-code-owners/) review them."
+                    "description": "Allows deletion of the protected branch by anyone with write access to the repository. Set to `false` to prevent deletion of the protected branch. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation."
                   },
-                  "required_approving_review_count": {
-                    "type": "integer",
-                    "description": "Specify the number of reviewers required to approve pull requests. Use a number between 1 and 6 or 0 to not require reviewers."
-                  },
-                  "require_last_push_approval": {
+                  "block_creations": {
                     "type": "boolean",
-                    "description": "Whether the most recent push must be approved by someone other than the person who pushed it. Default: `false`.",
+                    "description": "If set to `true`, the `restrictions` branch protection settings which limits who can push will also block pushes which create new branches, unless the push is initiated by a user, team, or app which has the ability to push. Set to `true` to restrict new branch creation. Default: `false`."
+                  },
+                  "required_conversation_resolution": {
+                    "type": "boolean",
+                    "description": "Requires all conversations on code to be resolved before a pull request can be merged into a branch that matches this rule. Set to `false` to disable. Default: `false`."
+                  },
+                  "lock_branch": {
+                    "type": "boolean",
+                    "description": "Whether to set the branch as read-only. If this is true, users will not be able to push to the branch. Default: `false`.",
                     "default": false
                   },
-                  "bypass_pull_request_allowances": {
-                    "type": "object",
-                    "description": "Allow specific users, teams, or apps to bypass pull request requirements.",
-                    "properties": {
-                      "users": {
-                        "type": "array",
-                        "description": "The list of user `login`s allowed to bypass pull request requirements.",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "teams": {
-                        "type": "array",
-                        "description": "The list of team `slug`s allowed to bypass pull request requirements.",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "apps": {
-                        "type": "array",
-                        "description": "The list of app `slug`s allowed to bypass pull request requirements.",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  }
-                }
-              },
-              "restrictions": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "description": "Restrict who can push to the protected branch. User, app, and team `restrictions` are only available for organization-owned repositories. Set to `null` to disable.",
-                "properties": {
-                  "users": {
-                    "type": "array",
-                    "description": "The list of user `login`s with push access",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "teams": {
-                    "type": "array",
-                    "description": "The list of team `slug`s with push access",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "apps": {
-                    "type": "array",
-                    "description": "The list of app `slug`s with push access",
-                    "items": {
-                      "type": "string"
-                    }
+                  "allow_fork_syncing": {
+                    "type": "boolean",
+                    "description": "Whether users can pull changes from upstream when the branch is locked. Set to `true` to allow fork syncing. Set to `false` to prevent fork syncing. Default: `false`.",
+                    "default": false
                   }
                 },
                 "required": [
-                  "users",
-                  "teams"
+                  "required_status_checks",
+                  "enforce_admins",
+                  "required_pull_request_reviews",
+                  "restrictions"
                 ]
-              },
-              "required_linear_history": {
-                "type": "boolean",
-                "description": "Enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch. Set to `true` to enforce a linear commit history. Set to `false` to disable a linear commit Git history. Your repository must allow squash merging or rebase merging before you can enable a linear commit history. Default: `false`. For more information, see \"[Requiring a linear commit history](https://docs.github.com/github/administering-a-repository/requiring-a-linear-commit-history)\" in the GitHub Help documentation."
-              },
-              "allow_force_pushes": {
-                "type": [
-                  "boolean",
-                  "null"
-                ],
-                "description": "Permits force pushes to the protected branch by anyone with write access to the repository. Set to `true` to allow force pushes. Set to `false` or `null` to block force pushes. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation.\""
-              },
-              "allow_deletions": {
-                "type": "boolean",
-                "description": "Allows deletion of the protected branch by anyone with write access to the repository. Set to `false` to prevent deletion of the protected branch. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation."
-              },
-              "block_creations": {
-                "type": "boolean",
-                "description": "If set to `true`, the `restrictions` branch protection settings which limits who can push will also block pushes which create new branches, unless the push is initiated by a user, team, or app which has the ability to push. Set to `true` to restrict new branch creation. Default: `false`."
-              },
-              "required_conversation_resolution": {
-                "type": "boolean",
-                "description": "Requires all conversations on code to be resolved before a pull request can be merged into a branch that matches this rule. Set to `false` to disable. Default: `false`."
-              },
-              "lock_branch": {
-                "type": "boolean",
-                "description": "Whether to set the branch as read-only. If this is true, users will not be able to push to the branch. Default: `false`.",
-                "default": false
-              },
-              "allow_fork_syncing": {
-                "type": "boolean",
-                "description": "Whether users can pull changes from upstream when the branch is locked. Set to `true` to allow fork syncing. Set to `false` to prevent fork syncing. Default: `false`.",
-                "default": false
               }
-            },
-            "required": [
-              "required_status_checks",
-              "enforce_admins",
-              "required_pull_request_reviews",
-              "restrictions"
             ]
           }
         }
@@ -1328,213 +1336,221 @@
           "type": "string"
         },
         "protection": {
-          "type": "object",
-          "properties": {
-            "required_status_checks": {
-              "type": [
-                "object",
-                "null"
-              ],
-              "description": "Require status checks to pass before merging. Set to `null` to disable.",
+          "anyOf": [
+            {
+              "type": "null",
+              "description": "Set to `null` to delete the existing branch protection"
+            },
+            {
+              "type": "object",
               "properties": {
-                "strict": {
-                  "type": "boolean",
-                  "description": "Require branches to be up to date before merging."
+                "required_status_checks": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "description": "Require status checks to pass before merging. Set to `null` to disable.",
+                  "properties": {
+                    "strict": {
+                      "type": "boolean",
+                      "description": "Require branches to be up to date before merging."
+                    },
+                    "contexts": {
+                      "type": "array",
+                      "deprecated": true,
+                      "description": "**Closing down notice**: The list of status checks to require in order to merge into this branch. If any of these checks have recently been set by a particular GitHub App, they will be required to come from that app in future for the branch to merge. Use `checks` instead of `contexts` for more fine-grained control.",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "checks": {
+                      "type": "array",
+                      "description": "The list of status checks to require in order to merge into this branch.",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "context"
+                        ],
+                        "properties": {
+                          "context": {
+                            "type": "string",
+                            "description": "The name of the required check"
+                          },
+                          "app_id": {
+                            "type": "integer",
+                            "description": "The ID of the GitHub App that must provide this check. Omit this field to automatically select the GitHub App that has recently provided this check, or any app if it was not set by a GitHub App. Pass -1 to explicitly allow any app to set the status."
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "strict",
+                    "contexts"
+                  ]
                 },
-                "contexts": {
-                  "type": "array",
-                  "deprecated": true,
-                  "description": "**Closing down notice**: The list of status checks to require in order to merge into this branch. If any of these checks have recently been set by a particular GitHub App, they will be required to come from that app in future for the branch to merge. Use `checks` instead of `contexts` for more fine-grained control.",
-                  "items": {
-                    "type": "string"
-                  }
+                "enforce_admins": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ],
+                  "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable."
                 },
-                "checks": {
-                  "type": "array",
-                  "description": "The list of status checks to require in order to merge into this branch.",
-                  "items": {
-                    "type": "object",
-                    "required": [
-                      "context"
-                    ],
-                    "properties": {
-                      "context": {
-                        "type": "string",
-                        "description": "The name of the required check"
-                      },
-                      "app_id": {
-                        "type": "integer",
-                        "description": "The ID of the GitHub App that must provide this check. Omit this field to automatically select the GitHub App that has recently provided this check, or any app if it was not set by a GitHub App. Pass -1 to explicitly allow any app to set the status."
+                "required_pull_request_reviews": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "description": "Require at least one approving review on a pull request, before merging. Set to `null` to disable.",
+                  "properties": {
+                    "dismissal_restrictions": {
+                      "type": "object",
+                      "description": "Specify which users, teams, and apps can dismiss pull request reviews. Pass an empty `dismissal_restrictions` object to disable. User and team `dismissal_restrictions` are only available for organization-owned repositories. Omit this parameter for personal repositories.",
+                      "properties": {
+                        "users": {
+                          "type": "array",
+                          "description": "The list of user `login`s with dismissal access",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "teams": {
+                          "type": "array",
+                          "description": "The list of team `slug`s with dismissal access",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "apps": {
+                          "type": "array",
+                          "description": "The list of app `slug`s with dismissal access",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "dismiss_stale_reviews": {
+                      "type": "boolean",
+                      "description": "Set to `true` if you want to automatically dismiss approving reviews when someone pushes a new commit."
+                    },
+                    "require_code_owner_reviews": {
+                      "type": "boolean",
+                      "description": "Blocks merging pull requests until [code owners](https://docs.github.com/articles/about-code-owners/) review them."
+                    },
+                    "required_approving_review_count": {
+                      "type": "integer",
+                      "description": "Specify the number of reviewers required to approve pull requests. Use a number between 1 and 6 or 0 to not require reviewers."
+                    },
+                    "require_last_push_approval": {
+                      "type": "boolean",
+                      "description": "Whether the most recent push must be approved by someone other than the person who pushed it. Default: `false`.",
+                      "default": false
+                    },
+                    "bypass_pull_request_allowances": {
+                      "type": "object",
+                      "description": "Allow specific users, teams, or apps to bypass pull request requirements.",
+                      "properties": {
+                        "users": {
+                          "type": "array",
+                          "description": "The list of user `login`s allowed to bypass pull request requirements.",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "teams": {
+                          "type": "array",
+                          "description": "The list of team `slug`s allowed to bypass pull request requirements.",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "apps": {
+                          "type": "array",
+                          "description": "The list of app `slug`s allowed to bypass pull request requirements.",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
                       }
                     }
                   }
-                }
-              },
-              "required": [
-                "strict",
-                "contexts"
-              ]
-            },
-            "enforce_admins": {
-              "type": [
-                "boolean",
-                "null"
-              ],
-              "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable."
-            },
-            "required_pull_request_reviews": {
-              "type": [
-                "object",
-                "null"
-              ],
-              "description": "Require at least one approving review on a pull request, before merging. Set to `null` to disable.",
-              "properties": {
-                "dismissal_restrictions": {
-                  "type": "object",
-                  "description": "Specify which users, teams, and apps can dismiss pull request reviews. Pass an empty `dismissal_restrictions` object to disable. User and team `dismissal_restrictions` are only available for organization-owned repositories. Omit this parameter for personal repositories.",
+                },
+                "restrictions": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "description": "Restrict who can push to the protected branch. User, app, and team `restrictions` are only available for organization-owned repositories. Set to `null` to disable.",
                   "properties": {
                     "users": {
                       "type": "array",
-                      "description": "The list of user `login`s with dismissal access",
+                      "description": "The list of user `login`s with push access",
                       "items": {
                         "type": "string"
                       }
                     },
                     "teams": {
                       "type": "array",
-                      "description": "The list of team `slug`s with dismissal access",
+                      "description": "The list of team `slug`s with push access",
                       "items": {
                         "type": "string"
                       }
                     },
                     "apps": {
                       "type": "array",
-                      "description": "The list of app `slug`s with dismissal access",
+                      "description": "The list of app `slug`s with push access",
                       "items": {
                         "type": "string"
                       }
                     }
-                  }
+                  },
+                  "required": [
+                    "users",
+                    "teams"
+                  ]
                 },
-                "dismiss_stale_reviews": {
+                "required_linear_history": {
                   "type": "boolean",
-                  "description": "Set to `true` if you want to automatically dismiss approving reviews when someone pushes a new commit."
+                  "description": "Enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch. Set to `true` to enforce a linear commit history. Set to `false` to disable a linear commit Git history. Your repository must allow squash merging or rebase merging before you can enable a linear commit history. Default: `false`. For more information, see \"[Requiring a linear commit history](https://docs.github.com/github/administering-a-repository/requiring-a-linear-commit-history)\" in the GitHub Help documentation."
                 },
-                "require_code_owner_reviews": {
+                "allow_force_pushes": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ],
+                  "description": "Permits force pushes to the protected branch by anyone with write access to the repository. Set to `true` to allow force pushes. Set to `false` or `null` to block force pushes. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation.\""
+                },
+                "allow_deletions": {
                   "type": "boolean",
-                  "description": "Blocks merging pull requests until [code owners](https://docs.github.com/articles/about-code-owners/) review them."
+                  "description": "Allows deletion of the protected branch by anyone with write access to the repository. Set to `false` to prevent deletion of the protected branch. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation."
                 },
-                "required_approving_review_count": {
-                  "type": "integer",
-                  "description": "Specify the number of reviewers required to approve pull requests. Use a number between 1 and 6 or 0 to not require reviewers."
-                },
-                "require_last_push_approval": {
+                "block_creations": {
                   "type": "boolean",
-                  "description": "Whether the most recent push must be approved by someone other than the person who pushed it. Default: `false`.",
+                  "description": "If set to `true`, the `restrictions` branch protection settings which limits who can push will also block pushes which create new branches, unless the push is initiated by a user, team, or app which has the ability to push. Set to `true` to restrict new branch creation. Default: `false`."
+                },
+                "required_conversation_resolution": {
+                  "type": "boolean",
+                  "description": "Requires all conversations on code to be resolved before a pull request can be merged into a branch that matches this rule. Set to `false` to disable. Default: `false`."
+                },
+                "lock_branch": {
+                  "type": "boolean",
+                  "description": "Whether to set the branch as read-only. If this is true, users will not be able to push to the branch. Default: `false`.",
                   "default": false
                 },
-                "bypass_pull_request_allowances": {
-                  "type": "object",
-                  "description": "Allow specific users, teams, or apps to bypass pull request requirements.",
-                  "properties": {
-                    "users": {
-                      "type": "array",
-                      "description": "The list of user `login`s allowed to bypass pull request requirements.",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "teams": {
-                      "type": "array",
-                      "description": "The list of team `slug`s allowed to bypass pull request requirements.",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "apps": {
-                      "type": "array",
-                      "description": "The list of app `slug`s allowed to bypass pull request requirements.",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "restrictions": {
-              "type": [
-                "object",
-                "null"
-              ],
-              "description": "Restrict who can push to the protected branch. User, app, and team `restrictions` are only available for organization-owned repositories. Set to `null` to disable.",
-              "properties": {
-                "users": {
-                  "type": "array",
-                  "description": "The list of user `login`s with push access",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "teams": {
-                  "type": "array",
-                  "description": "The list of team `slug`s with push access",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "apps": {
-                  "type": "array",
-                  "description": "The list of app `slug`s with push access",
-                  "items": {
-                    "type": "string"
-                  }
+                "allow_fork_syncing": {
+                  "type": "boolean",
+                  "description": "Whether users can pull changes from upstream when the branch is locked. Set to `true` to allow fork syncing. Set to `false` to prevent fork syncing. Default: `false`.",
+                  "default": false
                 }
               },
               "required": [
-                "users",
-                "teams"
+                "required_status_checks",
+                "enforce_admins",
+                "required_pull_request_reviews",
+                "restrictions"
               ]
-            },
-            "required_linear_history": {
-              "type": "boolean",
-              "description": "Enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch. Set to `true` to enforce a linear commit history. Set to `false` to disable a linear commit Git history. Your repository must allow squash merging or rebase merging before you can enable a linear commit history. Default: `false`. For more information, see \"[Requiring a linear commit history](https://docs.github.com/github/administering-a-repository/requiring-a-linear-commit-history)\" in the GitHub Help documentation."
-            },
-            "allow_force_pushes": {
-              "type": [
-                "boolean",
-                "null"
-              ],
-              "description": "Permits force pushes to the protected branch by anyone with write access to the repository. Set to `true` to allow force pushes. Set to `false` or `null` to block force pushes. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation.\""
-            },
-            "allow_deletions": {
-              "type": "boolean",
-              "description": "Allows deletion of the protected branch by anyone with write access to the repository. Set to `false` to prevent deletion of the protected branch. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation."
-            },
-            "block_creations": {
-              "type": "boolean",
-              "description": "If set to `true`, the `restrictions` branch protection settings which limits who can push will also block pushes which create new branches, unless the push is initiated by a user, team, or app which has the ability to push. Set to `true` to restrict new branch creation. Default: `false`."
-            },
-            "required_conversation_resolution": {
-              "type": "boolean",
-              "description": "Requires all conversations on code to be resolved before a pull request can be merged into a branch that matches this rule. Set to `false` to disable. Default: `false`."
-            },
-            "lock_branch": {
-              "type": "boolean",
-              "description": "Whether to set the branch as read-only. If this is true, users will not be able to push to the branch. Default: `false`.",
-              "default": false
-            },
-            "allow_fork_syncing": {
-              "type": "boolean",
-              "description": "Whether users can pull changes from upstream when the branch is locked. Set to `true` to allow fork syncing. Set to `false` to prevent fork syncing. Default: `false`.",
-              "default": false
             }
-          },
-          "required": [
-            "required_status_checks",
-            "enforce_admins",
-            "required_pull_request_reviews",
-            "restrictions"
           ]
         }
       }

--- a/schema/dereferenced/settings.json
+++ b/schema/dereferenced/settings.json
@@ -497,213 +497,221 @@
             "type": "string"
           },
           "protection": {
-            "type": "object",
-            "properties": {
-              "required_status_checks": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "description": "Require status checks to pass before merging. Set to `null` to disable.",
+            "anyOf": [
+              {
+                "type": "null",
+                "description": "Set to `null` to delete the existing branch protection"
+              },
+              {
+                "type": "object",
                 "properties": {
-                  "strict": {
-                    "type": "boolean",
-                    "description": "Require branches to be up to date before merging."
+                  "required_status_checks": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "description": "Require status checks to pass before merging. Set to `null` to disable.",
+                    "properties": {
+                      "strict": {
+                        "type": "boolean",
+                        "description": "Require branches to be up to date before merging."
+                      },
+                      "contexts": {
+                        "type": "array",
+                        "deprecated": true,
+                        "description": "**Closing down notice**: The list of status checks to require in order to merge into this branch. If any of these checks have recently been set by a particular GitHub App, they will be required to come from that app in future for the branch to merge. Use `checks` instead of `contexts` for more fine-grained control.",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "checks": {
+                        "type": "array",
+                        "description": "The list of status checks to require in order to merge into this branch.",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "context"
+                          ],
+                          "properties": {
+                            "context": {
+                              "type": "string",
+                              "description": "The name of the required check"
+                            },
+                            "app_id": {
+                              "type": "integer",
+                              "description": "The ID of the GitHub App that must provide this check. Omit this field to automatically select the GitHub App that has recently provided this check, or any app if it was not set by a GitHub App. Pass -1 to explicitly allow any app to set the status."
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "required": [
+                      "strict",
+                      "contexts"
+                    ]
                   },
-                  "contexts": {
-                    "type": "array",
-                    "deprecated": true,
-                    "description": "**Closing down notice**: The list of status checks to require in order to merge into this branch. If any of these checks have recently been set by a particular GitHub App, they will be required to come from that app in future for the branch to merge. Use `checks` instead of `contexts` for more fine-grained control.",
-                    "items": {
-                      "type": "string"
-                    }
+                  "enforce_admins": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
+                    "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable."
                   },
-                  "checks": {
-                    "type": "array",
-                    "description": "The list of status checks to require in order to merge into this branch.",
-                    "items": {
-                      "type": "object",
-                      "required": [
-                        "context"
-                      ],
-                      "properties": {
-                        "context": {
-                          "type": "string",
-                          "description": "The name of the required check"
-                        },
-                        "app_id": {
-                          "type": "integer",
-                          "description": "The ID of the GitHub App that must provide this check. Omit this field to automatically select the GitHub App that has recently provided this check, or any app if it was not set by a GitHub App. Pass -1 to explicitly allow any app to set the status."
+                  "required_pull_request_reviews": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "description": "Require at least one approving review on a pull request, before merging. Set to `null` to disable.",
+                    "properties": {
+                      "dismissal_restrictions": {
+                        "type": "object",
+                        "description": "Specify which users, teams, and apps can dismiss pull request reviews. Pass an empty `dismissal_restrictions` object to disable. User and team `dismissal_restrictions` are only available for organization-owned repositories. Omit this parameter for personal repositories.",
+                        "properties": {
+                          "users": {
+                            "type": "array",
+                            "description": "The list of user `login`s with dismissal access",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "teams": {
+                            "type": "array",
+                            "description": "The list of team `slug`s with dismissal access",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "apps": {
+                            "type": "array",
+                            "description": "The list of app `slug`s with dismissal access",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "dismiss_stale_reviews": {
+                        "type": "boolean",
+                        "description": "Set to `true` if you want to automatically dismiss approving reviews when someone pushes a new commit."
+                      },
+                      "require_code_owner_reviews": {
+                        "type": "boolean",
+                        "description": "Blocks merging pull requests until [code owners](https://docs.github.com/articles/about-code-owners/) review them."
+                      },
+                      "required_approving_review_count": {
+                        "type": "integer",
+                        "description": "Specify the number of reviewers required to approve pull requests. Use a number between 1 and 6 or 0 to not require reviewers."
+                      },
+                      "require_last_push_approval": {
+                        "type": "boolean",
+                        "description": "Whether the most recent push must be approved by someone other than the person who pushed it. Default: `false`.",
+                        "default": false
+                      },
+                      "bypass_pull_request_allowances": {
+                        "type": "object",
+                        "description": "Allow specific users, teams, or apps to bypass pull request requirements.",
+                        "properties": {
+                          "users": {
+                            "type": "array",
+                            "description": "The list of user `login`s allowed to bypass pull request requirements.",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "teams": {
+                            "type": "array",
+                            "description": "The list of team `slug`s allowed to bypass pull request requirements.",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "apps": {
+                            "type": "array",
+                            "description": "The list of app `slug`s allowed to bypass pull request requirements.",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
-                  }
-                },
-                "required": [
-                  "strict",
-                  "contexts"
-                ]
-              },
-              "enforce_admins": {
-                "type": [
-                  "boolean",
-                  "null"
-                ],
-                "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable."
-              },
-              "required_pull_request_reviews": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "description": "Require at least one approving review on a pull request, before merging. Set to `null` to disable.",
-                "properties": {
-                  "dismissal_restrictions": {
-                    "type": "object",
-                    "description": "Specify which users, teams, and apps can dismiss pull request reviews. Pass an empty `dismissal_restrictions` object to disable. User and team `dismissal_restrictions` are only available for organization-owned repositories. Omit this parameter for personal repositories.",
+                  },
+                  "restrictions": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "description": "Restrict who can push to the protected branch. User, app, and team `restrictions` are only available for organization-owned repositories. Set to `null` to disable.",
                     "properties": {
                       "users": {
                         "type": "array",
-                        "description": "The list of user `login`s with dismissal access",
+                        "description": "The list of user `login`s with push access",
                         "items": {
                           "type": "string"
                         }
                       },
                       "teams": {
                         "type": "array",
-                        "description": "The list of team `slug`s with dismissal access",
+                        "description": "The list of team `slug`s with push access",
                         "items": {
                           "type": "string"
                         }
                       },
                       "apps": {
                         "type": "array",
-                        "description": "The list of app `slug`s with dismissal access",
+                        "description": "The list of app `slug`s with push access",
                         "items": {
                           "type": "string"
                         }
                       }
-                    }
+                    },
+                    "required": [
+                      "users",
+                      "teams"
+                    ]
                   },
-                  "dismiss_stale_reviews": {
+                  "required_linear_history": {
                     "type": "boolean",
-                    "description": "Set to `true` if you want to automatically dismiss approving reviews when someone pushes a new commit."
+                    "description": "Enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch. Set to `true` to enforce a linear commit history. Set to `false` to disable a linear commit Git history. Your repository must allow squash merging or rebase merging before you can enable a linear commit history. Default: `false`. For more information, see \"[Requiring a linear commit history](https://docs.github.com/github/administering-a-repository/requiring-a-linear-commit-history)\" in the GitHub Help documentation."
                   },
-                  "require_code_owner_reviews": {
+                  "allow_force_pushes": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
+                    "description": "Permits force pushes to the protected branch by anyone with write access to the repository. Set to `true` to allow force pushes. Set to `false` or `null` to block force pushes. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation.\""
+                  },
+                  "allow_deletions": {
                     "type": "boolean",
-                    "description": "Blocks merging pull requests until [code owners](https://docs.github.com/articles/about-code-owners/) review them."
+                    "description": "Allows deletion of the protected branch by anyone with write access to the repository. Set to `false` to prevent deletion of the protected branch. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation."
                   },
-                  "required_approving_review_count": {
-                    "type": "integer",
-                    "description": "Specify the number of reviewers required to approve pull requests. Use a number between 1 and 6 or 0 to not require reviewers."
-                  },
-                  "require_last_push_approval": {
+                  "block_creations": {
                     "type": "boolean",
-                    "description": "Whether the most recent push must be approved by someone other than the person who pushed it. Default: `false`.",
+                    "description": "If set to `true`, the `restrictions` branch protection settings which limits who can push will also block pushes which create new branches, unless the push is initiated by a user, team, or app which has the ability to push. Set to `true` to restrict new branch creation. Default: `false`."
+                  },
+                  "required_conversation_resolution": {
+                    "type": "boolean",
+                    "description": "Requires all conversations on code to be resolved before a pull request can be merged into a branch that matches this rule. Set to `false` to disable. Default: `false`."
+                  },
+                  "lock_branch": {
+                    "type": "boolean",
+                    "description": "Whether to set the branch as read-only. If this is true, users will not be able to push to the branch. Default: `false`.",
                     "default": false
                   },
-                  "bypass_pull_request_allowances": {
-                    "type": "object",
-                    "description": "Allow specific users, teams, or apps to bypass pull request requirements.",
-                    "properties": {
-                      "users": {
-                        "type": "array",
-                        "description": "The list of user `login`s allowed to bypass pull request requirements.",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "teams": {
-                        "type": "array",
-                        "description": "The list of team `slug`s allowed to bypass pull request requirements.",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "apps": {
-                        "type": "array",
-                        "description": "The list of app `slug`s allowed to bypass pull request requirements.",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  }
-                }
-              },
-              "restrictions": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "description": "Restrict who can push to the protected branch. User, app, and team `restrictions` are only available for organization-owned repositories. Set to `null` to disable.",
-                "properties": {
-                  "users": {
-                    "type": "array",
-                    "description": "The list of user `login`s with push access",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "teams": {
-                    "type": "array",
-                    "description": "The list of team `slug`s with push access",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "apps": {
-                    "type": "array",
-                    "description": "The list of app `slug`s with push access",
-                    "items": {
-                      "type": "string"
-                    }
+                  "allow_fork_syncing": {
+                    "type": "boolean",
+                    "description": "Whether users can pull changes from upstream when the branch is locked. Set to `true` to allow fork syncing. Set to `false` to prevent fork syncing. Default: `false`.",
+                    "default": false
                   }
                 },
                 "required": [
-                  "users",
-                  "teams"
+                  "required_status_checks",
+                  "enforce_admins",
+                  "required_pull_request_reviews",
+                  "restrictions"
                 ]
-              },
-              "required_linear_history": {
-                "type": "boolean",
-                "description": "Enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch. Set to `true` to enforce a linear commit history. Set to `false` to disable a linear commit Git history. Your repository must allow squash merging or rebase merging before you can enable a linear commit history. Default: `false`. For more information, see \"[Requiring a linear commit history](https://docs.github.com/github/administering-a-repository/requiring-a-linear-commit-history)\" in the GitHub Help documentation."
-              },
-              "allow_force_pushes": {
-                "type": [
-                  "boolean",
-                  "null"
-                ],
-                "description": "Permits force pushes to the protected branch by anyone with write access to the repository. Set to `true` to allow force pushes. Set to `false` or `null` to block force pushes. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation.\""
-              },
-              "allow_deletions": {
-                "type": "boolean",
-                "description": "Allows deletion of the protected branch by anyone with write access to the repository. Set to `false` to prevent deletion of the protected branch. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation."
-              },
-              "block_creations": {
-                "type": "boolean",
-                "description": "If set to `true`, the `restrictions` branch protection settings which limits who can push will also block pushes which create new branches, unless the push is initiated by a user, team, or app which has the ability to push. Set to `true` to restrict new branch creation. Default: `false`."
-              },
-              "required_conversation_resolution": {
-                "type": "boolean",
-                "description": "Requires all conversations on code to be resolved before a pull request can be merged into a branch that matches this rule. Set to `false` to disable. Default: `false`."
-              },
-              "lock_branch": {
-                "type": "boolean",
-                "description": "Whether to set the branch as read-only. If this is true, users will not be able to push to the branch. Default: `false`.",
-                "default": false
-              },
-              "allow_fork_syncing": {
-                "type": "boolean",
-                "description": "Whether users can pull changes from upstream when the branch is locked. Set to `true` to allow fork syncing. Set to `false` to prevent fork syncing. Default: `false`.",
-                "default": false
               }
-            },
-            "required": [
-              "required_status_checks",
-              "enforce_admins",
-              "required_pull_request_reviews",
-              "restrictions"
             ]
           }
         }
@@ -2522,213 +2530,221 @@
           "type": "string"
         },
         "protection": {
-          "type": "object",
-          "properties": {
-            "required_status_checks": {
-              "type": [
-                "object",
-                "null"
-              ],
-              "description": "Require status checks to pass before merging. Set to `null` to disable.",
+          "anyOf": [
+            {
+              "type": "null",
+              "description": "Set to `null` to delete the existing branch protection"
+            },
+            {
+              "type": "object",
               "properties": {
-                "strict": {
-                  "type": "boolean",
-                  "description": "Require branches to be up to date before merging."
+                "required_status_checks": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "description": "Require status checks to pass before merging. Set to `null` to disable.",
+                  "properties": {
+                    "strict": {
+                      "type": "boolean",
+                      "description": "Require branches to be up to date before merging."
+                    },
+                    "contexts": {
+                      "type": "array",
+                      "deprecated": true,
+                      "description": "**Closing down notice**: The list of status checks to require in order to merge into this branch. If any of these checks have recently been set by a particular GitHub App, they will be required to come from that app in future for the branch to merge. Use `checks` instead of `contexts` for more fine-grained control.",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "checks": {
+                      "type": "array",
+                      "description": "The list of status checks to require in order to merge into this branch.",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "context"
+                        ],
+                        "properties": {
+                          "context": {
+                            "type": "string",
+                            "description": "The name of the required check"
+                          },
+                          "app_id": {
+                            "type": "integer",
+                            "description": "The ID of the GitHub App that must provide this check. Omit this field to automatically select the GitHub App that has recently provided this check, or any app if it was not set by a GitHub App. Pass -1 to explicitly allow any app to set the status."
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "strict",
+                    "contexts"
+                  ]
                 },
-                "contexts": {
-                  "type": "array",
-                  "deprecated": true,
-                  "description": "**Closing down notice**: The list of status checks to require in order to merge into this branch. If any of these checks have recently been set by a particular GitHub App, they will be required to come from that app in future for the branch to merge. Use `checks` instead of `contexts` for more fine-grained control.",
-                  "items": {
-                    "type": "string"
-                  }
+                "enforce_admins": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ],
+                  "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable."
                 },
-                "checks": {
-                  "type": "array",
-                  "description": "The list of status checks to require in order to merge into this branch.",
-                  "items": {
-                    "type": "object",
-                    "required": [
-                      "context"
-                    ],
-                    "properties": {
-                      "context": {
-                        "type": "string",
-                        "description": "The name of the required check"
-                      },
-                      "app_id": {
-                        "type": "integer",
-                        "description": "The ID of the GitHub App that must provide this check. Omit this field to automatically select the GitHub App that has recently provided this check, or any app if it was not set by a GitHub App. Pass -1 to explicitly allow any app to set the status."
+                "required_pull_request_reviews": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "description": "Require at least one approving review on a pull request, before merging. Set to `null` to disable.",
+                  "properties": {
+                    "dismissal_restrictions": {
+                      "type": "object",
+                      "description": "Specify which users, teams, and apps can dismiss pull request reviews. Pass an empty `dismissal_restrictions` object to disable. User and team `dismissal_restrictions` are only available for organization-owned repositories. Omit this parameter for personal repositories.",
+                      "properties": {
+                        "users": {
+                          "type": "array",
+                          "description": "The list of user `login`s with dismissal access",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "teams": {
+                          "type": "array",
+                          "description": "The list of team `slug`s with dismissal access",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "apps": {
+                          "type": "array",
+                          "description": "The list of app `slug`s with dismissal access",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "dismiss_stale_reviews": {
+                      "type": "boolean",
+                      "description": "Set to `true` if you want to automatically dismiss approving reviews when someone pushes a new commit."
+                    },
+                    "require_code_owner_reviews": {
+                      "type": "boolean",
+                      "description": "Blocks merging pull requests until [code owners](https://docs.github.com/articles/about-code-owners/) review them."
+                    },
+                    "required_approving_review_count": {
+                      "type": "integer",
+                      "description": "Specify the number of reviewers required to approve pull requests. Use a number between 1 and 6 or 0 to not require reviewers."
+                    },
+                    "require_last_push_approval": {
+                      "type": "boolean",
+                      "description": "Whether the most recent push must be approved by someone other than the person who pushed it. Default: `false`.",
+                      "default": false
+                    },
+                    "bypass_pull_request_allowances": {
+                      "type": "object",
+                      "description": "Allow specific users, teams, or apps to bypass pull request requirements.",
+                      "properties": {
+                        "users": {
+                          "type": "array",
+                          "description": "The list of user `login`s allowed to bypass pull request requirements.",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "teams": {
+                          "type": "array",
+                          "description": "The list of team `slug`s allowed to bypass pull request requirements.",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "apps": {
+                          "type": "array",
+                          "description": "The list of app `slug`s allowed to bypass pull request requirements.",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
                       }
                     }
                   }
-                }
-              },
-              "required": [
-                "strict",
-                "contexts"
-              ]
-            },
-            "enforce_admins": {
-              "type": [
-                "boolean",
-                "null"
-              ],
-              "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable."
-            },
-            "required_pull_request_reviews": {
-              "type": [
-                "object",
-                "null"
-              ],
-              "description": "Require at least one approving review on a pull request, before merging. Set to `null` to disable.",
-              "properties": {
-                "dismissal_restrictions": {
-                  "type": "object",
-                  "description": "Specify which users, teams, and apps can dismiss pull request reviews. Pass an empty `dismissal_restrictions` object to disable. User and team `dismissal_restrictions` are only available for organization-owned repositories. Omit this parameter for personal repositories.",
+                },
+                "restrictions": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "description": "Restrict who can push to the protected branch. User, app, and team `restrictions` are only available for organization-owned repositories. Set to `null` to disable.",
                   "properties": {
                     "users": {
                       "type": "array",
-                      "description": "The list of user `login`s with dismissal access",
+                      "description": "The list of user `login`s with push access",
                       "items": {
                         "type": "string"
                       }
                     },
                     "teams": {
                       "type": "array",
-                      "description": "The list of team `slug`s with dismissal access",
+                      "description": "The list of team `slug`s with push access",
                       "items": {
                         "type": "string"
                       }
                     },
                     "apps": {
                       "type": "array",
-                      "description": "The list of app `slug`s with dismissal access",
+                      "description": "The list of app `slug`s with push access",
                       "items": {
                         "type": "string"
                       }
                     }
-                  }
+                  },
+                  "required": [
+                    "users",
+                    "teams"
+                  ]
                 },
-                "dismiss_stale_reviews": {
+                "required_linear_history": {
                   "type": "boolean",
-                  "description": "Set to `true` if you want to automatically dismiss approving reviews when someone pushes a new commit."
+                  "description": "Enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch. Set to `true` to enforce a linear commit history. Set to `false` to disable a linear commit Git history. Your repository must allow squash merging or rebase merging before you can enable a linear commit history. Default: `false`. For more information, see \"[Requiring a linear commit history](https://docs.github.com/github/administering-a-repository/requiring-a-linear-commit-history)\" in the GitHub Help documentation."
                 },
-                "require_code_owner_reviews": {
+                "allow_force_pushes": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ],
+                  "description": "Permits force pushes to the protected branch by anyone with write access to the repository. Set to `true` to allow force pushes. Set to `false` or `null` to block force pushes. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation.\""
+                },
+                "allow_deletions": {
                   "type": "boolean",
-                  "description": "Blocks merging pull requests until [code owners](https://docs.github.com/articles/about-code-owners/) review them."
+                  "description": "Allows deletion of the protected branch by anyone with write access to the repository. Set to `false` to prevent deletion of the protected branch. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation."
                 },
-                "required_approving_review_count": {
-                  "type": "integer",
-                  "description": "Specify the number of reviewers required to approve pull requests. Use a number between 1 and 6 or 0 to not require reviewers."
-                },
-                "require_last_push_approval": {
+                "block_creations": {
                   "type": "boolean",
-                  "description": "Whether the most recent push must be approved by someone other than the person who pushed it. Default: `false`.",
+                  "description": "If set to `true`, the `restrictions` branch protection settings which limits who can push will also block pushes which create new branches, unless the push is initiated by a user, team, or app which has the ability to push. Set to `true` to restrict new branch creation. Default: `false`."
+                },
+                "required_conversation_resolution": {
+                  "type": "boolean",
+                  "description": "Requires all conversations on code to be resolved before a pull request can be merged into a branch that matches this rule. Set to `false` to disable. Default: `false`."
+                },
+                "lock_branch": {
+                  "type": "boolean",
+                  "description": "Whether to set the branch as read-only. If this is true, users will not be able to push to the branch. Default: `false`.",
                   "default": false
                 },
-                "bypass_pull_request_allowances": {
-                  "type": "object",
-                  "description": "Allow specific users, teams, or apps to bypass pull request requirements.",
-                  "properties": {
-                    "users": {
-                      "type": "array",
-                      "description": "The list of user `login`s allowed to bypass pull request requirements.",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "teams": {
-                      "type": "array",
-                      "description": "The list of team `slug`s allowed to bypass pull request requirements.",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "apps": {
-                      "type": "array",
-                      "description": "The list of app `slug`s allowed to bypass pull request requirements.",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "restrictions": {
-              "type": [
-                "object",
-                "null"
-              ],
-              "description": "Restrict who can push to the protected branch. User, app, and team `restrictions` are only available for organization-owned repositories. Set to `null` to disable.",
-              "properties": {
-                "users": {
-                  "type": "array",
-                  "description": "The list of user `login`s with push access",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "teams": {
-                  "type": "array",
-                  "description": "The list of team `slug`s with push access",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "apps": {
-                  "type": "array",
-                  "description": "The list of app `slug`s with push access",
-                  "items": {
-                    "type": "string"
-                  }
+                "allow_fork_syncing": {
+                  "type": "boolean",
+                  "description": "Whether users can pull changes from upstream when the branch is locked. Set to `true` to allow fork syncing. Set to `false` to prevent fork syncing. Default: `false`.",
+                  "default": false
                 }
               },
               "required": [
-                "users",
-                "teams"
+                "required_status_checks",
+                "enforce_admins",
+                "required_pull_request_reviews",
+                "restrictions"
               ]
-            },
-            "required_linear_history": {
-              "type": "boolean",
-              "description": "Enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch. Set to `true` to enforce a linear commit history. Set to `false` to disable a linear commit Git history. Your repository must allow squash merging or rebase merging before you can enable a linear commit history. Default: `false`. For more information, see \"[Requiring a linear commit history](https://docs.github.com/github/administering-a-repository/requiring-a-linear-commit-history)\" in the GitHub Help documentation."
-            },
-            "allow_force_pushes": {
-              "type": [
-                "boolean",
-                "null"
-              ],
-              "description": "Permits force pushes to the protected branch by anyone with write access to the repository. Set to `true` to allow force pushes. Set to `false` or `null` to block force pushes. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation.\""
-            },
-            "allow_deletions": {
-              "type": "boolean",
-              "description": "Allows deletion of the protected branch by anyone with write access to the repository. Set to `false` to prevent deletion of the protected branch. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation."
-            },
-            "block_creations": {
-              "type": "boolean",
-              "description": "If set to `true`, the `restrictions` branch protection settings which limits who can push will also block pushes which create new branches, unless the push is initiated by a user, team, or app which has the ability to push. Set to `true` to restrict new branch creation. Default: `false`."
-            },
-            "required_conversation_resolution": {
-              "type": "boolean",
-              "description": "Requires all conversations on code to be resolved before a pull request can be merged into a branch that matches this rule. Set to `false` to disable. Default: `false`."
-            },
-            "lock_branch": {
-              "type": "boolean",
-              "description": "Whether to set the branch as read-only. If this is true, users will not be able to push to the branch. Default: `false`.",
-              "default": false
-            },
-            "allow_fork_syncing": {
-              "type": "boolean",
-              "description": "Whether users can pull changes from upstream when the branch is locked. Set to `true` to allow fork syncing. Set to `false` to prevent fork syncing. Default: `false`.",
-              "default": false
             }
-          },
-          "required": [
-            "required_status_checks",
-            "enforce_admins",
-            "required_pull_request_reviews",
-            "restrictions"
           ]
         }
       }

--- a/schema/dereferenced/settings.json
+++ b/schema/dereferenced/settings.json
@@ -36,23 +36,14 @@
               ]
             },
             "security_and_analysis": {
-              "type": "object",
+              "type": [
+                "object",
+                "null"
+              ],
               "description": "Specify which security and analysis features to enable or disable for the repository.\n\nTo use this parameter, you must have admin permissions for the repository or be an owner or security manager for the organization that owns the repository. For more information, see \"[Managing security managers in your organization](https://docs.github.com/organizations/managing-peoples-access-to-your-organization-with-roles/managing-security-managers-in-your-organization).\"\n\nFor example, to enable GitHub Advanced Security, use this data in the body of the `PATCH` request:\n`{ \"security_and_analysis\": {\"advanced_security\": { \"status\": \"enabled\" } } }`.\n\nYou can check which security and analysis features are currently enabled by using a `GET /repos/{owner}/{repo}` request.",
-              "nullable": true,
               "properties": {
                 "advanced_security": {
                   "type": "object",
-                  "description": "Use the `status` property to enable or disable GitHub Advanced Security for this repository.\nFor more information, see \"[About GitHub Advanced\nSecurity](/github/getting-started-with-github/learning-about-github/about-github-advanced-security).\"\n\nFor standalone Code Scanning or Secret Protection products, this parameter cannot be used.",
-                  "properties": {
-                    "status": {
-                      "type": "string",
-                      "description": "Can be `enabled` or `disabled`."
-                    }
-                  }
-                },
-                "code_security": {
-                  "type": "object",
-                  "description": "Use the `status` property to enable or disable GitHub Code Security for this repository.",
                   "description": "Use the `status` property to enable or disable GitHub Advanced Security for this repository.\nFor more information, see \"[About GitHub Advanced\nSecurity](/github/getting-started-with-github/learning-about-github/about-github-advanced-security).\"\n\nFor standalone Code Scanning or Secret Protection products, this parameter cannot be used.",
                   "properties": {
                     "status": {
@@ -84,16 +75,6 @@
                 "secret_scanning_push_protection": {
                   "type": "object",
                   "description": "Use the `status` property to enable or disable secret scanning push protection for this repository. For more information, see \"[Protecting pushes with secret scanning](/code-security/secret-scanning/protecting-pushes-with-secret-scanning).\"",
-                  "properties": {
-                    "status": {
-                      "type": "string",
-                      "description": "Can be `enabled` or `disabled`."
-                    }
-                  }
-                },
-                "secret_scanning_ai_detection": {
-                  "type": "object",
-                  "description": "Use the `status` property to enable or disable secret scanning AI detection for this repository. For more information, see \"[Responsible detection of generic secrets with AI](https://docs.github.com/code-security/secret-scanning/using-advanced-secret-scanning-and-push-protection-features/generic-secret-detection/responsible-ai-generic-secrets).\"",
                   "properties": {
                     "status": {
                       "type": "string",
@@ -197,6 +178,19 @@
               "type": "boolean",
               "description": "Either `true` to enable the wiki for this repository or `false` to disable it.",
               "default": true
+            },
+            "has_pull_requests": {
+              "type": "boolean",
+              "description": "Either `true` to allow pull requests for this repository or `false` to prevent pull requests.",
+              "default": true
+            },
+            "pull_request_creation_policy": {
+              "type": "string",
+              "description": "The policy that controls who can create pull requests for this repository: `all` or `collaborators_only`.",
+              "enum": [
+                "all",
+                "collaborators_only"
+              ]
             },
             "is_template": {
               "type": "boolean",
@@ -329,7 +323,7 @@
               }
             },
             "force_create": {
-              "description": "Force create the repository even if it already exists",
+              "description": "Force create the repository",
               "type": "boolean"
             },
             "template": {
@@ -461,15 +455,6 @@
               "notifications_disabled"
             ]
           },
-          "permission": {
-            "type": "string",
-            "description": "**Closing down notice**. The permission that new repositories will be added to the team with when none is specified.",
-            "enum": [
-              "pull",
-              "push"
-            ],
-            "default": "pull"
-          },
           "parent_team_id": {
             "type": "integer",
             "description": "The ID of a team to set as the parent team."
@@ -515,9 +500,11 @@
             "type": "object",
             "properties": {
               "required_status_checks": {
-                "type": "object",
+                "type": [
+                  "object",
+                  "null"
+                ],
                 "description": "Require status checks to pass before merging. Set to `null` to disable.",
-                "nullable": true,
                 "properties": {
                   "strict": {
                     "type": "boolean",
@@ -558,14 +545,18 @@
                 ]
               },
               "enforce_admins": {
-                "type": "boolean",
-                "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable.",
-                "nullable": true
+                "type": [
+                  "boolean",
+                  "null"
+                ],
+                "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable."
               },
               "required_pull_request_reviews": {
-                "type": "object",
+                "type": [
+                  "object",
+                  "null"
+                ],
                 "description": "Require at least one approving review on a pull request, before merging. Set to `null` to disable.",
-                "nullable": true,
                 "properties": {
                   "dismissal_restrictions": {
                     "type": "object",
@@ -641,9 +632,11 @@
                 }
               },
               "restrictions": {
-                "type": "object",
+                "type": [
+                  "object",
+                  "null"
+                ],
                 "description": "Restrict who can push to the protected branch. User, app, and team `restrictions` are only available for organization-owned repositories. Set to `null` to disable.",
-                "nullable": true,
                 "properties": {
                   "users": {
                     "type": "array",
@@ -677,9 +670,11 @@
                 "description": "Enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch. Set to `true` to enforce a linear commit history. Set to `false` to disable a linear commit Git history. Your repository must allow squash merging or rebase merging before you can enable a linear commit history. Default: `false`. For more information, see \"[Requiring a linear commit history](https://docs.github.com/github/administering-a-repository/requiring-a-linear-commit-history)\" in the GitHub Help documentation."
               },
               "allow_force_pushes": {
-                "type": "boolean",
-                "description": "Permits force pushes to the protected branch by anyone with write access to the repository. Set to `true` to allow force pushes. Set to `false` or `null` to block force pushes. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation.\"",
-                "nullable": true
+                "type": [
+                  "boolean",
+                  "null"
+                ],
+                "description": "Permits force pushes to the protected branch by anyone with write access to the repository. Set to `true` to allow force pushes. Set to `false` or `null` to block force pushes. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation.\""
               },
               "allow_deletions": {
                 "type": "boolean",
@@ -793,9 +788,11 @@
               ],
               "properties": {
                 "actor_id": {
-                  "type": "integer",
-                  "nullable": true,
-                  "description": "The ID of the actor that can bypass a ruleset. Required for `Integration`, `RepositoryRole`, and `Team` actor types. If `actor_type` is `OrganizationAdmin`, `actor_id` is ignored. If `actor_type` is `DeployKey`, this should be null. `OrganizationAdmin` is not applicable for personal repositories."
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "description": "The ID of the actor that can bypass a ruleset. Required for `Integration`, `RepositoryRole`, `Team`, and `User` actor types. If `actor_type` is `OrganizationAdmin`, `actor_id` is ignored. If `actor_type` is `DeployKey`, this should be null. `OrganizationAdmin` is not applicable for personal repositories."
                 },
                 "actor_type": {
                   "type": "string",
@@ -804,7 +801,8 @@
                     "OrganizationAdmin",
                     "RepositoryRole",
                     "Team",
-                    "DeployKey"
+                    "DeployKey",
+                    "User"
                   ],
                   "description": "The type of actor that can bypass a ruleset."
                 },
@@ -1228,6 +1226,49 @@
                         "dismiss_stale_reviews_on_push": {
                           "type": "boolean",
                           "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
+                        },
+                        "dismissal_restriction": {
+                          "title": "DismissalRestriction",
+                          "description": "Specify people, teams, or apps allowed to dismiss pull request reviews.",
+                          "type": "object",
+                          "properties": {
+                            "allowed_actors": {
+                              "type": "array",
+                              "description": "Specify people, teams, or apps allowed to dismiss pull request reviews.",
+                              "items": {
+                                "title": "Actor",
+                                "description": "An actor allowed to dismiss pull request reviews",
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "integer",
+                                    "description": "ID of the actor that can dismiss reviews."
+                                  },
+                                  "type": {
+                                    "type": "string",
+                                    "description": "The type of the actor",
+                                    "enum": [
+                                      "User",
+                                      "Team",
+                                      "IntegrationInstallation",
+                                      "RepositoryRole"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "id",
+                                  "type"
+                                ]
+                              }
+                            },
+                            "enabled": {
+                              "type": "boolean",
+                              "description": "Whether to restrict review dismissal to specific actors."
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ]
                         },
                         "require_code_owner_review": {
                           "type": "boolean",
@@ -2035,9 +2076,11 @@
               ]
             },
             "security_and_analysis": {
-              "type": "object",
+              "type": [
+                "object",
+                "null"
+              ],
               "description": "Specify which security and analysis features to enable or disable for the repository.\n\nTo use this parameter, you must have admin permissions for the repository or be an owner or security manager for the organization that owns the repository. For more information, see \"[Managing security managers in your organization](https://docs.github.com/organizations/managing-peoples-access-to-your-organization-with-roles/managing-security-managers-in-your-organization).\"\n\nFor example, to enable GitHub Advanced Security, use this data in the body of the `PATCH` request:\n`{ \"security_and_analysis\": {\"advanced_security\": { \"status\": \"enabled\" } } }`.\n\nYou can check which security and analysis features are currently enabled by using a `GET /repos/{owner}/{repo}` request.",
-              "nullable": true,
               "properties": {
                 "advanced_security": {
                   "type": "object",
@@ -2176,6 +2219,19 @@
               "description": "Either `true` to enable the wiki for this repository or `false` to disable it.",
               "default": true
             },
+            "has_pull_requests": {
+              "type": "boolean",
+              "description": "Either `true` to allow pull requests for this repository or `false` to prevent pull requests.",
+              "default": true
+            },
+            "pull_request_creation_policy": {
+              "type": "string",
+              "description": "The policy that controls who can create pull requests for this repository: `all` or `collaborators_only`.",
+              "enum": [
+                "all",
+                "collaborators_only"
+              ]
+            },
             "is_template": {
               "type": "boolean",
               "description": "Either `true` to make this repo available as a template repository or `false` to prevent it.",
@@ -2307,7 +2363,7 @@
               }
             },
             "force_create": {
-              "description": "Force create the repository even if it already exists",
+              "description": "Force create the repository",
               "type": "boolean"
             },
             "template": {
@@ -2469,9 +2525,11 @@
           "type": "object",
           "properties": {
             "required_status_checks": {
-              "type": "object",
+              "type": [
+                "object",
+                "null"
+              ],
               "description": "Require status checks to pass before merging. Set to `null` to disable.",
-              "nullable": true,
               "properties": {
                 "strict": {
                   "type": "boolean",
@@ -2512,14 +2570,18 @@
               ]
             },
             "enforce_admins": {
-              "type": "boolean",
-              "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable.",
-              "nullable": true
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable."
             },
             "required_pull_request_reviews": {
-              "type": "object",
+              "type": [
+                "object",
+                "null"
+              ],
               "description": "Require at least one approving review on a pull request, before merging. Set to `null` to disable.",
-              "nullable": true,
               "properties": {
                 "dismissal_restrictions": {
                   "type": "object",
@@ -2595,9 +2657,11 @@
               }
             },
             "restrictions": {
-              "type": "object",
+              "type": [
+                "object",
+                "null"
+              ],
               "description": "Restrict who can push to the protected branch. User, app, and team `restrictions` are only available for organization-owned repositories. Set to `null` to disable.",
-              "nullable": true,
               "properties": {
                 "users": {
                   "type": "array",
@@ -2631,9 +2695,11 @@
               "description": "Enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch. Set to `true` to enforce a linear commit history. Set to `false` to disable a linear commit Git history. Your repository must allow squash merging or rebase merging before you can enable a linear commit history. Default: `false`. For more information, see \"[Requiring a linear commit history](https://docs.github.com/github/administering-a-repository/requiring-a-linear-commit-history)\" in the GitHub Help documentation."
             },
             "allow_force_pushes": {
-              "type": "boolean",
-              "description": "Permits force pushes to the protected branch by anyone with write access to the repository. Set to `true` to allow force pushes. Set to `false` or `null` to block force pushes. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation.\"",
-              "nullable": true
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "description": "Permits force pushes to the protected branch by anyone with write access to the repository. Set to `true` to allow force pushes. Set to `false` or `null` to block force pushes. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation.\""
             },
             "allow_deletions": {
               "type": "boolean",
@@ -2739,9 +2805,11 @@
             ],
             "properties": {
               "actor_id": {
-                "type": "integer",
-                "nullable": true,
-                "description": "The ID of the actor that can bypass a ruleset. Required for `Integration`, `RepositoryRole`, and `Team` actor types. If `actor_type` is `OrganizationAdmin`, `actor_id` is ignored. If `actor_type` is `DeployKey`, this should be null. `OrganizationAdmin` is not applicable for personal repositories."
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "The ID of the actor that can bypass a ruleset. Required for `Integration`, `RepositoryRole`, `Team`, and `User` actor types. If `actor_type` is `OrganizationAdmin`, `actor_id` is ignored. If `actor_type` is `DeployKey`, this should be null. `OrganizationAdmin` is not applicable for personal repositories."
               },
               "actor_type": {
                 "type": "string",
@@ -2750,7 +2818,8 @@
                   "OrganizationAdmin",
                   "RepositoryRole",
                   "Team",
-                  "DeployKey"
+                  "DeployKey",
+                  "User"
                 ],
                 "description": "The type of actor that can bypass a ruleset."
               },
@@ -3174,6 +3243,49 @@
                       "dismiss_stale_reviews_on_push": {
                         "type": "boolean",
                         "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
+                      },
+                      "dismissal_restriction": {
+                        "title": "DismissalRestriction",
+                        "description": "Specify people, teams, or apps allowed to dismiss pull request reviews.",
+                        "type": "object",
+                        "properties": {
+                          "allowed_actors": {
+                            "type": "array",
+                            "description": "Specify people, teams, or apps allowed to dismiss pull request reviews.",
+                            "items": {
+                              "title": "Actor",
+                              "description": "An actor allowed to dismiss pull request reviews",
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "integer",
+                                  "description": "ID of the actor that can dismiss reviews."
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "description": "The type of the actor",
+                                  "enum": [
+                                    "User",
+                                    "Team",
+                                    "IntegrationInstallation",
+                                    "RepositoryRole"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "type"
+                              ]
+                            }
+                          },
+                          "enabled": {
+                            "type": "boolean",
+                            "description": "Whether to restrict review dismissal to specific actors."
+                          }
+                        },
+                        "required": [
+                          "enabled"
+                        ]
                       },
                       "require_code_owner_review": {
                         "type": "boolean",

--- a/schema/dereferenced/settings.json
+++ b/schema/dereferenced/settings.json
@@ -499,8 +499,13 @@
           "protection": {
             "anyOf": [
               {
-                "type": "null",
-                "description": "Set to `null` to delete the existing branch protection"
+                "enum": [
+                  null,
+                  {},
+                  [],
+                  false
+                ],
+                "description": "An empty value deletes the existing branch protection"
               },
               {
                 "type": "object",
@@ -2532,8 +2537,13 @@
         "protection": {
           "anyOf": [
             {
-              "type": "null",
-              "description": "Set to `null` to delete the existing branch protection"
+              "enum": [
+                null,
+                {},
+                [],
+                false
+              ],
+              "description": "An empty value deletes the existing branch protection"
             },
             {
               "type": "object",

--- a/schema/dereferenced/suborgs.json
+++ b/schema/dereferenced/suborgs.json
@@ -531,213 +531,221 @@
             "type": "string"
           },
           "protection": {
-            "type": "object",
-            "properties": {
-              "required_status_checks": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "description": "Require status checks to pass before merging. Set to `null` to disable.",
+            "anyOf": [
+              {
+                "type": "null",
+                "description": "Set to `null` to delete the existing branch protection"
+              },
+              {
+                "type": "object",
                 "properties": {
-                  "strict": {
-                    "type": "boolean",
-                    "description": "Require branches to be up to date before merging."
+                  "required_status_checks": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "description": "Require status checks to pass before merging. Set to `null` to disable.",
+                    "properties": {
+                      "strict": {
+                        "type": "boolean",
+                        "description": "Require branches to be up to date before merging."
+                      },
+                      "contexts": {
+                        "type": "array",
+                        "deprecated": true,
+                        "description": "**Closing down notice**: The list of status checks to require in order to merge into this branch. If any of these checks have recently been set by a particular GitHub App, they will be required to come from that app in future for the branch to merge. Use `checks` instead of `contexts` for more fine-grained control.",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "checks": {
+                        "type": "array",
+                        "description": "The list of status checks to require in order to merge into this branch.",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "context"
+                          ],
+                          "properties": {
+                            "context": {
+                              "type": "string",
+                              "description": "The name of the required check"
+                            },
+                            "app_id": {
+                              "type": "integer",
+                              "description": "The ID of the GitHub App that must provide this check. Omit this field to automatically select the GitHub App that has recently provided this check, or any app if it was not set by a GitHub App. Pass -1 to explicitly allow any app to set the status."
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "required": [
+                      "strict",
+                      "contexts"
+                    ]
                   },
-                  "contexts": {
-                    "type": "array",
-                    "deprecated": true,
-                    "description": "**Closing down notice**: The list of status checks to require in order to merge into this branch. If any of these checks have recently been set by a particular GitHub App, they will be required to come from that app in future for the branch to merge. Use `checks` instead of `contexts` for more fine-grained control.",
-                    "items": {
-                      "type": "string"
-                    }
+                  "enforce_admins": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
+                    "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable."
                   },
-                  "checks": {
-                    "type": "array",
-                    "description": "The list of status checks to require in order to merge into this branch.",
-                    "items": {
-                      "type": "object",
-                      "required": [
-                        "context"
-                      ],
-                      "properties": {
-                        "context": {
-                          "type": "string",
-                          "description": "The name of the required check"
-                        },
-                        "app_id": {
-                          "type": "integer",
-                          "description": "The ID of the GitHub App that must provide this check. Omit this field to automatically select the GitHub App that has recently provided this check, or any app if it was not set by a GitHub App. Pass -1 to explicitly allow any app to set the status."
+                  "required_pull_request_reviews": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "description": "Require at least one approving review on a pull request, before merging. Set to `null` to disable.",
+                    "properties": {
+                      "dismissal_restrictions": {
+                        "type": "object",
+                        "description": "Specify which users, teams, and apps can dismiss pull request reviews. Pass an empty `dismissal_restrictions` object to disable. User and team `dismissal_restrictions` are only available for organization-owned repositories. Omit this parameter for personal repositories.",
+                        "properties": {
+                          "users": {
+                            "type": "array",
+                            "description": "The list of user `login`s with dismissal access",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "teams": {
+                            "type": "array",
+                            "description": "The list of team `slug`s with dismissal access",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "apps": {
+                            "type": "array",
+                            "description": "The list of app `slug`s with dismissal access",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "dismiss_stale_reviews": {
+                        "type": "boolean",
+                        "description": "Set to `true` if you want to automatically dismiss approving reviews when someone pushes a new commit."
+                      },
+                      "require_code_owner_reviews": {
+                        "type": "boolean",
+                        "description": "Blocks merging pull requests until [code owners](https://docs.github.com/articles/about-code-owners/) review them."
+                      },
+                      "required_approving_review_count": {
+                        "type": "integer",
+                        "description": "Specify the number of reviewers required to approve pull requests. Use a number between 1 and 6 or 0 to not require reviewers."
+                      },
+                      "require_last_push_approval": {
+                        "type": "boolean",
+                        "description": "Whether the most recent push must be approved by someone other than the person who pushed it. Default: `false`.",
+                        "default": false
+                      },
+                      "bypass_pull_request_allowances": {
+                        "type": "object",
+                        "description": "Allow specific users, teams, or apps to bypass pull request requirements.",
+                        "properties": {
+                          "users": {
+                            "type": "array",
+                            "description": "The list of user `login`s allowed to bypass pull request requirements.",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "teams": {
+                            "type": "array",
+                            "description": "The list of team `slug`s allowed to bypass pull request requirements.",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "apps": {
+                            "type": "array",
+                            "description": "The list of app `slug`s allowed to bypass pull request requirements.",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
-                  }
-                },
-                "required": [
-                  "strict",
-                  "contexts"
-                ]
-              },
-              "enforce_admins": {
-                "type": [
-                  "boolean",
-                  "null"
-                ],
-                "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable."
-              },
-              "required_pull_request_reviews": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "description": "Require at least one approving review on a pull request, before merging. Set to `null` to disable.",
-                "properties": {
-                  "dismissal_restrictions": {
-                    "type": "object",
-                    "description": "Specify which users, teams, and apps can dismiss pull request reviews. Pass an empty `dismissal_restrictions` object to disable. User and team `dismissal_restrictions` are only available for organization-owned repositories. Omit this parameter for personal repositories.",
+                  },
+                  "restrictions": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "description": "Restrict who can push to the protected branch. User, app, and team `restrictions` are only available for organization-owned repositories. Set to `null` to disable.",
                     "properties": {
                       "users": {
                         "type": "array",
-                        "description": "The list of user `login`s with dismissal access",
+                        "description": "The list of user `login`s with push access",
                         "items": {
                           "type": "string"
                         }
                       },
                       "teams": {
                         "type": "array",
-                        "description": "The list of team `slug`s with dismissal access",
+                        "description": "The list of team `slug`s with push access",
                         "items": {
                           "type": "string"
                         }
                       },
                       "apps": {
                         "type": "array",
-                        "description": "The list of app `slug`s with dismissal access",
+                        "description": "The list of app `slug`s with push access",
                         "items": {
                           "type": "string"
                         }
                       }
-                    }
+                    },
+                    "required": [
+                      "users",
+                      "teams"
+                    ]
                   },
-                  "dismiss_stale_reviews": {
+                  "required_linear_history": {
                     "type": "boolean",
-                    "description": "Set to `true` if you want to automatically dismiss approving reviews when someone pushes a new commit."
+                    "description": "Enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch. Set to `true` to enforce a linear commit history. Set to `false` to disable a linear commit Git history. Your repository must allow squash merging or rebase merging before you can enable a linear commit history. Default: `false`. For more information, see \"[Requiring a linear commit history](https://docs.github.com/github/administering-a-repository/requiring-a-linear-commit-history)\" in the GitHub Help documentation."
                   },
-                  "require_code_owner_reviews": {
+                  "allow_force_pushes": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
+                    "description": "Permits force pushes to the protected branch by anyone with write access to the repository. Set to `true` to allow force pushes. Set to `false` or `null` to block force pushes. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation.\""
+                  },
+                  "allow_deletions": {
                     "type": "boolean",
-                    "description": "Blocks merging pull requests until [code owners](https://docs.github.com/articles/about-code-owners/) review them."
+                    "description": "Allows deletion of the protected branch by anyone with write access to the repository. Set to `false` to prevent deletion of the protected branch. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation."
                   },
-                  "required_approving_review_count": {
-                    "type": "integer",
-                    "description": "Specify the number of reviewers required to approve pull requests. Use a number between 1 and 6 or 0 to not require reviewers."
-                  },
-                  "require_last_push_approval": {
+                  "block_creations": {
                     "type": "boolean",
-                    "description": "Whether the most recent push must be approved by someone other than the person who pushed it. Default: `false`.",
+                    "description": "If set to `true`, the `restrictions` branch protection settings which limits who can push will also block pushes which create new branches, unless the push is initiated by a user, team, or app which has the ability to push. Set to `true` to restrict new branch creation. Default: `false`."
+                  },
+                  "required_conversation_resolution": {
+                    "type": "boolean",
+                    "description": "Requires all conversations on code to be resolved before a pull request can be merged into a branch that matches this rule. Set to `false` to disable. Default: `false`."
+                  },
+                  "lock_branch": {
+                    "type": "boolean",
+                    "description": "Whether to set the branch as read-only. If this is true, users will not be able to push to the branch. Default: `false`.",
                     "default": false
                   },
-                  "bypass_pull_request_allowances": {
-                    "type": "object",
-                    "description": "Allow specific users, teams, or apps to bypass pull request requirements.",
-                    "properties": {
-                      "users": {
-                        "type": "array",
-                        "description": "The list of user `login`s allowed to bypass pull request requirements.",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "teams": {
-                        "type": "array",
-                        "description": "The list of team `slug`s allowed to bypass pull request requirements.",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "apps": {
-                        "type": "array",
-                        "description": "The list of app `slug`s allowed to bypass pull request requirements.",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  }
-                }
-              },
-              "restrictions": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "description": "Restrict who can push to the protected branch. User, app, and team `restrictions` are only available for organization-owned repositories. Set to `null` to disable.",
-                "properties": {
-                  "users": {
-                    "type": "array",
-                    "description": "The list of user `login`s with push access",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "teams": {
-                    "type": "array",
-                    "description": "The list of team `slug`s with push access",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "apps": {
-                    "type": "array",
-                    "description": "The list of app `slug`s with push access",
-                    "items": {
-                      "type": "string"
-                    }
+                  "allow_fork_syncing": {
+                    "type": "boolean",
+                    "description": "Whether users can pull changes from upstream when the branch is locked. Set to `true` to allow fork syncing. Set to `false` to prevent fork syncing. Default: `false`.",
+                    "default": false
                   }
                 },
                 "required": [
-                  "users",
-                  "teams"
+                  "required_status_checks",
+                  "enforce_admins",
+                  "required_pull_request_reviews",
+                  "restrictions"
                 ]
-              },
-              "required_linear_history": {
-                "type": "boolean",
-                "description": "Enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch. Set to `true` to enforce a linear commit history. Set to `false` to disable a linear commit Git history. Your repository must allow squash merging or rebase merging before you can enable a linear commit history. Default: `false`. For more information, see \"[Requiring a linear commit history](https://docs.github.com/github/administering-a-repository/requiring-a-linear-commit-history)\" in the GitHub Help documentation."
-              },
-              "allow_force_pushes": {
-                "type": [
-                  "boolean",
-                  "null"
-                ],
-                "description": "Permits force pushes to the protected branch by anyone with write access to the repository. Set to `true` to allow force pushes. Set to `false` or `null` to block force pushes. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation.\""
-              },
-              "allow_deletions": {
-                "type": "boolean",
-                "description": "Allows deletion of the protected branch by anyone with write access to the repository. Set to `false` to prevent deletion of the protected branch. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation."
-              },
-              "block_creations": {
-                "type": "boolean",
-                "description": "If set to `true`, the `restrictions` branch protection settings which limits who can push will also block pushes which create new branches, unless the push is initiated by a user, team, or app which has the ability to push. Set to `true` to restrict new branch creation. Default: `false`."
-              },
-              "required_conversation_resolution": {
-                "type": "boolean",
-                "description": "Requires all conversations on code to be resolved before a pull request can be merged into a branch that matches this rule. Set to `false` to disable. Default: `false`."
-              },
-              "lock_branch": {
-                "type": "boolean",
-                "description": "Whether to set the branch as read-only. If this is true, users will not be able to push to the branch. Default: `false`.",
-                "default": false
-              },
-              "allow_fork_syncing": {
-                "type": "boolean",
-                "description": "Whether users can pull changes from upstream when the branch is locked. Set to `true` to allow fork syncing. Set to `false` to prevent fork syncing. Default: `false`.",
-                "default": false
               }
-            },
-            "required": [
-              "required_status_checks",
-              "enforce_admins",
-              "required_pull_request_reviews",
-              "restrictions"
             ]
           }
         }
@@ -1362,213 +1370,221 @@
           "type": "string"
         },
         "protection": {
-          "type": "object",
-          "properties": {
-            "required_status_checks": {
-              "type": [
-                "object",
-                "null"
-              ],
-              "description": "Require status checks to pass before merging. Set to `null` to disable.",
+          "anyOf": [
+            {
+              "type": "null",
+              "description": "Set to `null` to delete the existing branch protection"
+            },
+            {
+              "type": "object",
               "properties": {
-                "strict": {
-                  "type": "boolean",
-                  "description": "Require branches to be up to date before merging."
+                "required_status_checks": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "description": "Require status checks to pass before merging. Set to `null` to disable.",
+                  "properties": {
+                    "strict": {
+                      "type": "boolean",
+                      "description": "Require branches to be up to date before merging."
+                    },
+                    "contexts": {
+                      "type": "array",
+                      "deprecated": true,
+                      "description": "**Closing down notice**: The list of status checks to require in order to merge into this branch. If any of these checks have recently been set by a particular GitHub App, they will be required to come from that app in future for the branch to merge. Use `checks` instead of `contexts` for more fine-grained control.",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "checks": {
+                      "type": "array",
+                      "description": "The list of status checks to require in order to merge into this branch.",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "context"
+                        ],
+                        "properties": {
+                          "context": {
+                            "type": "string",
+                            "description": "The name of the required check"
+                          },
+                          "app_id": {
+                            "type": "integer",
+                            "description": "The ID of the GitHub App that must provide this check. Omit this field to automatically select the GitHub App that has recently provided this check, or any app if it was not set by a GitHub App. Pass -1 to explicitly allow any app to set the status."
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "strict",
+                    "contexts"
+                  ]
                 },
-                "contexts": {
-                  "type": "array",
-                  "deprecated": true,
-                  "description": "**Closing down notice**: The list of status checks to require in order to merge into this branch. If any of these checks have recently been set by a particular GitHub App, they will be required to come from that app in future for the branch to merge. Use `checks` instead of `contexts` for more fine-grained control.",
-                  "items": {
-                    "type": "string"
-                  }
+                "enforce_admins": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ],
+                  "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable."
                 },
-                "checks": {
-                  "type": "array",
-                  "description": "The list of status checks to require in order to merge into this branch.",
-                  "items": {
-                    "type": "object",
-                    "required": [
-                      "context"
-                    ],
-                    "properties": {
-                      "context": {
-                        "type": "string",
-                        "description": "The name of the required check"
-                      },
-                      "app_id": {
-                        "type": "integer",
-                        "description": "The ID of the GitHub App that must provide this check. Omit this field to automatically select the GitHub App that has recently provided this check, or any app if it was not set by a GitHub App. Pass -1 to explicitly allow any app to set the status."
+                "required_pull_request_reviews": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "description": "Require at least one approving review on a pull request, before merging. Set to `null` to disable.",
+                  "properties": {
+                    "dismissal_restrictions": {
+                      "type": "object",
+                      "description": "Specify which users, teams, and apps can dismiss pull request reviews. Pass an empty `dismissal_restrictions` object to disable. User and team `dismissal_restrictions` are only available for organization-owned repositories. Omit this parameter for personal repositories.",
+                      "properties": {
+                        "users": {
+                          "type": "array",
+                          "description": "The list of user `login`s with dismissal access",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "teams": {
+                          "type": "array",
+                          "description": "The list of team `slug`s with dismissal access",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "apps": {
+                          "type": "array",
+                          "description": "The list of app `slug`s with dismissal access",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "dismiss_stale_reviews": {
+                      "type": "boolean",
+                      "description": "Set to `true` if you want to automatically dismiss approving reviews when someone pushes a new commit."
+                    },
+                    "require_code_owner_reviews": {
+                      "type": "boolean",
+                      "description": "Blocks merging pull requests until [code owners](https://docs.github.com/articles/about-code-owners/) review them."
+                    },
+                    "required_approving_review_count": {
+                      "type": "integer",
+                      "description": "Specify the number of reviewers required to approve pull requests. Use a number between 1 and 6 or 0 to not require reviewers."
+                    },
+                    "require_last_push_approval": {
+                      "type": "boolean",
+                      "description": "Whether the most recent push must be approved by someone other than the person who pushed it. Default: `false`.",
+                      "default": false
+                    },
+                    "bypass_pull_request_allowances": {
+                      "type": "object",
+                      "description": "Allow specific users, teams, or apps to bypass pull request requirements.",
+                      "properties": {
+                        "users": {
+                          "type": "array",
+                          "description": "The list of user `login`s allowed to bypass pull request requirements.",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "teams": {
+                          "type": "array",
+                          "description": "The list of team `slug`s allowed to bypass pull request requirements.",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "apps": {
+                          "type": "array",
+                          "description": "The list of app `slug`s allowed to bypass pull request requirements.",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
                       }
                     }
                   }
-                }
-              },
-              "required": [
-                "strict",
-                "contexts"
-              ]
-            },
-            "enforce_admins": {
-              "type": [
-                "boolean",
-                "null"
-              ],
-              "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable."
-            },
-            "required_pull_request_reviews": {
-              "type": [
-                "object",
-                "null"
-              ],
-              "description": "Require at least one approving review on a pull request, before merging. Set to `null` to disable.",
-              "properties": {
-                "dismissal_restrictions": {
-                  "type": "object",
-                  "description": "Specify which users, teams, and apps can dismiss pull request reviews. Pass an empty `dismissal_restrictions` object to disable. User and team `dismissal_restrictions` are only available for organization-owned repositories. Omit this parameter for personal repositories.",
+                },
+                "restrictions": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "description": "Restrict who can push to the protected branch. User, app, and team `restrictions` are only available for organization-owned repositories. Set to `null` to disable.",
                   "properties": {
                     "users": {
                       "type": "array",
-                      "description": "The list of user `login`s with dismissal access",
+                      "description": "The list of user `login`s with push access",
                       "items": {
                         "type": "string"
                       }
                     },
                     "teams": {
                       "type": "array",
-                      "description": "The list of team `slug`s with dismissal access",
+                      "description": "The list of team `slug`s with push access",
                       "items": {
                         "type": "string"
                       }
                     },
                     "apps": {
                       "type": "array",
-                      "description": "The list of app `slug`s with dismissal access",
+                      "description": "The list of app `slug`s with push access",
                       "items": {
                         "type": "string"
                       }
                     }
-                  }
+                  },
+                  "required": [
+                    "users",
+                    "teams"
+                  ]
                 },
-                "dismiss_stale_reviews": {
+                "required_linear_history": {
                   "type": "boolean",
-                  "description": "Set to `true` if you want to automatically dismiss approving reviews when someone pushes a new commit."
+                  "description": "Enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch. Set to `true` to enforce a linear commit history. Set to `false` to disable a linear commit Git history. Your repository must allow squash merging or rebase merging before you can enable a linear commit history. Default: `false`. For more information, see \"[Requiring a linear commit history](https://docs.github.com/github/administering-a-repository/requiring-a-linear-commit-history)\" in the GitHub Help documentation."
                 },
-                "require_code_owner_reviews": {
+                "allow_force_pushes": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ],
+                  "description": "Permits force pushes to the protected branch by anyone with write access to the repository. Set to `true` to allow force pushes. Set to `false` or `null` to block force pushes. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation.\""
+                },
+                "allow_deletions": {
                   "type": "boolean",
-                  "description": "Blocks merging pull requests until [code owners](https://docs.github.com/articles/about-code-owners/) review them."
+                  "description": "Allows deletion of the protected branch by anyone with write access to the repository. Set to `false` to prevent deletion of the protected branch. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation."
                 },
-                "required_approving_review_count": {
-                  "type": "integer",
-                  "description": "Specify the number of reviewers required to approve pull requests. Use a number between 1 and 6 or 0 to not require reviewers."
-                },
-                "require_last_push_approval": {
+                "block_creations": {
                   "type": "boolean",
-                  "description": "Whether the most recent push must be approved by someone other than the person who pushed it. Default: `false`.",
+                  "description": "If set to `true`, the `restrictions` branch protection settings which limits who can push will also block pushes which create new branches, unless the push is initiated by a user, team, or app which has the ability to push. Set to `true` to restrict new branch creation. Default: `false`."
+                },
+                "required_conversation_resolution": {
+                  "type": "boolean",
+                  "description": "Requires all conversations on code to be resolved before a pull request can be merged into a branch that matches this rule. Set to `false` to disable. Default: `false`."
+                },
+                "lock_branch": {
+                  "type": "boolean",
+                  "description": "Whether to set the branch as read-only. If this is true, users will not be able to push to the branch. Default: `false`.",
                   "default": false
                 },
-                "bypass_pull_request_allowances": {
-                  "type": "object",
-                  "description": "Allow specific users, teams, or apps to bypass pull request requirements.",
-                  "properties": {
-                    "users": {
-                      "type": "array",
-                      "description": "The list of user `login`s allowed to bypass pull request requirements.",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "teams": {
-                      "type": "array",
-                      "description": "The list of team `slug`s allowed to bypass pull request requirements.",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "apps": {
-                      "type": "array",
-                      "description": "The list of app `slug`s allowed to bypass pull request requirements.",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "restrictions": {
-              "type": [
-                "object",
-                "null"
-              ],
-              "description": "Restrict who can push to the protected branch. User, app, and team `restrictions` are only available for organization-owned repositories. Set to `null` to disable.",
-              "properties": {
-                "users": {
-                  "type": "array",
-                  "description": "The list of user `login`s with push access",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "teams": {
-                  "type": "array",
-                  "description": "The list of team `slug`s with push access",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "apps": {
-                  "type": "array",
-                  "description": "The list of app `slug`s with push access",
-                  "items": {
-                    "type": "string"
-                  }
+                "allow_fork_syncing": {
+                  "type": "boolean",
+                  "description": "Whether users can pull changes from upstream when the branch is locked. Set to `true` to allow fork syncing. Set to `false` to prevent fork syncing. Default: `false`.",
+                  "default": false
                 }
               },
               "required": [
-                "users",
-                "teams"
+                "required_status_checks",
+                "enforce_admins",
+                "required_pull_request_reviews",
+                "restrictions"
               ]
-            },
-            "required_linear_history": {
-              "type": "boolean",
-              "description": "Enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch. Set to `true` to enforce a linear commit history. Set to `false` to disable a linear commit Git history. Your repository must allow squash merging or rebase merging before you can enable a linear commit history. Default: `false`. For more information, see \"[Requiring a linear commit history](https://docs.github.com/github/administering-a-repository/requiring-a-linear-commit-history)\" in the GitHub Help documentation."
-            },
-            "allow_force_pushes": {
-              "type": [
-                "boolean",
-                "null"
-              ],
-              "description": "Permits force pushes to the protected branch by anyone with write access to the repository. Set to `true` to allow force pushes. Set to `false` or `null` to block force pushes. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation.\""
-            },
-            "allow_deletions": {
-              "type": "boolean",
-              "description": "Allows deletion of the protected branch by anyone with write access to the repository. Set to `false` to prevent deletion of the protected branch. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation."
-            },
-            "block_creations": {
-              "type": "boolean",
-              "description": "If set to `true`, the `restrictions` branch protection settings which limits who can push will also block pushes which create new branches, unless the push is initiated by a user, team, or app which has the ability to push. Set to `true` to restrict new branch creation. Default: `false`."
-            },
-            "required_conversation_resolution": {
-              "type": "boolean",
-              "description": "Requires all conversations on code to be resolved before a pull request can be merged into a branch that matches this rule. Set to `false` to disable. Default: `false`."
-            },
-            "lock_branch": {
-              "type": "boolean",
-              "description": "Whether to set the branch as read-only. If this is true, users will not be able to push to the branch. Default: `false`.",
-              "default": false
-            },
-            "allow_fork_syncing": {
-              "type": "boolean",
-              "description": "Whether users can pull changes from upstream when the branch is locked. Set to `true` to allow fork syncing. Set to `false` to prevent fork syncing. Default: `false`.",
-              "default": false
             }
-          },
-          "required": [
-            "required_status_checks",
-            "enforce_admins",
-            "required_pull_request_reviews",
-            "restrictions"
           ]
         }
       }

--- a/schema/dereferenced/suborgs.json
+++ b/schema/dereferenced/suborgs.json
@@ -70,9 +70,11 @@
               ]
             },
             "security_and_analysis": {
-              "type": "object",
+              "type": [
+                "object",
+                "null"
+              ],
               "description": "Specify which security and analysis features to enable or disable for the repository.\n\nTo use this parameter, you must have admin permissions for the repository or be an owner or security manager for the organization that owns the repository. For more information, see \"[Managing security managers in your organization](https://docs.github.com/organizations/managing-peoples-access-to-your-organization-with-roles/managing-security-managers-in-your-organization).\"\n\nFor example, to enable GitHub Advanced Security, use this data in the body of the `PATCH` request:\n`{ \"security_and_analysis\": {\"advanced_security\": { \"status\": \"enabled\" } } }`.\n\nYou can check which security and analysis features are currently enabled by using a `GET /repos/{owner}/{repo}` request.",
-              "nullable": true,
               "properties": {
                 "advanced_security": {
                   "type": "object",
@@ -210,6 +212,19 @@
               "type": "boolean",
               "description": "Either `true` to enable the wiki for this repository or `false` to disable it.",
               "default": true
+            },
+            "has_pull_requests": {
+              "type": "boolean",
+              "description": "Either `true` to allow pull requests for this repository or `false` to prevent pull requests.",
+              "default": true
+            },
+            "pull_request_creation_policy": {
+              "type": "string",
+              "description": "The policy that controls who can create pull requests for this repository: `all` or `collaborators_only`.",
+              "enum": [
+                "all",
+                "collaborators_only"
+              ]
             },
             "is_template": {
               "type": "boolean",
@@ -519,9 +534,11 @@
             "type": "object",
             "properties": {
               "required_status_checks": {
-                "type": "object",
+                "type": [
+                  "object",
+                  "null"
+                ],
                 "description": "Require status checks to pass before merging. Set to `null` to disable.",
-                "nullable": true,
                 "properties": {
                   "strict": {
                     "type": "boolean",
@@ -562,14 +579,18 @@
                 ]
               },
               "enforce_admins": {
-                "type": "boolean",
-                "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable.",
-                "nullable": true
+                "type": [
+                  "boolean",
+                  "null"
+                ],
+                "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable."
               },
               "required_pull_request_reviews": {
-                "type": "object",
+                "type": [
+                  "object",
+                  "null"
+                ],
                 "description": "Require at least one approving review on a pull request, before merging. Set to `null` to disable.",
-                "nullable": true,
                 "properties": {
                   "dismissal_restrictions": {
                     "type": "object",
@@ -645,9 +666,11 @@
                 }
               },
               "restrictions": {
-                "type": "object",
+                "type": [
+                  "object",
+                  "null"
+                ],
                 "description": "Restrict who can push to the protected branch. User, app, and team `restrictions` are only available for organization-owned repositories. Set to `null` to disable.",
-                "nullable": true,
                 "properties": {
                   "users": {
                     "type": "array",
@@ -681,9 +704,11 @@
                 "description": "Enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch. Set to `true` to enforce a linear commit history. Set to `false` to disable a linear commit Git history. Your repository must allow squash merging or rebase merging before you can enable a linear commit history. Default: `false`. For more information, see \"[Requiring a linear commit history](https://docs.github.com/github/administering-a-repository/requiring-a-linear-commit-history)\" in the GitHub Help documentation."
               },
               "allow_force_pushes": {
-                "type": "boolean",
-                "description": "Permits force pushes to the protected branch by anyone with write access to the repository. Set to `true` to allow force pushes. Set to `false` or `null` to block force pushes. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation.\"",
-                "nullable": true
+                "type": [
+                  "boolean",
+                  "null"
+                ],
+                "description": "Permits force pushes to the protected branch by anyone with write access to the repository. Set to `true` to allow force pushes. Set to `false` or `null` to block force pushes. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation.\""
               },
               "allow_deletions": {
                 "type": "boolean",
@@ -891,9 +916,11 @@
               ]
             },
             "security_and_analysis": {
-              "type": "object",
+              "type": [
+                "object",
+                "null"
+              ],
               "description": "Specify which security and analysis features to enable or disable for the repository.\n\nTo use this parameter, you must have admin permissions for the repository or be an owner or security manager for the organization that owns the repository. For more information, see \"[Managing security managers in your organization](https://docs.github.com/organizations/managing-peoples-access-to-your-organization-with-roles/managing-security-managers-in-your-organization).\"\n\nFor example, to enable GitHub Advanced Security, use this data in the body of the `PATCH` request:\n`{ \"security_and_analysis\": {\"advanced_security\": { \"status\": \"enabled\" } } }`.\n\nYou can check which security and analysis features are currently enabled by using a `GET /repos/{owner}/{repo}` request.",
-              "nullable": true,
               "properties": {
                 "advanced_security": {
                   "type": "object",
@@ -1031,6 +1058,19 @@
               "type": "boolean",
               "description": "Either `true` to enable the wiki for this repository or `false` to disable it.",
               "default": true
+            },
+            "has_pull_requests": {
+              "type": "boolean",
+              "description": "Either `true` to allow pull requests for this repository or `false` to prevent pull requests.",
+              "default": true
+            },
+            "pull_request_creation_policy": {
+              "type": "string",
+              "description": "The policy that controls who can create pull requests for this repository: `all` or `collaborators_only`.",
+              "enum": [
+                "all",
+                "collaborators_only"
+              ]
             },
             "is_template": {
               "type": "boolean",
@@ -1325,9 +1365,11 @@
           "type": "object",
           "properties": {
             "required_status_checks": {
-              "type": "object",
+              "type": [
+                "object",
+                "null"
+              ],
               "description": "Require status checks to pass before merging. Set to `null` to disable.",
-              "nullable": true,
               "properties": {
                 "strict": {
                   "type": "boolean",
@@ -1368,14 +1410,18 @@
               ]
             },
             "enforce_admins": {
-              "type": "boolean",
-              "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable.",
-              "nullable": true
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable."
             },
             "required_pull_request_reviews": {
-              "type": "object",
+              "type": [
+                "object",
+                "null"
+              ],
               "description": "Require at least one approving review on a pull request, before merging. Set to `null` to disable.",
-              "nullable": true,
               "properties": {
                 "dismissal_restrictions": {
                   "type": "object",
@@ -1451,9 +1497,11 @@
               }
             },
             "restrictions": {
-              "type": "object",
+              "type": [
+                "object",
+                "null"
+              ],
               "description": "Restrict who can push to the protected branch. User, app, and team `restrictions` are only available for organization-owned repositories. Set to `null` to disable.",
-              "nullable": true,
               "properties": {
                 "users": {
                   "type": "array",
@@ -1487,9 +1535,11 @@
               "description": "Enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch. Set to `true` to enforce a linear commit history. Set to `false` to disable a linear commit Git history. Your repository must allow squash merging or rebase merging before you can enable a linear commit history. Default: `false`. For more information, see \"[Requiring a linear commit history](https://docs.github.com/github/administering-a-repository/requiring-a-linear-commit-history)\" in the GitHub Help documentation."
             },
             "allow_force_pushes": {
-              "type": "boolean",
-              "description": "Permits force pushes to the protected branch by anyone with write access to the repository. Set to `true` to allow force pushes. Set to `false` or `null` to block force pushes. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation.\"",
-              "nullable": true
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "description": "Permits force pushes to the protected branch by anyone with write access to the repository. Set to `true` to allow force pushes. Set to `false` or `null` to block force pushes. Default: `false`. For more information, see \"[Enabling force pushes to a protected branch](https://docs.github.com/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)\" in the GitHub Help documentation.\""
             },
             "allow_deletions": {
               "type": "boolean",
@@ -1595,9 +1645,11 @@
             ],
             "properties": {
               "actor_id": {
-                "type": "integer",
-                "nullable": true,
-                "description": "The ID of the actor that can bypass a ruleset. Required for `Integration`, `RepositoryRole`, and `Team` actor types. If `actor_type` is `OrganizationAdmin`, `actor_id` is ignored. If `actor_type` is `DeployKey`, this should be null. `OrganizationAdmin` is not applicable for personal repositories."
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "The ID of the actor that can bypass a ruleset. Required for `Integration`, `RepositoryRole`, `Team`, and `User` actor types. If `actor_type` is `OrganizationAdmin`, `actor_id` is ignored. If `actor_type` is `DeployKey`, this should be null. `OrganizationAdmin` is not applicable for personal repositories."
               },
               "actor_type": {
                 "type": "string",
@@ -1606,7 +1658,8 @@
                   "OrganizationAdmin",
                   "RepositoryRole",
                   "Team",
-                  "DeployKey"
+                  "DeployKey",
+                  "User"
                 ],
                 "description": "The type of actor that can bypass a ruleset."
               },
@@ -2030,6 +2083,49 @@
                       "dismiss_stale_reviews_on_push": {
                         "type": "boolean",
                         "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
+                      },
+                      "dismissal_restriction": {
+                        "title": "DismissalRestriction",
+                        "description": "Specify people, teams, or apps allowed to dismiss pull request reviews.",
+                        "type": "object",
+                        "properties": {
+                          "allowed_actors": {
+                            "type": "array",
+                            "description": "Specify people, teams, or apps allowed to dismiss pull request reviews.",
+                            "items": {
+                              "title": "Actor",
+                              "description": "An actor allowed to dismiss pull request reviews",
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "integer",
+                                  "description": "ID of the actor that can dismiss reviews."
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "description": "The type of the actor",
+                                  "enum": [
+                                    "User",
+                                    "Team",
+                                    "IntegrationInstallation",
+                                    "RepositoryRole"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "type"
+                              ]
+                            }
+                          },
+                          "enabled": {
+                            "type": "boolean",
+                            "description": "Whether to restrict review dismissal to specific actors."
+                          }
+                        },
+                        "required": [
+                          "enabled"
+                        ]
                       },
                       "require_code_owner_review": {
                         "type": "boolean",

--- a/schema/dereferenced/suborgs.json
+++ b/schema/dereferenced/suborgs.json
@@ -787,6 +787,1074 @@
         }
       }
     },
+    "rulesets": {
+      "description": "Repository rulesets applied to every repository in the suborg",
+      "type": "array",
+      "items": {
+        "description": "A repository ruleset entry",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the ruleset."
+          },
+          "target": {
+            "type": "string",
+            "description": "The target of the ruleset",
+            "enum": [
+              "branch",
+              "tag",
+              "push"
+            ],
+            "default": "branch"
+          },
+          "enforcement": {
+            "type": "string",
+            "description": "The enforcement level of the ruleset. `evaluate` allows admins to test rules before enforcing them. Admins can view insights on the Rule Insights page (`evaluate` is only available with GitHub Enterprise).",
+            "enum": [
+              "disabled",
+              "active",
+              "evaluate"
+            ]
+          },
+          "bypass_actors": {
+            "type": "array",
+            "description": "The actors that can bypass the rules in this ruleset",
+            "items": {
+              "title": "Repository Ruleset Bypass Actor",
+              "type": "object",
+              "description": "An actor that can bypass rules in a ruleset",
+              "required": [
+                "actor_type"
+              ],
+              "properties": {
+                "actor_id": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "description": "The ID of the actor that can bypass a ruleset. Required for `Integration`, `RepositoryRole`, `Team`, and `User` actor types. If `actor_type` is `OrganizationAdmin`, `actor_id` is ignored. If `actor_type` is `DeployKey`, this should be null. `OrganizationAdmin` is not applicable for personal repositories."
+                },
+                "actor_type": {
+                  "type": "string",
+                  "enum": [
+                    "Integration",
+                    "OrganizationAdmin",
+                    "RepositoryRole",
+                    "Team",
+                    "DeployKey",
+                    "User"
+                  ],
+                  "description": "The type of actor that can bypass a ruleset."
+                },
+                "bypass_mode": {
+                  "type": "string",
+                  "description": "When the specified actor can bypass the ruleset. `pull_request` means that an actor can only bypass rules on pull requests. `pull_request` is not applicable for the `DeployKey` actor type. Also, `pull_request` is only applicable to branch rulesets. When `bypass_mode` is `exempt`, rules will not be run for that actor and a bypass audit entry will not be created.",
+                  "enum": [
+                    "always",
+                    "pull_request",
+                    "exempt"
+                  ],
+                  "default": "always"
+                }
+              }
+            }
+          },
+          "conditions": {
+            "title": "Repository ruleset conditions for ref names",
+            "type": "object",
+            "description": "Parameters for a repository ruleset ref name condition",
+            "properties": {
+              "ref_name": {
+                "type": "object",
+                "properties": {
+                  "include": {
+                    "type": "array",
+                    "description": "Array of ref names or patterns to include. One of these patterns must match for the condition to pass. Also accepts `~DEFAULT_BRANCH` to include the default branch or `~ALL` to include all branches.",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "exclude": {
+                    "type": "array",
+                    "description": "Array of ref names or patterns to exclude. The condition will not pass if any of these patterns match.",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "rules": {
+            "type": "array",
+            "description": "An array of rules within the ruleset.",
+            "items": {
+              "title": "Repository Rule",
+              "type": "object",
+              "description": "A repository rule.",
+              "oneOf": [
+                {
+                  "title": "creation",
+                  "description": "Only allow users with bypass permission to create matching refs.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "creation"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "update",
+                  "description": "Only allow users with bypass permission to update matching refs.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "update"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "update_allows_fetch_and_merge": {
+                          "type": "boolean",
+                          "description": "Branch can pull changes from its upstream repository"
+                        }
+                      },
+                      "required": [
+                        "update_allows_fetch_and_merge"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "deletion",
+                  "description": "Only allow users with bypass permissions to delete matching refs.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "deletion"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "required_linear_history",
+                  "description": "Prevent merge commits from being pushed to matching refs.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "required_linear_history"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "merge_queue",
+                  "description": "Merges must be performed via a merge queue.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "merge_queue"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "check_response_timeout_minutes": {
+                          "type": "integer",
+                          "description": "Maximum time for a required status check to report a conclusion. After this much time has elapsed, checks that have not reported a conclusion will be assumed to have failed",
+                          "minimum": 1,
+                          "maximum": 360
+                        },
+                        "grouping_strategy": {
+                          "type": "string",
+                          "description": "When set to ALLGREEN, the merge commit created by merge queue for each PR in the group must pass all required checks to merge. When set to HEADGREEN, only the commit at the head of the merge group, i.e. the commit containing changes from all of the PRs in the group, must pass its required checks to merge.",
+                          "enum": [
+                            "ALLGREEN",
+                            "HEADGREEN"
+                          ]
+                        },
+                        "max_entries_to_build": {
+                          "type": "integer",
+                          "description": "Limit the number of queued pull requests requesting checks and workflow runs at the same time.",
+                          "minimum": 0,
+                          "maximum": 100
+                        },
+                        "max_entries_to_merge": {
+                          "type": "integer",
+                          "description": "The maximum number of PRs that will be merged together in a group.",
+                          "minimum": 0,
+                          "maximum": 100
+                        },
+                        "merge_method": {
+                          "type": "string",
+                          "description": "Method to use when merging changes from queued pull requests.",
+                          "enum": [
+                            "MERGE",
+                            "SQUASH",
+                            "REBASE"
+                          ]
+                        },
+                        "min_entries_to_merge": {
+                          "type": "integer",
+                          "description": "The minimum number of PRs that will be merged together in a group.",
+                          "minimum": 0,
+                          "maximum": 100
+                        },
+                        "min_entries_to_merge_wait_minutes": {
+                          "type": "integer",
+                          "description": "The time merge queue should wait after the first PR is added to the queue for the minimum group size to be met. After this time has elapsed, the minimum group size will be ignored and a smaller group will be merged.",
+                          "minimum": 0,
+                          "maximum": 360
+                        }
+                      },
+                      "required": [
+                        "check_response_timeout_minutes",
+                        "grouping_strategy",
+                        "max_entries_to_build",
+                        "max_entries_to_merge",
+                        "merge_method",
+                        "min_entries_to_merge",
+                        "min_entries_to_merge_wait_minutes"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "required_deployments",
+                  "description": "Choose which environments must be successfully deployed to before refs can be pushed into a ref that matches this rule.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "required_deployments"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "required_deployment_environments": {
+                          "type": "array",
+                          "description": "The environments that must be successfully deployed to before branches can be merged.",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "required_deployment_environments"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "required_signatures",
+                  "description": "Commits pushed to matching refs must have verified signatures.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "required_signatures"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "pull_request",
+                  "description": "Require all commits be made to a non-target branch and submitted via a pull request before they can be merged.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "pull_request"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "allowed_merge_methods": {
+                          "type": "array",
+                          "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled.",
+                          "items": {
+                            "type": "string",
+                            "enum": [
+                              "merge",
+                              "squash",
+                              "rebase"
+                            ]
+                          }
+                        },
+                        "dismiss_stale_reviews_on_push": {
+                          "type": "boolean",
+                          "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
+                        },
+                        "dismissal_restriction": {
+                          "title": "DismissalRestriction",
+                          "description": "Specify people, teams, or apps allowed to dismiss pull request reviews.",
+                          "type": "object",
+                          "properties": {
+                            "allowed_actors": {
+                              "type": "array",
+                              "description": "Specify people, teams, or apps allowed to dismiss pull request reviews.",
+                              "items": {
+                                "title": "Actor",
+                                "description": "An actor allowed to dismiss pull request reviews",
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "integer",
+                                    "description": "ID of the actor that can dismiss reviews."
+                                  },
+                                  "type": {
+                                    "type": "string",
+                                    "description": "The type of the actor",
+                                    "enum": [
+                                      "User",
+                                      "Team",
+                                      "IntegrationInstallation",
+                                      "RepositoryRole"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "id",
+                                  "type"
+                                ]
+                              }
+                            },
+                            "enabled": {
+                              "type": "boolean",
+                              "description": "Whether to restrict review dismissal to specific actors."
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ]
+                        },
+                        "require_code_owner_review": {
+                          "type": "boolean",
+                          "description": "Require an approving review in pull requests that modify files that have a designated code owner."
+                        },
+                        "require_last_push_approval": {
+                          "type": "boolean",
+                          "description": "Whether the most recent reviewable push must be approved by someone other than the person who pushed it."
+                        },
+                        "required_approving_review_count": {
+                          "type": "integer",
+                          "description": "The number of approving reviews that are required before a pull request can be merged.",
+                          "minimum": 0,
+                          "maximum": 10
+                        },
+                        "required_review_thread_resolution": {
+                          "type": "boolean",
+                          "description": "All conversations on code must be resolved before a pull request can be merged."
+                        },
+                        "required_reviewers": {
+                          "type": "array",
+                          "description": "> [!NOTE]\n> `required_reviewers` is in beta and subject to change.\n\nA collection of reviewers and associated file patterns. Each reviewer has a list of file patterns which determine the files that reviewer is required to review.",
+                          "items": {
+                            "title": "RequiredReviewerConfiguration",
+                            "description": "A reviewing team, and file patterns describing which files they must approve changes to.",
+                            "type": "object",
+                            "properties": {
+                              "file_patterns": {
+                                "type": "array",
+                                "description": "Array of file patterns. Pull requests which change matching files must be approved by the specified team. File patterns use fnmatch syntax.",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "minimum_approvals": {
+                                "type": "integer",
+                                "description": "Minimum number of approvals required from the specified team. If set to zero, the team will be added to the pull request but approval is optional."
+                              },
+                              "reviewer": {
+                                "title": "Reviewer",
+                                "description": "A required reviewing team",
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "integer",
+                                    "description": "ID of the reviewer which must review changes to matching files."
+                                  },
+                                  "type": {
+                                    "type": "string",
+                                    "description": "The type of the reviewer",
+                                    "enum": [
+                                      "Team"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "id",
+                                  "type"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "file_patterns",
+                              "minimum_approvals",
+                              "reviewer"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "dismiss_stale_reviews_on_push",
+                        "require_code_owner_review",
+                        "require_last_push_approval",
+                        "required_approving_review_count",
+                        "required_review_thread_resolution"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "required_status_checks",
+                  "description": "Choose which status checks must pass before the ref is updated. When enabled, commits must first be pushed to another ref where the checks pass.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "required_status_checks"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "do_not_enforce_on_create": {
+                          "type": "boolean",
+                          "description": "Allow repositories and branches to be created if a check would otherwise prohibit it."
+                        },
+                        "required_status_checks": {
+                          "type": "array",
+                          "description": "Status checks that are required.",
+                          "items": {
+                            "title": "StatusCheckConfiguration",
+                            "description": "Required status check",
+                            "type": "object",
+                            "properties": {
+                              "context": {
+                                "type": "string",
+                                "description": "The status check context name that must be present on the commit."
+                              },
+                              "integration_id": {
+                                "type": "integer",
+                                "description": "The optional integration ID that this status check must originate from."
+                              }
+                            },
+                            "required": [
+                              "context"
+                            ]
+                          }
+                        },
+                        "strict_required_status_checks_policy": {
+                          "type": "boolean",
+                          "description": "Whether pull requests targeting a matching branch must be tested with the latest code. This setting will not take effect unless at least one status check is enabled."
+                        }
+                      },
+                      "required": [
+                        "required_status_checks",
+                        "strict_required_status_checks_policy"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "non_fast_forward",
+                  "description": "Prevent users with push access from force pushing to refs.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "non_fast_forward"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "commit_message_pattern",
+                  "description": "Parameters to be used for the commit_message_pattern rule",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "commit_message_pattern"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "How this rule appears when configuring it."
+                        },
+                        "negate": {
+                          "type": "boolean",
+                          "description": "If true, the rule will fail if the pattern matches."
+                        },
+                        "operator": {
+                          "type": "string",
+                          "description": "The operator to use for matching.",
+                          "enum": [
+                            "starts_with",
+                            "ends_with",
+                            "contains",
+                            "regex"
+                          ]
+                        },
+                        "pattern": {
+                          "type": "string",
+                          "description": "The pattern to match with."
+                        }
+                      },
+                      "required": [
+                        "operator",
+                        "pattern"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "commit_author_email_pattern",
+                  "description": "Parameters to be used for the commit_author_email_pattern rule",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "commit_author_email_pattern"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "How this rule appears when configuring it."
+                        },
+                        "negate": {
+                          "type": "boolean",
+                          "description": "If true, the rule will fail if the pattern matches."
+                        },
+                        "operator": {
+                          "type": "string",
+                          "description": "The operator to use for matching.",
+                          "enum": [
+                            "starts_with",
+                            "ends_with",
+                            "contains",
+                            "regex"
+                          ]
+                        },
+                        "pattern": {
+                          "type": "string",
+                          "description": "The pattern to match with."
+                        }
+                      },
+                      "required": [
+                        "operator",
+                        "pattern"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "committer_email_pattern",
+                  "description": "Parameters to be used for the committer_email_pattern rule",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "committer_email_pattern"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "How this rule appears when configuring it."
+                        },
+                        "negate": {
+                          "type": "boolean",
+                          "description": "If true, the rule will fail if the pattern matches."
+                        },
+                        "operator": {
+                          "type": "string",
+                          "description": "The operator to use for matching.",
+                          "enum": [
+                            "starts_with",
+                            "ends_with",
+                            "contains",
+                            "regex"
+                          ]
+                        },
+                        "pattern": {
+                          "type": "string",
+                          "description": "The pattern to match with."
+                        }
+                      },
+                      "required": [
+                        "operator",
+                        "pattern"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "branch_name_pattern",
+                  "description": "Parameters to be used for the branch_name_pattern rule",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "branch_name_pattern"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "How this rule appears when configuring it."
+                        },
+                        "negate": {
+                          "type": "boolean",
+                          "description": "If true, the rule will fail if the pattern matches."
+                        },
+                        "operator": {
+                          "type": "string",
+                          "description": "The operator to use for matching.",
+                          "enum": [
+                            "starts_with",
+                            "ends_with",
+                            "contains",
+                            "regex"
+                          ]
+                        },
+                        "pattern": {
+                          "type": "string",
+                          "description": "The pattern to match with."
+                        }
+                      },
+                      "required": [
+                        "operator",
+                        "pattern"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "tag_name_pattern",
+                  "description": "Parameters to be used for the tag_name_pattern rule",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "tag_name_pattern"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "How this rule appears when configuring it."
+                        },
+                        "negate": {
+                          "type": "boolean",
+                          "description": "If true, the rule will fail if the pattern matches."
+                        },
+                        "operator": {
+                          "type": "string",
+                          "description": "The operator to use for matching.",
+                          "enum": [
+                            "starts_with",
+                            "ends_with",
+                            "contains",
+                            "regex"
+                          ]
+                        },
+                        "pattern": {
+                          "type": "string",
+                          "description": "The pattern to match with."
+                        }
+                      },
+                      "required": [
+                        "operator",
+                        "pattern"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "workflows",
+                  "description": "Require all changes made to a targeted branch to pass the specified workflows before they can be merged.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "workflows"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "do_not_enforce_on_create": {
+                          "type": "boolean",
+                          "description": "Allow repositories and branches to be created if a check would otherwise prohibit it."
+                        },
+                        "workflows": {
+                          "type": "array",
+                          "description": "Workflows that must pass for this rule to pass.",
+                          "items": {
+                            "title": "WorkflowFileReference",
+                            "description": "A workflow that must run for this rule to pass",
+                            "type": "object",
+                            "properties": {
+                              "path": {
+                                "type": "string",
+                                "description": "The path to the workflow file"
+                              },
+                              "ref": {
+                                "type": "string",
+                                "description": "The ref (branch or tag) of the workflow file to use"
+                              },
+                              "repository_id": {
+                                "type": "integer",
+                                "description": "The ID of the repository where the workflow is defined"
+                              },
+                              "sha": {
+                                "type": "string",
+                                "description": "The commit SHA of the workflow file to use"
+                              }
+                            },
+                            "required": [
+                              "path",
+                              "repository_id"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "workflows"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "code_scanning",
+                  "description": "Choose which tools must provide code scanning results before the reference is updated. When configured, code scanning must be enabled and have results for both the commit and the reference being updated.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "code_scanning"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "code_scanning_tools": {
+                          "type": "array",
+                          "description": "Tools that must provide code scanning results for this rule to pass.",
+                          "items": {
+                            "title": "CodeScanningTool",
+                            "description": "A tool that must provide code scanning results for this rule to pass.",
+                            "type": "object",
+                            "properties": {
+                              "alerts_threshold": {
+                                "type": "string",
+                                "description": "The severity level at which code scanning results that raise alerts block a reference update. For more information on alert severity levels, see \"[About code scanning alerts](https://docs.github.com/code-security/code-scanning/managing-code-scanning-alerts/about-code-scanning-alerts#about-alert-severity-and-security-severity-levels).\"",
+                                "enum": [
+                                  "none",
+                                  "errors",
+                                  "errors_and_warnings",
+                                  "all"
+                                ]
+                              },
+                              "security_alerts_threshold": {
+                                "type": "string",
+                                "description": "The severity level at which code scanning results that raise security alerts block a reference update. For more information on security severity levels, see \"[About code scanning alerts](https://docs.github.com/code-security/code-scanning/managing-code-scanning-alerts/about-code-scanning-alerts#about-alert-severity-and-security-severity-levels).\"",
+                                "enum": [
+                                  "none",
+                                  "critical",
+                                  "high_or_higher",
+                                  "medium_or_higher",
+                                  "all"
+                                ]
+                              },
+                              "tool": {
+                                "type": "string",
+                                "description": "The name of a code scanning tool"
+                              }
+                            },
+                            "required": [
+                              "alerts_threshold",
+                              "security_alerts_threshold",
+                              "tool"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "code_scanning_tools"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "copilot_code_review",
+                  "description": "Request Copilot code review for new pull requests automatically if the author has access to Copilot code review and their premium requests quota has not reached the limit.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "copilot_code_review"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "review_draft_pull_requests": {
+                          "type": "boolean",
+                          "description": "Copilot automatically reviews draft pull requests before they are marked as ready for review."
+                        },
+                        "review_on_push": {
+                          "type": "boolean",
+                          "description": "Copilot automatically reviews each new push to the pull request."
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "title": "license_compliance_scanning",
+                  "description": "Enforce any added or changed dependencies to comply with the organization's license policy.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "license_compliance_scanning"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "file_path_restriction",
+                  "description": "Prevent commits that include changes in specified file and folder paths from being pushed to the commit graph. This includes absolute paths that contain file names.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "file_path_restriction"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "restricted_file_paths": {
+                          "type": "array",
+                          "description": "The file paths that are restricted from being pushed to the commit graph.",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "restricted_file_paths"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "max_file_path_length",
+                  "description": "Prevent commits that include file paths that exceed the specified character limit from being pushed to the commit graph.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "max_file_path_length"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "max_file_path_length": {
+                          "type": "integer",
+                          "description": "The maximum amount of characters allowed in file paths.",
+                          "minimum": 1,
+                          "maximum": 32767
+                        }
+                      },
+                      "required": [
+                        "max_file_path_length"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "file_extension_restriction",
+                  "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "file_extension_restriction"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "restricted_file_extensions": {
+                          "type": "array",
+                          "description": "The file extensions that are restricted from being pushed to the commit graph.",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "restricted_file_extensions"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "max_file_size",
+                  "description": "Prevent commits with individual files that exceed the specified limit from being pushed to the commit graph.",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "max_file_size"
+                      ]
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "max_file_size": {
+                          "type": "integer",
+                          "description": "The maximum file size allowed in megabytes. This limit does not apply to Git Large File Storage (Git LFS).",
+                          "minimum": 1,
+                          "maximum": 100
+                        }
+                      },
+                      "required": [
+                        "max_file_size"
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "required": [
+          "name",
+          "enforcement"
+        ]
+      }
+    },
     "environments": {
       "description": "Deployment environments",
       "type": "array",
@@ -1622,7 +2690,7 @@
       }
     },
     "RulesetSettings": {
-      "description": "A ruleset entry",
+      "description": "A repository ruleset entry",
       "type": "object",
       "properties": {
         "name": {
@@ -1635,8 +2703,7 @@
           "enum": [
             "branch",
             "tag",
-            "push",
-            "repository"
+            "push"
           ],
           "default": "branch"
         },
@@ -1693,248 +2760,30 @@
           }
         },
         "conditions": {
-          "title": "Organization ruleset conditions",
+          "title": "Repository ruleset conditions for ref names",
           "type": "object",
-          "description": "Conditions for an organization ruleset.\nThe branch and tag rulesets conditions object should contain both `repository_name` and `ref_name` properties, or both `repository_id` and `ref_name` properties, or both `repository_property` and `ref_name` properties.\nThe push rulesets conditions object does not require the `ref_name` property.\nFor repository policy rulesets, the conditions object should only contain the `repository_name`, the `repository_id`, or the `repository_property`.",
-          "oneOf": [
-            {
+          "description": "Parameters for a repository ruleset ref name condition",
+          "properties": {
+            "ref_name": {
               "type": "object",
-              "title": "repository_name_and_ref_name",
-              "description": "Conditions to target repositories by name and refs by name",
-              "allOf": [
-                {
-                  "title": "Repository ruleset conditions for ref names",
-                  "type": "object",
-                  "description": "Parameters for a repository ruleset ref name condition",
-                  "properties": {
-                    "ref_name": {
-                      "type": "object",
-                      "properties": {
-                        "include": {
-                          "type": "array",
-                          "description": "Array of ref names or patterns to include. One of these patterns must match for the condition to pass. Also accepts `~DEFAULT_BRANCH` to include the default branch or `~ALL` to include all branches.",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "exclude": {
-                          "type": "array",
-                          "description": "Array of ref names or patterns to exclude. The condition will not pass if any of these patterns match.",
-                          "items": {
-                            "type": "string"
-                          }
-                        }
-                      }
-                    }
+              "properties": {
+                "include": {
+                  "type": "array",
+                  "description": "Array of ref names or patterns to include. One of these patterns must match for the condition to pass. Also accepts `~DEFAULT_BRANCH` to include the default branch or `~ALL` to include all branches.",
+                  "items": {
+                    "type": "string"
                   }
                 },
-                {
-                  "title": "Repository ruleset conditions for repository names",
-                  "type": "object",
-                  "description": "Parameters for a repository name condition",
-                  "properties": {
-                    "repository_name": {
-                      "type": "object",
-                      "properties": {
-                        "include": {
-                          "type": "array",
-                          "description": "Array of repository names or patterns to include. One of these patterns must match for the condition to pass. Also accepts `~ALL` to include all repositories.",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "exclude": {
-                          "type": "array",
-                          "description": "Array of repository names or patterns to exclude. The condition will not pass if any of these patterns match.",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "protected": {
-                          "type": "boolean",
-                          "description": "Whether renaming of target repositories is prevented."
-                        }
-                      }
-                    }
-                  },
-                  "required": [
-                    "repository_name"
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "object",
-              "title": "repository_id_and_ref_name",
-              "description": "Conditions to target repositories by id and refs by name",
-              "allOf": [
-                {
-                  "title": "Repository ruleset conditions for ref names",
-                  "type": "object",
-                  "description": "Parameters for a repository ruleset ref name condition",
-                  "properties": {
-                    "ref_name": {
-                      "type": "object",
-                      "properties": {
-                        "include": {
-                          "type": "array",
-                          "description": "Array of ref names or patterns to include. One of these patterns must match for the condition to pass. Also accepts `~DEFAULT_BRANCH` to include the default branch or `~ALL` to include all branches.",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "exclude": {
-                          "type": "array",
-                          "description": "Array of ref names or patterns to exclude. The condition will not pass if any of these patterns match.",
-                          "items": {
-                            "type": "string"
-                          }
-                        }
-                      }
-                    }
+                "exclude": {
+                  "type": "array",
+                  "description": "Array of ref names or patterns to exclude. The condition will not pass if any of these patterns match.",
+                  "items": {
+                    "type": "string"
                   }
-                },
-                {
-                  "title": "Repository ruleset conditions for repository IDs",
-                  "type": "object",
-                  "description": "Parameters for a repository ID condition",
-                  "properties": {
-                    "repository_id": {
-                      "type": "object",
-                      "properties": {
-                        "repository_ids": {
-                          "type": "array",
-                          "description": "The repository IDs that the ruleset applies to. One of these IDs must match for the condition to pass.",
-                          "items": {
-                            "type": "integer"
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "required": [
-                    "repository_id"
-                  ]
                 }
-              ]
-            },
-            {
-              "type": "object",
-              "title": "repository_property_and_ref_name",
-              "description": "Conditions to target repositories by property and refs by name",
-              "allOf": [
-                {
-                  "title": "Repository ruleset conditions for ref names",
-                  "type": "object",
-                  "description": "Parameters for a repository ruleset ref name condition",
-                  "properties": {
-                    "ref_name": {
-                      "type": "object",
-                      "properties": {
-                        "include": {
-                          "type": "array",
-                          "description": "Array of ref names or patterns to include. One of these patterns must match for the condition to pass. Also accepts `~DEFAULT_BRANCH` to include the default branch or `~ALL` to include all branches.",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "exclude": {
-                          "type": "array",
-                          "description": "Array of ref names or patterns to exclude. The condition will not pass if any of these patterns match.",
-                          "items": {
-                            "type": "string"
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                {
-                  "title": "Repository ruleset conditions for repository properties",
-                  "type": "object",
-                  "description": "Parameters for a repository property condition",
-                  "properties": {
-                    "repository_property": {
-                      "type": "object",
-                      "properties": {
-                        "include": {
-                          "type": "array",
-                          "description": "The repository properties and values to include. All of these properties must match for the condition to pass.",
-                          "items": {
-                            "title": "Repository ruleset property targeting definition",
-                            "type": "object",
-                            "description": "Parameters for a targeting a repository property",
-                            "properties": {
-                              "name": {
-                                "type": "string",
-                                "description": "The name of the repository property to target"
-                              },
-                              "property_values": {
-                                "type": "array",
-                                "description": "The values to match for the repository property",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "source": {
-                                "type": "string",
-                                "description": "The source of the repository property. Defaults to 'custom' if not specified.",
-                                "enum": [
-                                  "custom",
-                                  "system"
-                                ]
-                              }
-                            },
-                            "required": [
-                              "name",
-                              "property_values"
-                            ]
-                          }
-                        },
-                        "exclude": {
-                          "type": "array",
-                          "description": "The repository properties and values to exclude. The condition will not pass if any of these properties match.",
-                          "items": {
-                            "title": "Repository ruleset property targeting definition",
-                            "type": "object",
-                            "description": "Parameters for a targeting a repository property",
-                            "properties": {
-                              "name": {
-                                "type": "string",
-                                "description": "The name of the repository property to target"
-                              },
-                              "property_values": {
-                                "type": "array",
-                                "description": "The values to match for the repository property",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "source": {
-                                "type": "string",
-                                "description": "The source of the repository property. Defaults to 'custom' if not specified.",
-                                "enum": [
-                                  "custom",
-                                  "system"
-                                ]
-                              }
-                            },
-                            "required": [
-                              "name",
-                              "property_values"
-                            ]
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "required": [
-                    "repository_property"
-                  ]
-                }
-              ]
+              }
             }
-          ]
+          }
         },
         "rules": {
           "type": "array",
@@ -2016,6 +2865,83 @@
                     "type": "string",
                     "enum": [
                       "required_linear_history"
+                    ]
+                  }
+                }
+              },
+              {
+                "title": "merge_queue",
+                "description": "Merges must be performed via a merge queue.",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "merge_queue"
+                    ]
+                  },
+                  "parameters": {
+                    "type": "object",
+                    "properties": {
+                      "check_response_timeout_minutes": {
+                        "type": "integer",
+                        "description": "Maximum time for a required status check to report a conclusion. After this much time has elapsed, checks that have not reported a conclusion will be assumed to have failed",
+                        "minimum": 1,
+                        "maximum": 360
+                      },
+                      "grouping_strategy": {
+                        "type": "string",
+                        "description": "When set to ALLGREEN, the merge commit created by merge queue for each PR in the group must pass all required checks to merge. When set to HEADGREEN, only the commit at the head of the merge group, i.e. the commit containing changes from all of the PRs in the group, must pass its required checks to merge.",
+                        "enum": [
+                          "ALLGREEN",
+                          "HEADGREEN"
+                        ]
+                      },
+                      "max_entries_to_build": {
+                        "type": "integer",
+                        "description": "Limit the number of queued pull requests requesting checks and workflow runs at the same time.",
+                        "minimum": 0,
+                        "maximum": 100
+                      },
+                      "max_entries_to_merge": {
+                        "type": "integer",
+                        "description": "The maximum number of PRs that will be merged together in a group.",
+                        "minimum": 0,
+                        "maximum": 100
+                      },
+                      "merge_method": {
+                        "type": "string",
+                        "description": "Method to use when merging changes from queued pull requests.",
+                        "enum": [
+                          "MERGE",
+                          "SQUASH",
+                          "REBASE"
+                        ]
+                      },
+                      "min_entries_to_merge": {
+                        "type": "integer",
+                        "description": "The minimum number of PRs that will be merged together in a group.",
+                        "minimum": 0,
+                        "maximum": 100
+                      },
+                      "min_entries_to_merge_wait_minutes": {
+                        "type": "integer",
+                        "description": "The time merge queue should wait after the first PR is added to the queue for the minimum group size to be met. After this time has elapsed, the minimum group size will be ignored and a smaller group will be merged.",
+                        "minimum": 0,
+                        "maximum": 360
+                      }
+                    },
+                    "required": [
+                      "check_response_timeout_minutes",
+                      "grouping_strategy",
+                      "max_entries_to_build",
+                      "max_entries_to_merge",
+                      "merge_method",
+                      "min_entries_to_merge",
+                      "min_entries_to_merge_wait_minutes"
                     ]
                   }
                 }
@@ -2528,128 +3454,6 @@
                 }
               },
               {
-                "title": "file_path_restriction",
-                "description": "Prevent commits that include changes in specified file and folder paths from being pushed to the commit graph. This includes absolute paths that contain file names.",
-                "type": "object",
-                "required": [
-                  "type"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "file_path_restriction"
-                    ]
-                  },
-                  "parameters": {
-                    "type": "object",
-                    "properties": {
-                      "restricted_file_paths": {
-                        "type": "array",
-                        "description": "The file paths that are restricted from being pushed to the commit graph.",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "required": [
-                      "restricted_file_paths"
-                    ]
-                  }
-                }
-              },
-              {
-                "title": "max_file_path_length",
-                "description": "Prevent commits that include file paths that exceed the specified character limit from being pushed to the commit graph.",
-                "type": "object",
-                "required": [
-                  "type"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "max_file_path_length"
-                    ]
-                  },
-                  "parameters": {
-                    "type": "object",
-                    "properties": {
-                      "max_file_path_length": {
-                        "type": "integer",
-                        "description": "The maximum amount of characters allowed in file paths.",
-                        "minimum": 1,
-                        "maximum": 32767
-                      }
-                    },
-                    "required": [
-                      "max_file_path_length"
-                    ]
-                  }
-                }
-              },
-              {
-                "title": "file_extension_restriction",
-                "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph.",
-                "type": "object",
-                "required": [
-                  "type"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "file_extension_restriction"
-                    ]
-                  },
-                  "parameters": {
-                    "type": "object",
-                    "properties": {
-                      "restricted_file_extensions": {
-                        "type": "array",
-                        "description": "The file extensions that are restricted from being pushed to the commit graph.",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "required": [
-                      "restricted_file_extensions"
-                    ]
-                  }
-                }
-              },
-              {
-                "title": "max_file_size",
-                "description": "Prevent commits with individual files that exceed the specified limit from being pushed to the commit graph.",
-                "type": "object",
-                "required": [
-                  "type"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "max_file_size"
-                    ]
-                  },
-                  "parameters": {
-                    "type": "object",
-                    "properties": {
-                      "max_file_size": {
-                        "type": "integer",
-                        "description": "The maximum file size allowed in megabytes. This limit does not apply to Git Large File Storage (Git LFS).",
-                        "minimum": 1,
-                        "maximum": 100
-                      }
-                    },
-                    "required": [
-                      "max_file_size"
-                    ]
-                  }
-                }
-              },
-              {
                 "title": "workflows",
                 "description": "Require all changes made to a targeted branch to pass the specified workflows before they can be merged.",
                 "type": "object",
@@ -2799,6 +3603,144 @@
                         "description": "Copilot automatically reviews each new push to the pull request."
                       }
                     }
+                  }
+                }
+              },
+              {
+                "title": "license_compliance_scanning",
+                "description": "Enforce any added or changed dependencies to comply with the organization's license policy.",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "license_compliance_scanning"
+                    ]
+                  }
+                }
+              },
+              {
+                "title": "file_path_restriction",
+                "description": "Prevent commits that include changes in specified file and folder paths from being pushed to the commit graph. This includes absolute paths that contain file names.",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "file_path_restriction"
+                    ]
+                  },
+                  "parameters": {
+                    "type": "object",
+                    "properties": {
+                      "restricted_file_paths": {
+                        "type": "array",
+                        "description": "The file paths that are restricted from being pushed to the commit graph.",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": [
+                      "restricted_file_paths"
+                    ]
+                  }
+                }
+              },
+              {
+                "title": "max_file_path_length",
+                "description": "Prevent commits that include file paths that exceed the specified character limit from being pushed to the commit graph.",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "max_file_path_length"
+                    ]
+                  },
+                  "parameters": {
+                    "type": "object",
+                    "properties": {
+                      "max_file_path_length": {
+                        "type": "integer",
+                        "description": "The maximum amount of characters allowed in file paths.",
+                        "minimum": 1,
+                        "maximum": 32767
+                      }
+                    },
+                    "required": [
+                      "max_file_path_length"
+                    ]
+                  }
+                }
+              },
+              {
+                "title": "file_extension_restriction",
+                "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph.",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "file_extension_restriction"
+                    ]
+                  },
+                  "parameters": {
+                    "type": "object",
+                    "properties": {
+                      "restricted_file_extensions": {
+                        "type": "array",
+                        "description": "The file extensions that are restricted from being pushed to the commit graph.",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": [
+                      "restricted_file_extensions"
+                    ]
+                  }
+                }
+              },
+              {
+                "title": "max_file_size",
+                "description": "Prevent commits with individual files that exceed the specified limit from being pushed to the commit graph.",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "max_file_size"
+                    ]
+                  },
+                  "parameters": {
+                    "type": "object",
+                    "properties": {
+                      "max_file_size": {
+                        "type": "integer",
+                        "description": "The maximum file size allowed in megabytes. This limit does not apply to Git Large File Storage (Git LFS).",
+                        "minimum": 1,
+                        "maximum": 100
+                      }
+                    },
+                    "required": [
+                      "max_file_size"
+                    ]
                   }
                 }
               }

--- a/schema/dereferenced/suborgs.json
+++ b/schema/dereferenced/suborgs.json
@@ -533,8 +533,13 @@
           "protection": {
             "anyOf": [
               {
-                "type": "null",
-                "description": "Set to `null` to delete the existing branch protection"
+                "enum": [
+                  null,
+                  {},
+                  [],
+                  false
+                ],
+                "description": "An empty value deletes the existing branch protection"
               },
               {
                 "type": "object",
@@ -2440,8 +2445,13 @@
         "protection": {
           "anyOf": [
             {
-              "type": "null",
-              "description": "Set to `null` to delete the existing branch protection"
+              "enum": [
+                null,
+                {},
+                [],
+                false
+              ],
+              "description": "An empty value deletes the existing branch protection"
             },
             {
               "type": "object",

--- a/schema/repos.json
+++ b/schema/repos.json
@@ -226,8 +226,8 @@
         "protection": {
           "anyOf": [
             {
-              "type": "null",
-              "description": "Set to `null` to delete the existing branch protection"
+              "enum": [null, {}, [], false],
+              "description": "An empty value deletes the existing branch protection"
             },
             {
               "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1branches~1{branch}~1protection/put/requestBody/content/application~1json/schema"

--- a/schema/repos.json
+++ b/schema/repos.json
@@ -48,6 +48,13 @@
     "validator": {
       "$ref": "#/$defs/ValidatorSettings"
     },
+    "rulesets": {
+      "description": "Repository rulesets applied to this repository",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/RulesetSettings"
+      }
+    },
     "environments": {
       "description": "Deployment environments",
       "type": "array",
@@ -243,8 +250,8 @@
       }
     },
     "RulesetSettings": {
-      "description": "A ruleset entry",
-      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1orgs~1{org}~1rulesets/post/requestBody/content/application~1json/schema"
+      "description": "A repository ruleset entry",
+      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1rulesets/post/requestBody/content/application~1json/schema"
     },
     "EnvironmentsSettings": {
       "description": "A deployment environment configuration entry",

--- a/schema/repos.json
+++ b/schema/repos.json
@@ -217,7 +217,15 @@
           "type": "string"
         },
         "protection": {
-          "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1branches~1{branch}~1protection/put/requestBody/content/application~1json/schema"
+          "anyOf": [
+            {
+              "type": "null",
+              "description": "Set to `null` to delete the existing branch protection"
+            },
+            {
+              "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1branches~1{branch}~1protection/put/requestBody/content/application~1json/schema"
+            }
+          ]
         }
       }
     },

--- a/schema/repos.json
+++ b/schema/repos.json
@@ -75,7 +75,7 @@
       "description": "Repository settings",
       "allOf": [
         {
-          "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}/patch/requestBody/content/application~1json/schema"
+          "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}/patch/requestBody/content/application~1json/schema"
         },
         {
           "type": "object",
@@ -162,7 +162,7 @@
       "description": "A collaborator entry giving a specific user access to a repository.",
       "allOf": [
         {
-          "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1collaborators~1{username}/put/requestBody/content/application~1json/schema"
+          "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1collaborators~1{username}/put/requestBody/content/application~1json/schema"
         },
         {
           "type": "object",
@@ -190,7 +190,7 @@
     },
     "TeamSettings": {
       "description": "A team entry",
-      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2026-03-10.json#/paths/~1orgs~1{org}~1teams/post/requestBody/content/application~1json/schema"
+      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1orgs~1{org}~1teams/post/requestBody/content/application~1json/schema"
     },
     "MilestoneSettings": {
       "description": "A milestone entry",
@@ -217,13 +217,13 @@
           "type": "string"
         },
         "protection": {
-          "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1branches~1{branch}~1protection/put/requestBody/content/application~1json/schema"
+          "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1branches~1{branch}~1protection/put/requestBody/content/application~1json/schema"
         }
       }
     },
     "AutolinkSettings": {
       "description": "An autolink reference entry",
-      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1autolinks/post/requestBody/content/application~1json/schema"
+      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1autolinks/post/requestBody/content/application~1json/schema"
     },
     "ValidatorSettings": {
       "description": "Repository name validation",
@@ -236,7 +236,7 @@
     },
     "RulesetSettings": {
       "description": "A ruleset entry",
-      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2026-03-10.json#/paths/~1orgs~1{org}~1rulesets/post/requestBody/content/application~1json/schema"
+      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1orgs~1{org}~1rulesets/post/requestBody/content/application~1json/schema"
     },
     "EnvironmentsSettings": {
       "description": "A deployment environment configuration entry",

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -226,8 +226,8 @@
         "protection": {
           "anyOf": [
             {
-              "type": "null",
-              "description": "Set to `null` to delete the existing branch protection"
+              "enum": [null, {}, [], false],
+              "description": "An empty value deletes the existing branch protection"
             },
             {
               "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1branches~1{branch}~1protection/put/requestBody/content/application~1json/schema"

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -224,7 +224,15 @@
           "type": "string"
         },
         "protection": {
-          "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1branches~1{branch}~1protection/put/requestBody/content/application~1json/schema"
+          "anyOf": [
+            {
+              "type": "null",
+              "description": "Set to `null` to delete the existing branch protection"
+            },
+            {
+              "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1branches~1{branch}~1protection/put/requestBody/content/application~1json/schema"
+            }
+          ]
         }
       }
     },

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -82,7 +82,7 @@
       "description": "Repository settings",
       "allOf": [
         {
-          "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}/patch/requestBody/content/application~1json/schema"
+          "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}/patch/requestBody/content/application~1json/schema"
         },
         {
           "type": "object",
@@ -169,7 +169,7 @@
       "description": "A collaborator entry giving a specific user access to a repository.",
       "allOf": [
         {
-          "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1collaborators~1{username}/put/requestBody/content/application~1json/schema"
+          "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1collaborators~1{username}/put/requestBody/content/application~1json/schema"
         },
         {
           "type": "object",
@@ -197,7 +197,7 @@
     },
     "TeamSettings": {
       "description": "A team entry",
-      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2026-03-10.json#/paths/~1orgs~1{org}~1teams/post/requestBody/content/application~1json/schema"
+      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1orgs~1{org}~1teams/post/requestBody/content/application~1json/schema"
     },
     "MilestoneSettings": {
       "description": "A milestone entry",
@@ -224,13 +224,13 @@
           "type": "string"
         },
         "protection": {
-          "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1branches~1{branch}~1protection/put/requestBody/content/application~1json/schema"
+          "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1branches~1{branch}~1protection/put/requestBody/content/application~1json/schema"
         }
       }
     },
     "AutolinkSettings": {
       "description": "An autolink reference entry",
-      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1autolinks/post/requestBody/content/application~1json/schema"
+      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1autolinks/post/requestBody/content/application~1json/schema"
     },
     "ValidatorSettings": {
       "description": "Repository name validation",
@@ -243,7 +243,7 @@
     },
     "RulesetSettings": {
       "description": "A ruleset entry",
-      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2026-03-10.json#/paths/~1orgs~1{org}~1rulesets/post/requestBody/content/application~1json/schema"
+      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1orgs~1{org}~1rulesets/post/requestBody/content/application~1json/schema"
     },
     "EnvironmentsSettings": {
       "description": "A deployment environment configuration entry",

--- a/schema/suborgs.json
+++ b/schema/suborgs.json
@@ -82,6 +82,13 @@
     "validator": {
       "$ref": "#/$defs/ValidatorSettings"
     },
+    "rulesets": {
+      "description": "Repository rulesets applied to every repository in the suborg",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/RulesetSettings"
+      }
+    },
     "environments": {
       "description": "Deployment environments",
       "type": "array",
@@ -277,8 +284,8 @@
       }
     },
     "RulesetSettings": {
-      "description": "A ruleset entry",
-      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1orgs~1{org}~1rulesets/post/requestBody/content/application~1json/schema"
+      "description": "A repository ruleset entry",
+      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1rulesets/post/requestBody/content/application~1json/schema"
     },
     "EnvironmentsSettings": {
       "description": "A deployment environment configuration entry",

--- a/schema/suborgs.json
+++ b/schema/suborgs.json
@@ -109,7 +109,7 @@
       "description": "Repository settings. Use force_create to create the repository if it does not exist, and template to specify a template repository to use when creating it.",
       "allOf": [
         {
-          "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}/patch/requestBody/content/application~1json/schema"
+          "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}/patch/requestBody/content/application~1json/schema"
         },
         {
           "type": "object",
@@ -196,7 +196,7 @@
       "description": "A collaborator entry giving a specific user access to a repository.",
       "allOf": [
         {
-          "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1collaborators~1{username}/put/requestBody/content/application~1json/schema"
+          "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1collaborators~1{username}/put/requestBody/content/application~1json/schema"
         },
         {
           "type": "object",
@@ -224,7 +224,7 @@
     },
     "TeamSettings": {
       "description": "A team entry",
-      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2026-03-10.json#/paths/~1orgs~1{org}~1teams/post/requestBody/content/application~1json/schema"
+      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1orgs~1{org}~1teams/post/requestBody/content/application~1json/schema"
     },
     "MilestoneSettings": {
       "description": "A milestone entry",
@@ -251,13 +251,13 @@
           "type": "string"
         },
         "protection": {
-          "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1branches~1{branch}~1protection/put/requestBody/content/application~1json/schema"
+          "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1branches~1{branch}~1protection/put/requestBody/content/application~1json/schema"
         }
       }
     },
     "AutolinkSettings": {
       "description": "An autolink reference entry",
-      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1autolinks/post/requestBody/content/application~1json/schema"
+      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1autolinks/post/requestBody/content/application~1json/schema"
     },
     "ValidatorSettings": {
       "description": "Repository name validation",
@@ -270,7 +270,7 @@
     },
     "RulesetSettings": {
       "description": "A ruleset entry",
-      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.2026-03-10.json#/paths/~1orgs~1{org}~1rulesets/post/requestBody/content/application~1json/schema"
+      "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1orgs~1{org}~1rulesets/post/requestBody/content/application~1json/schema"
     },
     "EnvironmentsSettings": {
       "description": "A deployment environment configuration entry",

--- a/schema/suborgs.json
+++ b/schema/suborgs.json
@@ -251,7 +251,15 @@
           "type": "string"
         },
         "protection": {
-          "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1branches~1{branch}~1protection/put/requestBody/content/application~1json/schema"
+          "anyOf": [
+            {
+              "type": "null",
+              "description": "Set to `null` to delete the existing branch protection"
+            },
+            {
+              "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1branches~1{branch}~1protection/put/requestBody/content/application~1json/schema"
+            }
+          ]
         }
       }
     },

--- a/schema/suborgs.json
+++ b/schema/suborgs.json
@@ -260,8 +260,8 @@
         "protection": {
           "anyOf": [
             {
-              "type": "null",
-              "description": "Set to `null` to delete the existing branch protection"
+              "enum": [null, {}, [], false],
+              "description": "An empty value deletes the existing branch protection"
             },
             {
               "$ref": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2026-03-10.json#/paths/~1repos~1{owner}~1{repo}~1branches~1{branch}~1protection/put/requestBody/content/application~1json/schema"

--- a/script/build-schema
+++ b/script/build-schema
@@ -32,9 +32,11 @@ const schemas = [
   console.log(`Fetching ${specUrl} ...`)
   const resolvedSpec = await $RefParser.dereference(specUrl)
 
+  // Serve the pre-dereferenced spec for the exact URL the schema files pin,
+  // so the resolver can never match a different document.
   const githubApiResolver = {
     order: 1,
-    canRead: /\/descriptions-next\/api\.github\.com\/api\.github\.com/,
+    canRead: file => file.url === specUrl,
     read: () => resolvedSpec
   }
 

--- a/script/build-schema
+++ b/script/build-schema
@@ -6,8 +6,8 @@ const path = require('node:path')
 
 const schemas = [
   { src: 'schema/settings.json', dest: 'schema/dereferenced/settings.json' },
-  { src: 'schema/suborgs.json',  dest: 'schema/dereferenced/suborgs.json' },
-  { src: 'schema/repos.json',    dest: 'schema/dereferenced/repos.json' }
+  { src: 'schema/suborgs.json', dest: 'schema/dereferenced/suborgs.json' },
+  { src: 'schema/repos.json', dest: 'schema/dereferenced/repos.json' }
 ]
 
 ;(async () => {
@@ -34,7 +34,7 @@ const schemas = [
 
   const githubApiResolver = {
     order: 1,
-    canRead: /\/descriptions\/api\.github\.com\/api\.github\.com/,
+    canRead: /\/descriptions-next\/api\.github\.com\/api\.github\.com/,
     read: () => resolvedSpec
   }
 

--- a/test/unit/schema.test.js
+++ b/test/unit/schema.test.js
@@ -36,8 +36,8 @@ describe('dereferenced schemas', () => {
     const schema = JSON.parse(fs.readFileSync(path.join(__dirname, '../../schema/dereferenced/settings.json')))
     const protection = schema.properties.branches.items.properties.protection
     const protectionObject = protection.anyOf.find(variant => variant.type === 'object')
-    const requiredStatusChecks = protectionObject.properties.required_status_checks
-    expect(requiredStatusChecks.type).toContain('null')
+    expect(protectionObject.properties.required_status_checks.type).toContain('null')
+    expect(protectionObject.properties.enforce_admins.type).toContain('null')
     expect(protectionObject.properties.restrictions.type).toContain('null')
   })
 

--- a/test/unit/schema.test.js
+++ b/test/unit/schema.test.js
@@ -35,8 +35,20 @@ describe('dereferenced schemas', () => {
   it('allows null for required-but-nullable branch protection fields', () => {
     const schema = JSON.parse(fs.readFileSync(path.join(__dirname, '../../schema/dereferenced/settings.json')))
     const protection = schema.properties.branches.items.properties.protection
-    const requiredStatusChecks = protection.properties.required_status_checks
+    const protectionObject = protection.anyOf.find(variant => variant.type === 'object')
+    const requiredStatusChecks = protectionObject.properties.required_status_checks
     expect(requiredStatusChecks.type).toContain('null')
-    expect(protection.properties.restrictions.type).toContain('null')
+    expect(protectionObject.properties.restrictions.type).toContain('null')
+  })
+
+  // `protection: null` is safe-settings' own delete-branch-protection semantic
+  // (see isEmpty in lib/plugins/branches.js); the GitHub API's PUT body it is
+  // validated against does not model that, so the schema allows null explicitly.
+  it('allows `protection: null` in every schema that has branches', () => {
+    files.forEach(file => {
+      const schema = JSON.parse(fs.readFileSync(path.join(__dirname, '../../schema/dereferenced', file)))
+      const protection = schema.properties.branches.items.properties.protection
+      expect(protection.anyOf).toEqual(expect.arrayContaining([expect.objectContaining({ type: 'null' })]))
+    })
   })
 })

--- a/test/unit/schema.test.js
+++ b/test/unit/schema.test.js
@@ -1,0 +1,42 @@
+/* eslint-disable no-undef */
+
+const fs = require('fs')
+const path = require('path')
+
+// The generated schemas declare JSON Schema draft 2020-12, where OpenAPI 3.0's
+// `nullable` keyword does not exist. The build consumes GitHub's OpenAPI 3.1
+// description, which models null-ability as `type: [X, 'null']` unions instead,
+// so no `nullable` keyword may survive in the output.
+describe('dereferenced schemas', () => {
+  const files = ['settings.json', 'suborgs.json', 'repos.json']
+
+  files.forEach(file => {
+    describe(file, () => {
+      const schema = JSON.parse(fs.readFileSync(path.join(__dirname, '../../schema/dereferenced', file)))
+
+      it('contains no OpenAPI `nullable` keywords', () => {
+        const found = []
+        const walk = (node, at) => {
+          if (Array.isArray(node)) {
+            node.forEach((v, i) => walk(v, `${at}/${i}`))
+          } else if (node && typeof node === 'object') {
+            if ('nullable' in node) {
+              found.push(at)
+            }
+            Object.entries(node).forEach(([k, v]) => walk(v, `${at}/${k}`))
+          }
+        }
+        walk(schema, '')
+        expect(found).toEqual([])
+      })
+    })
+  })
+
+  it('allows null for required-but-nullable branch protection fields', () => {
+    const schema = JSON.parse(fs.readFileSync(path.join(__dirname, '../../schema/dereferenced/settings.json')))
+    const protection = schema.properties.branches.items.properties.protection
+    const requiredStatusChecks = protection.properties.required_status_checks
+    expect(requiredStatusChecks.type).toContain('null')
+    expect(protection.properties.restrictions.type).toContain('null')
+  })
+})

--- a/test/unit/schema.test.js
+++ b/test/unit/schema.test.js
@@ -48,7 +48,9 @@ describe('dereferenced schemas', () => {
     ;['suborgs.json', 'repos.json'].forEach(file => {
       const schema = JSON.parse(fs.readFileSync(path.join(__dirname, '../../schema/dereferenced', file), 'utf8'))
       const ruleset = schema.properties.rulesets.items
-      expect(ruleset.required).toEqual(['name', 'enforcement'])
+      // `required` is an unordered set in JSON Schema
+      expect(ruleset.required).toHaveLength(2)
+      expect(ruleset.required).toEqual(expect.arrayContaining(['name', 'enforcement']))
       // org-only condition targeting must not leak into the repo-level shape
       expect(JSON.stringify(ruleset.properties.conditions)).not.toContain('repository_name')
       const actorTypes = ruleset.properties.bypass_actors.items.properties.actor_type.enum
@@ -64,7 +66,11 @@ describe('dereferenced schemas', () => {
     files.forEach(file => {
       const schema = JSON.parse(fs.readFileSync(path.join(__dirname, '../../schema/dereferenced', file), 'utf8'))
       const protection = schema.properties.branches.items.properties.protection
-      expect(protection.anyOf).toEqual(expect.arrayContaining([expect.objectContaining({ enum: [null, {}, [], false] })]))
+      // enum ordering is not semantically meaningful, so assert membership
+      const emptyVariant = protection.anyOf.find(variant => Array.isArray(variant.enum))
+      expect(emptyVariant).toBeDefined()
+      expect(emptyVariant.enum).toHaveLength(4)
+      expect(emptyVariant.enum).toEqual(expect.arrayContaining([null, {}, [], false]))
     })
   })
 })

--- a/test/unit/schema.test.js
+++ b/test/unit/schema.test.js
@@ -41,6 +41,21 @@ describe('dereferenced schemas', () => {
     expect(protectionObject.properties.restrictions.type).toContain('null')
   })
 
+  // Suborg and repo override files feed the rulesets plugin at repo scope
+  // (childPluginsList in lib/settings.js), so their schemas validate rulesets
+  // against the repo-level API shape, not the org-level one.
+  it('validates per-repo rulesets in the suborg and repo schemas', () => {
+    ;['suborgs.json', 'repos.json'].forEach(file => {
+      const schema = JSON.parse(fs.readFileSync(path.join(__dirname, '../../schema/dereferenced', file)))
+      const ruleset = schema.properties.rulesets.items
+      expect(ruleset.required).toEqual(['name', 'enforcement'])
+      // org-only condition targeting must not leak into the repo-level shape
+      expect(JSON.stringify(ruleset.properties.conditions)).not.toContain('repository_name')
+      const actorTypes = ruleset.properties.bypass_actors.items.properties.actor_type.enum
+      expect(actorTypes).toContain('User')
+    })
+  })
+
   // `protection: null` is safe-settings' own delete-branch-protection semantic
   // (see isEmpty in lib/plugins/branches.js); the GitHub API's PUT body it is
   // validated against does not model that, so the schema allows null explicitly.

--- a/test/unit/schema.test.js
+++ b/test/unit/schema.test.js
@@ -12,7 +12,7 @@ describe('dereferenced schemas', () => {
 
   files.forEach(file => {
     describe(file, () => {
-      const schema = JSON.parse(fs.readFileSync(path.join(__dirname, '../../schema/dereferenced', file)))
+      const schema = JSON.parse(fs.readFileSync(path.join(__dirname, '../../schema/dereferenced', file), 'utf8'))
 
       it('contains no OpenAPI `nullable` keywords', () => {
         const found = []
@@ -33,7 +33,7 @@ describe('dereferenced schemas', () => {
   })
 
   it('allows null for required-but-nullable branch protection fields', () => {
-    const schema = JSON.parse(fs.readFileSync(path.join(__dirname, '../../schema/dereferenced/settings.json')))
+    const schema = JSON.parse(fs.readFileSync(path.join(__dirname, '../../schema/dereferenced/settings.json'), 'utf8'))
     const protection = schema.properties.branches.items.properties.protection
     const protectionObject = protection.anyOf.find(variant => variant.type === 'object')
     expect(protectionObject.properties.required_status_checks.type).toContain('null')
@@ -46,7 +46,7 @@ describe('dereferenced schemas', () => {
   // against the repo-level API shape, not the org-level one.
   it('validates per-repo rulesets in the suborg and repo schemas', () => {
     ;['suborgs.json', 'repos.json'].forEach(file => {
-      const schema = JSON.parse(fs.readFileSync(path.join(__dirname, '../../schema/dereferenced', file)))
+      const schema = JSON.parse(fs.readFileSync(path.join(__dirname, '../../schema/dereferenced', file), 'utf8'))
       const ruleset = schema.properties.rulesets.items
       expect(ruleset.required).toEqual(['name', 'enforcement'])
       // org-only condition targeting must not leak into the repo-level shape
@@ -62,7 +62,7 @@ describe('dereferenced schemas', () => {
   // not model that, so the schema allows the empty values explicitly.
   it('allows the empty protection values that delete branch protection', () => {
     files.forEach(file => {
-      const schema = JSON.parse(fs.readFileSync(path.join(__dirname, '../../schema/dereferenced', file)))
+      const schema = JSON.parse(fs.readFileSync(path.join(__dirname, '../../schema/dereferenced', file), 'utf8'))
       const protection = schema.properties.branches.items.properties.protection
       expect(protection.anyOf).toEqual(expect.arrayContaining([expect.objectContaining({ enum: [null, {}, [], false] })]))
     })

--- a/test/unit/schema.test.js
+++ b/test/unit/schema.test.js
@@ -56,14 +56,15 @@ describe('dereferenced schemas', () => {
     })
   })
 
-  // `protection: null` is safe-settings' own delete-branch-protection semantic
-  // (see isEmpty in lib/plugins/branches.js); the GitHub API's PUT body it is
-  // validated against does not model that, so the schema allows null explicitly.
-  it('allows `protection: null` in every schema that has branches', () => {
+  // An empty `protection` value is safe-settings' own delete-branch-protection
+  // semantic (see isEmpty in lib/plugins/branches.js, and the plugin tests for
+  // null/{}/[]/false); the GitHub API's PUT body it is validated against does
+  // not model that, so the schema allows the empty values explicitly.
+  it('allows the empty protection values that delete branch protection', () => {
     files.forEach(file => {
       const schema = JSON.parse(fs.readFileSync(path.join(__dirname, '../../schema/dereferenced', file)))
       const protection = schema.properties.branches.items.properties.protection
-      expect(protection.anyOf).toEqual(expect.arrayContaining([expect.objectContaining({ type: 'null' })]))
+      expect(protection.anyOf).toEqual(expect.arrayContaining([expect.objectContaining({ enum: [null, {}, [], false] })]))
     })
   })
 })


### PR DESCRIPTION
Fixes #1024.

Three related fixes to the config schemas.

#### 1. Consume GitHub's OpenAPI 3.1 description so nullable API fields validate

The generated schemas declare draft 2020-12 but were built from GitHub's OpenAPI 3.0 description, whose `nullable: true` markers are meaningless in that dialect. Fields the API documents as null-able rejected `null` under any compliant validator:

```yaml
branches:
  - name: main
    protection:
      required_status_checks: null   # API: "Set to null to disable" — schema: rejected
      enforce_admins: true
      restrictions: null
```

The 18 spec `$ref`s in `schema/*.json` now point at `descriptions-next/`, GitHub's OpenAPI 3.1 build of the same pinned snapshot date, and the resolver in `script/build-schema` serves the pre-dereferenced spec for exactly that URL. OpenAPI 3.1 is native JSON Schema 2020-12: null-ability arrives as `type: [X, "null"]` unions, so the output is dialect-true with no post-processing. (Bonus: the 3.1 spec also adds `User` to the ruleset bypass `actor_type` enum.)

#### 2. Allow `protection: null`, safe-settings' own delete-branch-protection syntax

The branches plugin deletes branch protection when the config says `protection: null` (`isEmpty` in `lib/plugins/branches.js`; there's an upstream unit test for exactly this shape), but the schema modeled `protection` as the API's PUT body only, which is `type: object`. The property is now an `anyOf` of `{ "type": "null" }` and the existing PUT-body reference, in all three schemas. Object values still validate against the full PUT body.

#### 3. Validate rulesets in suborg and repo configs

Suborg and repo override files can configure `rulesets:` (they feed the rulesets plugin at repo scope via `childPluginsList`), but `schema/repos.json` and `schema/suborgs.json` had no `rulesets` property, so anything under that key passed validation silently:

```yaml
# passed schema validation before this PR
rulesets:
  - enforcement: definitely-not-a-valid-value
    bypass_actors:
      - actor_type: Wizard
```

Both files actually already contained an unused `RulesetSettings` definition; it's now wired to a `rulesets` property, and pointed at the repo-level `POST /repos/{owner}/{repo}/rulesets` body instead of the org-level one it referenced (repo rulesets have no `repository_name`/`repository_property` condition targeting). The config above now fails with three precise errors; realistic per-repo ruleset configs validate.

Not included: `actor_type: EnterpriseOwner`, which the API returns for enterprise-owned orgs but which is missing from GitHub's own OpenAPI spec (reported at github/rest-api-description#<N>); it will flow in with a future spec pin bump.

**Regenerated artifacts**

`schema/dereferenced/*.json` are rebuilt with `npm run build:schema` only — no hand edits. Notes for reviewing the diff: rebuilding at current HEAD without any changes already produces a ~264-line diff (the committed artifacts were stale); the `anyOf` wrapper re-indents the whole protection subtree (`git diff -w` shows the real change is +72 lines); the rulesets addition inlines the repo-ruleset subschema. Regeneration is deterministic: running the build twice produces no further changes.

**Tests**

New `test/unit/schema.test.js`: no `nullable` keyword survives anywhere; `required_status_checks`, `enforce_admins`, and `restrictions` accept null; `protection: null` is accepted by all three schemas; suborg/repo rulesets validate against the repo-level shape (required `name`+`enforcement`, no org-only conditions, `User` in the bypass enum).