### PR TITLE
Fix CustomProperties plugin calls renamed in @octokit/plugin-rest-endpoint-methods v17

### DIFF
--- a/lib/plugins/custom_properties.js
+++ b/lib/plugins/custom_properties.js
@@ -39,7 +39,7 @@ module.exports = class CustomProperties extends Diffable {
     this.log.debug(`Getting all custom properties for the repo ${repoFullName}`)
 
     const customProperties = await this.github.paginate(
-      this.github.rest.repos.getCustomPropertiesValues,
+      this.github.rest.repos.customPropertiesForReposGetRepositoryValues,
       {
         owner,
         repo,
@@ -110,14 +110,14 @@ module.exports = class CustomProperties extends Diffable {
       return new NopCommand(
         this.constructor.name,
         this.repo,
-        this.github.rest.repos.createOrUpdateCustomPropertiesValues.endpoint(params),
+        this.github.rest.repos.customPropertiesForReposCreateOrUpdateRepositoryValues.endpoint(params),
         `${operation} Custom Property`
       )
     }
 
     try {
       this.log.debug(`${operation} Custom Property "${name}" for the repo ${repoFullName}`)
-      await this.github.rest.repos.createOrUpdateCustomPropertiesValues(params)
+      await this.github.rest.repos.customPropertiesForReposCreateOrUpdateRepositoryValues(params)
       this.log.debug(`Successfully ${operation.toLowerCase()}d Custom Property "${name}" for the repo ${repoFullName}`)
     } catch (e) {
       this.logError(`Error during ${operation} Custom Property "${name}" for the repo ${repoFullName}: ${e.message || e}`)

--- a/test/unit/lib/plugins/custom_properties.test.js
+++ b/test/unit/lib/plugins/custom_properties.test.js
@@ -17,8 +17,8 @@ describe('CustomProperties', () => {
       paginate: jest.fn(),
       rest: {
         repos: {
-          getCustomPropertiesValues: jest.fn(),
-          createOrUpdateCustomPropertiesValues: jest.fn()
+          customPropertiesForReposGetRepositoryValues: jest.fn(),
+          customPropertiesForReposCreateOrUpdateRepositoryValues: jest.fn()
         }
       }
     }
@@ -49,7 +49,7 @@ describe('CustomProperties', () => {
       const result = await plugin.find()
 
       expect(github.paginate).toHaveBeenCalledWith(
-        github.rest.repos.getCustomPropertiesValues,
+        github.rest.repos.customPropertiesForReposGetRepositoryValues,
         {
           owner,
           repo,
@@ -100,14 +100,14 @@ describe('CustomProperties', () => {
 
       return plugin.sync().then(() => {
         expect(github.paginate).toHaveBeenCalledWith(
-          github.rest.repos.getCustomPropertiesValues,
+          github.rest.repos.customPropertiesForReposGetRepositoryValues,
           {
             owner,
             repo,
             per_page: 100
           }
         )
-        expect(github.rest.repos.createOrUpdateCustomPropertiesValues).not.toHaveBeenCalledWith({
+        expect(github.rest.repos.customPropertiesForReposCreateOrUpdateRepositoryValues).not.toHaveBeenCalledWith({
           owner,
           repo,
           properties: [
@@ -117,7 +117,7 @@ describe('CustomProperties', () => {
             }
           ]
         })
-        expect(github.rest.repos.createOrUpdateCustomPropertiesValues).toHaveBeenCalledWith({
+        expect(github.rest.repos.customPropertiesForReposCreateOrUpdateRepositoryValues).toHaveBeenCalledWith({
           owner,
           repo,
           properties: [
@@ -127,7 +127,7 @@ describe('CustomProperties', () => {
             }
           ]
         })
-        expect(github.rest.repos.createOrUpdateCustomPropertiesValues).toHaveBeenCalledWith({
+        expect(github.rest.repos.customPropertiesForReposCreateOrUpdateRepositoryValues).toHaveBeenCalledWith({
           owner,
           repo,
           properties: [
@@ -137,7 +137,7 @@ describe('CustomProperties', () => {
             }
           ]
         })
-        expect(github.rest.repos.createOrUpdateCustomPropertiesValues).toHaveBeenCalledWith({
+        expect(github.rest.repos.customPropertiesForReposCreateOrUpdateRepositoryValues).toHaveBeenCalledWith({
           owner,
           repo,
           properties: [
@@ -152,7 +152,7 @@ describe('CustomProperties', () => {
       // const plugin = configure([{ name: 'Test', value: 'test' }])
       // await plugin.update({ name: 'test', value: 'old' }, { name: 'test', value: 'test' })
 
-      // expect(github.rest.repos.createOrUpdateCustomPropertiesValues).toHaveBeenCalledWith({
+      // expect(github.rest.repos.customPropertiesForReposCreateOrUpdateRepositoryValues).toHaveBeenCalledWith({
       //   owner,
       //   repo,
       //   properties: [


### PR DESCRIPTION
## Summary

Fixes #981.

`@octokit/plugin-rest-endpoint-methods` v17.0.0 (resolved transitively via `octokit@^5` / `probot@^14`) renamed the repository custom-properties methods as a [documented breaking change](https://github.com/octokit/plugin-rest-endpoint-methods.js/releases/tag/v17.0.0):

| Old (removed) | New (v17) |
|---|---|
| `repos.getCustomPropertiesValues` | `repos.customPropertiesForReposGetRepositoryValues` |
| `repos.createOrUpdateCustomPropertiesValues` | `repos.customPropertiesForReposCreateOrUpdateRepositoryValues` |

`lib/plugins/custom_properties.js` still called the old names, which broke the plugin in three ways:

- **Read (`find()`)**: `paginate(undefined, …)` falls back to `GET https://api.github.com/` (the API root), so existing property values always read as empty and every configured property diffs as a brand-new addition on every repo, every sync.
- **Write (apply mode)**: every `add()` fails with `…createOrUpdateCustomPropertiesValues is not a function`. The error is caught and logged per property, so nothing crashes; custom properties are silently never applied, with one error line per repo per sync cycle.
- **Nop mode (PR validation)**: `.endpoint(params)` on the undefined method throws synchronously, which escapes `Promise.all` in `Settings.updateRepos` and crashes the process, leaving the check-run stuck `IN_PROGRESS`.

This is the same root cause as #971; the #978 fix patched `normalize()` but the renamed-method calls remained.

## Changes

- Rename the three call sites in `lib/plugins/custom_properties.js` to the v17 method names
- Update the unit-test mocks in `test/unit/lib/plugins/custom_properties.test.js` to match

Deliberately kept minimal per the contributing guidelines: no behavior changes beyond restoring the intended API calls. I'm aware #990 rebuilds a broader set of fixes from 2.1.18; this PR just unblocks custom-properties sync in the meantime and should be trivial to carry or drop in that effort.

## Verification

- `npm run test:unit:ci` passes (134 passed, 14 skipped, same as base)
- Confirmed against a live install: on 2.1.21 both old method names are `undefined` on `ProbotOctokit().rest.repos` and the two v17 names above are present; `request.endpoint(undefined, {owner, repo, per_page})` resolves to `GET https://api.github.com/`, matching the silent-read failure described in #981

## Note for maintainers

These endpoint operation IDs have now changed twice upstream. If you'd prefer the plugin to be immune to future renames, I'm happy to switch the calls to raw routes instead (`octokit.request('GET /repos/{owner}/{repo}/properties/values')` / `('PATCH …')`). I went with the `.rest` namespace here to stay consistent with #949.
