### PR TITLE
fix: process repositories in batches to prevent partial sync on large orgs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ LABEL version="1.0" \
 ## to the image to be as small as possible
 COPY  package*.json /opt/safe-settings/
 COPY  index.js /opt/safe-settings/
+COPY  full-sync.js /opt/safe-settings/
 COPY  lib /opt/safe-settings/lib
 
 ## Install the app and dependencies

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -538,13 +538,23 @@ ${this.results.reduce((x, y) => {
 
   async eachRepositoryRepos (github, log) {
     log.debug('Fetching repositories')
-    return github.paginate('GET /installation/repositories').then(repositories => {
-      return Promise.all(repositories.map(repository => {
-        const { owner, name } = repository
-        return this.checkAndProcessRepo(owner.login, name)
-      })
+    const repositories = await github.paginate('GET /installation/repositories')
+    const CONCURRENCY = 10
+    const results = []
+    for (let i = 0; i < repositories.length; i += CONCURRENCY) {
+      const chunk = repositories.slice(i, i + CONCURRENCY)
+      const chunkResults = await Promise.allSettled(
+        chunk.map(({ owner, name }) => this.checkAndProcessRepo(owner.login, name))
       )
-    })
+      for (const result of chunkResults) {
+        if (result.status === 'fulfilled') {
+          results.push(result.value)
+        } else {
+          log.error(`Error processing repository in batch: ${result.reason}`)
+        }
+      }
+    }
+    return results
   }
 
   async checkAndProcessRepo (owner, name) {


### PR DESCRIPTION
## Problem

`SettingsRepository.eachRepositoryRepos` fetches every repository in the installation and processes them all at once with a single `Promise.all(...)` over the full list. On large organizations this has two problems:

1. **Unbounded concurrency** — thousands of `checkAndProcessRepo` calls fire simultaneously, creating heavy API/memory pressure.
2. **Partial sync on any failure** — `Promise.all` rejects as soon as one repository fails, aborting the entire run. Repositories that hadn't been processed yet are silently skipped, leaving the org partially synced.

## Fix

- Process repositories in fixed-size batches (`CONCURRENCY = 10`) instead of all at once, bounding concurrency and API pressure.
- Use `Promise.allSettled` per batch so a single repository's failure no longer aborts the whole sync. Failed repositories are logged via `log.error` and processing continues.
- Aggregate and return the successfully processed results.

This makes full-org syncs resilient: one bad repository no longer prevents the rest of the org from being synced.

## Additional change

- Add `COPY full-sync.js /opt/safe-settings/` to the `Dockerfile` so the full-sync entrypoint is present in the built image (it was previously omitted).

## Behavior / compatibility

- Behavior for small orgs is unchanged aside from batching; all repositories are still processed.
- No public API or configuration changes.
