### PR TITLE
feat(custom_properties): support include/exclude to preserve unmanaged property values

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,54 @@ See [`docs/sample-settings/settings.yml`](docs/sample-settings/settings.yml) for
 >       - '*-config'
 >  ```
 
+#### Preserving custom properties that `safe-settings` does not manage
+
+Custom properties cannot be deleted through the API, so a property that exists on a
+repository but is absent from `custom_properties` has its value set to `null`. By
+default `safe-settings` therefore owns *every* custom property on the repository. Use
+the object form to declare what it manages and leave everything else untouched:
+
+```yml
+custom_properties:
+  include:
+    - name: ruleset-tier
+      value: strict
+  exclude:
+    # Never clear the value of any property starting with "app-"
+    - name: ^app-
+```
+
+To manage only the properties you declare and leave all others alone, exclude
+everything with `.*`:
+
+```yml
+custom_properties:
+  include:
+    - name: ruleset-tier
+      value: strict
+  exclude:
+    - name: .*
+```
+
+> [!NOTE]
+> Unlike the repository patterns above, these are **regular expressions matched
+> against the property name**, not globs — "match everything" is `.*`, and a bare `*`
+> is not a valid pattern. Casing does not matter.
+>
+> - `exclude` only prevents clearing. A property in `include` is always applied, even
+>   if it also matches an `exclude` pattern
+> - `exclude` on its own still means `safe-settings` manages this repository's custom
+>   properties — every property not matching a pattern is cleared. To manage nothing,
+>   omit the `custom_properties` section entirely
+> - An invalid pattern, or an object form with neither `include` nor `exclude`, is
+>   reported as a config error and fails closed: every property on that repository is
+>   left untouched, so a typo protects values rather than clearing them
+> - `exclude` patterns accumulate across scopes, so a repository can add patterns to
+>   the ones defined for the org or suborg without restating them
+
+See [`docs/sample-settings/settings.yml`](docs/sample-settings/settings.yml) for a
+commented example.
+
 ### Additional values
 
 In addition to the values in the file above, the settings file can have some additional values:

--- a/docs/sample-settings/settings.yml
+++ b/docs/sample-settings/settings.yml
@@ -203,9 +203,25 @@ branches:
 
 # Custom properties
 # See https://docs.github.com/en/rest/repos/custom-properties?apiVersion=2026-03-10
+# A property absent from this config has its value cleared. To leave properties
+# owned by other automation untouched, use the object form shown below - see
+# "Preserving custom properties that `safe-settings` does not manage" in the README.
 custom_properties:
   - name: test
     value: test
+
+# custom_properties:
+#   include:
+#     - name: test
+#       value: test
+#   exclude:
+#     # Regexes - not globs - matched against the property name
+#     - name: ^app-
+#     # Or `.*` to manage only the properties listed under `include`
+#     - name: ^deploy-status$
+#   * The object form must contain `include`, `exclude`, or both. A malformed
+#     `custom_properties` (`{}`, say) is reported and also fails closed, leaving
+#     every property on the repo untouched.
 
 # See the docs (https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources) for a description of autolinks and replacement values.
 autolinks:

--- a/lib/plugins/custom_properties.js
+++ b/lib/plugins/custom_properties.js
@@ -1,13 +1,73 @@
 const Diffable = require('./diffable')
 const NopCommand = require('../nopcommand')
 
+// Config shapes, precedence and the fail-closed behavior below are documented in
+// README.md, "Preserving custom properties that `safe-settings` does not manage",
+// with a commented example in docs/sample-settings/settings.yml.
+function isExcludeAwareConfig (entries) {
+  return !!entries &&
+    typeof entries === 'object' &&
+    !Array.isArray(entries) &&
+    (Array.isArray(entries.include) || Array.isArray(entries.exclude))
+}
+
 module.exports = class CustomProperties extends Diffable {
-  constructor (...args) {
-    super(...args)
+  constructor (nop, github, repo, entries, log, errors) {
+    let include = entries
+    let exclude = []
+    let malformed = false
+
+    if (isExcludeAwareConfig(entries)) {
+      include = Array.isArray(entries.include) ? entries.include : []
+      exclude = Array.isArray(entries.exclude) ? entries.exclude : []
+    } else if (entries !== null && entries !== undefined && !Array.isArray(entries)) {
+      // Neither config shape, e.g. `custom_properties: {}`. Fail closed rather than
+      // letting a TypeError escape the constructor and reject the org-wide sync.
+      include = []
+      malformed = true
+    }
+
+    super(nop, github, repo, include, log, errors)
+
+    const { patterns, excludeAll } = this.compileExcludePatterns(exclude)
+    this.exclude = patterns
+    this.excludeAll = excludeAll || malformed
+
+    if (malformed) {
+      this.logError('`custom_properties` must be a list of properties or an object with `include` and/or `exclude` keys. Ignoring it and excluding all custom properties for this repo so no values are cleared.')
+    }
 
     if (this.entries) {
       this.normalizeEntries()
     }
+  }
+
+  // An invalid pattern is recorded as a config error rather than thrown, because
+  // child plugins are constructed outside any try/catch in `Settings.updateRepos`.
+  compileExcludePatterns (exclude) {
+    return exclude.reduce((state, item) => {
+      if (!item || typeof item.name !== 'string') {
+        return state
+      }
+
+      try {
+        // Lowercased to match the normalized property names.
+        state.patterns.push(new RegExp(item.name.toLowerCase()))
+      } catch (e) {
+        this.logError(`Invalid custom property exclude pattern "${item.name}": ${e.message || e}. Excluding all custom properties for this repo so no values are cleared.`)
+        state.excludeAll = true
+      }
+
+      return state
+    }, { patterns: [], excludeAll: false })
+  }
+
+  isExcluded (name) {
+    if (this.excludeAll) {
+      return true
+    }
+
+    return typeof name === 'string' && this.exclude.some(rx => rx.test(name))
   }
 
   // Force all names to lowercase to avoid comparison issues.
@@ -90,6 +150,10 @@ module.exports = class CustomProperties extends Diffable {
 
   // Custom Properties on repository does not support deletion, so we set the value to null
   async remove ({ name }) {
+    if (this.isExcluded(name)) {
+      this.log.debug(`Custom Property "${name}" matches an exclude pattern; leaving its value untouched`)
+      return Promise.resolve([])
+    }
     return this.modifyProperty('Delete', { name, value: null })
   }
 

--- a/schema/dereferenced/repos.json
+++ b/schema/dereferenced/repos.json
@@ -778,19 +778,69 @@
     },
     "custom_properties": {
       "description": "Custom properties",
-      "type": "array",
-      "items": {
-        "description": "A custom property entry",
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "value": {
-            "type": "string"
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "description": "A custom property entry",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "include": {
+              "description": "Custom properties managed by safe-settings",
+              "type": "array",
+              "items": {
+                "description": "A custom property entry",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "exclude": {
+              "description": "Never clear the value of any custom property whose name matches one of these regexes",
+              "type": "array",
+              "items": {
+                "description": "A regex, matched against the lowercased custom property name, identifying properties safe-settings must not clear",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "include"
+              ]
+            },
+            {
+              "required": [
+                "exclude"
+              ]
+            }
+          ]
         }
-      }
+      ]
     },
     "variables": {
       "description": "Repository or org-level Actions variables",

--- a/schema/dereferenced/settings.json
+++ b/schema/dereferenced/settings.json
@@ -1956,19 +1956,69 @@
     },
     "custom_properties": {
       "description": "Custom properties",
-      "type": "array",
-      "items": {
-        "description": "A custom property entry",
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "value": {
-            "type": "string"
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "description": "A custom property entry",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "include": {
+              "description": "Custom properties managed by safe-settings",
+              "type": "array",
+              "items": {
+                "description": "A custom property entry",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "exclude": {
+              "description": "Never clear the value of any custom property whose name matches one of these regexes",
+              "type": "array",
+              "items": {
+                "description": "A regex, matched against the lowercased custom property name, identifying properties safe-settings must not clear",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "include"
+              ]
+            },
+            {
+              "required": [
+                "exclude"
+              ]
+            }
+          ]
         }
-      }
+      ]
     },
     "variables": {
       "description": "Repository or org-level Actions variables",

--- a/schema/dereferenced/suborgs.json
+++ b/schema/dereferenced/suborgs.json
@@ -812,19 +812,69 @@
     },
     "custom_properties": {
       "description": "Custom properties",
-      "type": "array",
-      "items": {
-        "description": "A custom property entry",
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "value": {
-            "type": "string"
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "description": "A custom property entry",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "include": {
+              "description": "Custom properties managed by safe-settings",
+              "type": "array",
+              "items": {
+                "description": "A custom property entry",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "exclude": {
+              "description": "Never clear the value of any custom property whose name matches one of these regexes",
+              "type": "array",
+              "items": {
+                "description": "A regex, matched against the lowercased custom property name, identifying properties safe-settings must not clear",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "include"
+              ]
+            },
+            {
+              "required": [
+                "exclude"
+              ]
+            }
+          ]
         }
-      }
+      ]
     },
     "variables": {
       "description": "Repository or org-level Actions variables",

--- a/schema/repos.json
+++ b/schema/repos.json
@@ -57,10 +57,37 @@
     },
     "custom_properties": {
       "description": "Custom properties",
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/CustomPropertiesSettings"
-      }
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomPropertiesSettings"
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "include": {
+              "description": "Custom properties managed by safe-settings",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/CustomPropertiesSettings"
+              }
+            },
+            "exclude": {
+              "description": "Never clear the value of any custom property whose name matches one of these regexes",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/CustomPropertiesExcludeSettings"
+              }
+            }
+          },
+          "anyOf": [
+            { "required": ["include"] },
+            { "required": ["exclude"] }
+          ]
+        }
+      ]
     },
     "variables": {
       "description": "Repository or org-level Actions variables",
@@ -296,6 +323,15 @@
           "type": "string"
         },
         "value": {
+          "type": "string"
+        }
+      }
+    },
+    "CustomPropertiesExcludeSettings": {
+      "description": "A regex, matched against the lowercased custom property name, identifying properties safe-settings must not clear",
+      "type": "object",
+      "properties": {
+        "name": {
           "type": "string"
         }
       }

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -64,10 +64,37 @@
     },
     "custom_properties": {
       "description": "Custom properties",
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/CustomPropertiesSettings"
-      }
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomPropertiesSettings"
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "include": {
+              "description": "Custom properties managed by safe-settings",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/CustomPropertiesSettings"
+              }
+            },
+            "exclude": {
+              "description": "Never clear the value of any custom property whose name matches one of these regexes",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/CustomPropertiesExcludeSettings"
+              }
+            }
+          },
+          "anyOf": [
+            { "required": ["include"] },
+            { "required": ["exclude"] }
+          ]
+        }
+      ]
     },
     "variables": {
       "description": "Repository or org-level Actions variables",
@@ -303,6 +330,15 @@
           "type": "string"
         },
         "value": {
+          "type": "string"
+        }
+      }
+    },
+    "CustomPropertiesExcludeSettings": {
+      "description": "A regex, matched against the lowercased custom property name, identifying properties safe-settings must not clear",
+      "type": "object",
+      "properties": {
+        "name": {
           "type": "string"
         }
       }

--- a/schema/suborgs.json
+++ b/schema/suborgs.json
@@ -91,10 +91,37 @@
     },
     "custom_properties": {
       "description": "Custom properties",
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/CustomPropertiesSettings"
-      }
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomPropertiesSettings"
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "include": {
+              "description": "Custom properties managed by safe-settings",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/CustomPropertiesSettings"
+              }
+            },
+            "exclude": {
+              "description": "Never clear the value of any custom property whose name matches one of these regexes",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/CustomPropertiesExcludeSettings"
+              }
+            }
+          },
+          "anyOf": [
+            { "required": ["include"] },
+            { "required": ["exclude"] }
+          ]
+        }
+      ]
     },
     "variables": {
       "description": "Repository or org-level Actions variables",
@@ -330,6 +357,15 @@
           "type": "string"
         },
         "value": {
+          "type": "string"
+        }
+      }
+    },
+    "CustomPropertiesExcludeSettings": {
+      "description": "A regex, matched against the lowercased custom property name, identifying properties safe-settings must not clear",
+      "type": "object",
+      "properties": {
+        "name": {
           "type": "string"
         }
       }

--- a/test/unit/lib/plugins/custom_properties.test.js
+++ b/test/unit/lib/plugins/custom_properties.test.js
@@ -1,29 +1,42 @@
 const CustomProperties = require('../../../../lib/plugins/custom_properties')
+const MergeDeep = require('../../../../lib/mergeDeep')
 
 describe('CustomProperties', () => {
   const nop = false
   let github
   let log
+  let errors
 
   const owner = 'test-owner'
   const repo = 'test-repo'
 
   function configure (config) {
-    return new CustomProperties(nop, github, { owner, repo }, config, log, [])
+    return new CustomProperties(nop, github, { owner, repo }, config, log, errors)
+  }
+
+  function configureNop (config) {
+    return new CustomProperties(true, github, { owner, repo }, config, log, errors)
   }
 
   beforeEach(() => {
+    const createOrUpdateCustomPropertiesValues = jest.fn()
+    createOrUpdateCustomPropertiesValues.endpoint = jest.fn(params => ({
+      url: `/repos/${params.owner}/${params.repo}/properties/values`,
+      body: params
+    }))
+
     github = {
       paginate: jest.fn(),
       rest: {
         repos: {
           getCustomPropertiesValues: jest.fn(),
-          createOrUpdateCustomPropertiesValues: jest.fn()
+          createOrUpdateCustomPropertiesValues
         }
       }
     }
 
-    log = { debug: jest.fn(), error: console.error }
+    log = { debug: jest.fn(), error: jest.fn() }
+    errors = []
   })
 
   describe('Custom Properties plugin', () => {
@@ -162,6 +175,470 @@ describe('CustomProperties', () => {
       //     }
       //   ]
       // })
+    })
+  })
+
+  describe('include/exclude config shape', () => {
+    // Existing repo state shared by most of the exclude tests: one property
+    // managed by safe-settings, one owned by another app, one abandoned.
+    function mockExistingProperties (properties) {
+      github.paginate.mockResolvedValue(properties)
+    }
+
+    function propertyUpdate (name, value) {
+      return {
+        owner,
+        repo,
+        properties: [{ property_name: name, value }]
+      }
+    }
+
+    it('keeps the plain array shape working unchanged', () => {
+      mockExistingProperties([
+        { property_name: 'jira-team', value: 'Search' },
+        { property_name: 'stale-prop', value: 'whatever' }
+      ])
+
+      const plugin = configure([
+        { name: 'jira-team', value: 'Platform' },
+        { name: 'jira-project', value: 'ARCH' }
+      ])
+
+      expect(plugin.exclude).toEqual([])
+
+      return plugin.sync().then(() => {
+        // update
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues)
+          .toHaveBeenCalledWith(propertyUpdate('jira-team', 'Platform'))
+        // add
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues)
+          .toHaveBeenCalledWith(propertyUpdate('jira-project', 'ARCH'))
+        // remove
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues)
+          .toHaveBeenCalledWith(propertyUpdate('stale-prop', null))
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues).toHaveBeenCalledTimes(3)
+      })
+    })
+
+    it('does not null out an unmanaged property matching an exclude pattern', () => {
+      mockExistingProperties([
+        { property_name: 'jira-team', value: 'Search' },
+        { property_name: 'app-deploy-ring', value: 'canary' }
+      ])
+
+      const plugin = configure({
+        include: [
+          { name: 'jira-team', value: 'Platform' },
+          { name: 'jira-project', value: 'ARCH' }
+        ],
+        exclude: [
+          { name: '^app-.*' }
+        ]
+      })
+
+      return plugin.sync().then(() => {
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues)
+          .not.toHaveBeenCalledWith(propertyUpdate('app-deploy-ring', null))
+        // Managed properties are still enforced.
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues)
+          .toHaveBeenCalledWith(propertyUpdate('jira-team', 'Platform'))
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues)
+          .toHaveBeenCalledWith(propertyUpdate('jira-project', 'ARCH'))
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues).toHaveBeenCalledTimes(2)
+      })
+    })
+
+    it('enforces a property that is in include even when it matches exclude', () => {
+      mockExistingProperties([
+        { property_name: 'app-owner', value: 'unknown' }
+      ])
+
+      const plugin = configure({
+        include: [
+          { name: 'app-owner', value: 'platform-team' }
+        ],
+        exclude: [
+          { name: '^app-.*' }
+        ]
+      })
+
+      return plugin.sync().then(() => {
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues)
+          .toHaveBeenCalledWith(propertyUpdate('app-owner', 'platform-team'))
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    it('still removes an unmanaged property that matches no exclude pattern', () => {
+      mockExistingProperties([
+        { property_name: 'app-deploy-ring', value: 'canary' },
+        { property_name: 'stale-prop', value: 'leftover' }
+      ])
+
+      const plugin = configure({
+        include: [
+          { name: 'jira-team', value: 'Platform' }
+        ],
+        exclude: [
+          { name: '^app-.*' }
+        ]
+      })
+
+      return plugin.sync().then(() => {
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues)
+          .toHaveBeenCalledWith(propertyUpdate('stale-prop', null))
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues)
+          .not.toHaveBeenCalledWith(propertyUpdate('app-deploy-ring', null))
+      })
+    })
+
+    it('protects properties whose API casing differs from the pattern', () => {
+      // The API may return any casing; the plugin normalizes to lowercase, so
+      // exclude patterns are matched against the lowercased name.
+      mockExistingProperties([
+        { property_name: 'APP-Thing', value: 'set-by-an-app' }
+      ])
+
+      const plugin = configure({
+        include: [],
+        exclude: [{ name: '^app-.*' }]
+      })
+
+      return plugin.sync().then(() => {
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues).not.toHaveBeenCalled()
+      })
+    })
+
+    it('produces no Delete NopCommand for an excluded property in nop mode', () => {
+      mockExistingProperties([
+        { property_name: 'app-deploy-ring', value: 'canary' },
+        { property_name: 'stale-prop', value: 'leftover' }
+      ])
+
+      const plugin = configureNop({
+        include: [{ name: 'jira-team', value: 'Platform' }],
+        exclude: [{ name: '^app-.*' }]
+      })
+
+      return plugin.sync().then(res => {
+        const commands = res.flat().filter(c => c && c.action)
+        const deletes = commands.filter(c => c.action.msg === 'Delete Custom Property')
+
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues).not.toHaveBeenCalled()
+        expect(deletes).toHaveLength(1)
+        expect(deletes[0].body.properties).toEqual([
+          { property_name: 'stale-prop', value: null }
+        ])
+      })
+    })
+
+    describe('degenerate shapes', () => {
+      it('accepts include without exclude', () => {
+        const plugin = configure({
+          include: [{ name: 'Jira-Team', value: 'Platform' }]
+        })
+
+        expect(plugin.entries).toEqual([{ name: 'jira-team', value: 'Platform' }])
+        expect(plugin.exclude).toEqual([])
+      })
+
+      it('accepts exclude without include, managing nothing', () => {
+        mockExistingProperties([
+          { property_name: 'app-thing', value: 'a' },
+          { property_name: 'other-thing', value: 'b' }
+        ])
+
+        const plugin = configure({
+          exclude: [{ name: '^app-.*' }]
+        })
+
+        expect(plugin.entries).toEqual([])
+
+        // An empty include list means safe-settings owns the whole surface, so
+        // everything not protected by `exclude` is still nulled out.
+        return plugin.sync().then(() => {
+          expect(github.rest.repos.createOrUpdateCustomPropertiesValues)
+            .toHaveBeenCalledWith(propertyUpdate('other-thing', null))
+          expect(github.rest.repos.createOrUpdateCustomPropertiesValues).toHaveBeenCalledTimes(1)
+        })
+      })
+
+      it('does not throw on a null config', () => {
+        let plugin
+        expect(() => { plugin = configure(null) }).not.toThrow()
+        expect(plugin.entries).toBeNull()
+        expect(plugin.exclude).toEqual([])
+        expect(plugin.sync()).toBeUndefined()
+      })
+
+      it('does not throw on an undefined config', () => {
+        let plugin
+        expect(() => { plugin = configure(undefined) }).not.toThrow()
+        expect(plugin.exclude).toEqual([])
+      })
+
+      it('ignores exclude entries without a name string', () => {
+        const plugin = configure({
+          include: [{ name: 'jira-team', value: 'Platform' }],
+          exclude: [{ name: '^app-.*' }, {}, null, { value: 'nope' }, { name: 42 }]
+        })
+
+        expect(plugin.exclude).toHaveLength(1)
+        expect(plugin.isExcluded('app-thing')).toBe(true)
+      })
+
+      it('ignores a non-array exclude', () => {
+        const plugin = configure({
+          include: [{ name: 'jira-team', value: 'Platform' }],
+          exclude: 'app-'
+        })
+
+        expect(plugin.exclude).toEqual([])
+        expect(plugin.entries).toEqual([{ name: 'jira-team', value: 'Platform' }])
+      })
+    })
+
+    describe('malformed object config', () => {
+      it('does not throw on an empty object', () => {
+        expect(() => configure({})).not.toThrow()
+      })
+
+      it('fails closed and reports a config error for an empty object', () => {
+        const plugin = configure({})
+
+        expect(plugin.entries).toEqual([])
+        expect(plugin.excludeAll).toBe(true)
+        expect(errors).toHaveLength(1)
+        expect(errors[0].msg).toMatch(/must be a list of properties or an object with `include`/)
+      })
+
+      it('clears nothing when the config is an empty object', async () => {
+        github.paginate.mockResolvedValue([{ property_name: 'deploy-status', value: 'green' }])
+
+        const plugin = configure({})
+        await plugin.sync()
+
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues).not.toHaveBeenCalled()
+      })
+
+      it('fails closed when include is present but not an array', async () => {
+        github.paginate.mockResolvedValue([{ property_name: 'deploy-status', value: 'green' }])
+
+        const plugin = configure({ include: 'not-a-list' })
+        await plugin.sync()
+
+        expect(plugin.excludeAll).toBe(true)
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('pattern casing', () => {
+      it('matches an uppercase pattern against the lowercased property name', () => {
+        const plugin = configure({ include: [], exclude: [{ name: '^Deploy-Status$' }] })
+
+        expect(plugin.isExcluded('deploy-status')).toBe(true)
+      })
+
+      it('does not clear a property whose exclude pattern was written in uppercase', async () => {
+        github.paginate.mockResolvedValue([{ property_name: 'Deploy-Status', value: 'green' }])
+
+        const plugin = configure({ include: [], exclude: [{ name: '^Deploy-' }] })
+        await plugin.sync()
+
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('invalid exclude patterns', () => {
+      it('records a config error instead of throwing', () => {
+        let plugin
+        expect(() => {
+          plugin = configure({
+            include: [{ name: 'jira-team', value: 'Platform' }],
+            exclude: [{ name: '^app-.*' }, { name: '[unterminated' }]
+          })
+        }).not.toThrow()
+
+        expect(plugin.exclude).toHaveLength(1)
+        expect(plugin.isExcluded('app-thing')).toBe(true)
+
+        expect(errors).toHaveLength(1)
+        expect(errors[0]).toMatchObject({
+          owner,
+          repo,
+          plugin: 'CustomProperties'
+        })
+        expect(errors[0].msg).toMatch(/Invalid custom property exclude pattern "\[unterminated"/)
+      })
+
+      it('fails closed - an invalid pattern excludes every property', () => {
+        const plugin = configure({ include: [], exclude: [{ name: '[unterminated' }] })
+
+        expect(plugin.excludeAll).toBe(true)
+        expect(plugin.isExcluded('anything-at-all')).toBe(true)
+      })
+
+      it('clears nothing when a glob "*" is used instead of the regex ".*"', async () => {
+        github.paginate.mockResolvedValue([
+          { property_name: 'deploy-status', value: 'green' },
+          { property_name: 'cost-center', value: '4417' }
+        ])
+
+        const plugin = configure({ include: [], exclude: [{ name: '*' }] })
+        await plugin.sync()
+
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues).not.toHaveBeenCalled()
+        expect(errors).toHaveLength(1)
+      })
+
+      it('still enforces included properties when an invalid pattern fails closed', async () => {
+        github.paginate.mockResolvedValue([
+          { property_name: 'jira-team', value: 'OldTeam' },
+          { property_name: 'deploy-status', value: 'green' }
+        ])
+
+        const plugin = configure({
+          include: [{ name: 'jira-team', value: 'Platform' }],
+          exclude: [{ name: '*' }]
+        })
+        await plugin.sync()
+
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues).toHaveBeenCalledTimes(1)
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues).toHaveBeenCalledWith(
+          expect.objectContaining({
+            properties: [{ property_name: 'jira-team', value: 'Platform' }]
+          })
+        )
+      })
+    })
+
+    // `Settings.childPluginsList` merges the org, suborg and repo configs with
+    // MergeDeep before handing the result to the plugin, so the config the plugin
+    // actually receives is not the config any single file declares. These use the
+    // real MergeDeep to assert against that merged shape.
+    describe('config merged across org, suborg and repo scopes', () => {
+      function mergeScopes (...scopes) {
+        const mergeDeep = new MergeDeep(log, github, ['id', 'node_id', 'default', 'url'])
+        const sources = scopes.map(scope => ({ custom_properties: scope }))
+        return mergeDeep.mergeDeep({}, ...sources).custom_properties
+      }
+
+      it('leaves a plain array config untouched through the merge', () => {
+        const merged = mergeScopes(
+          [{ name: 'jira-team', value: 'Platform' }],
+          [{ name: 'jira-team', value: 'RepoTeam' }]
+        )
+
+        expect(Array.isArray(merged)).toBe(true)
+        expect(merged).toEqual([{ name: 'jira-team', value: 'RepoTeam' }])
+      })
+
+      it('accumulates exclude patterns from every scope', () => {
+        const merged = mergeScopes(
+          { include: [{ name: 'jira-team', value: 'Platform' }], exclude: [{ name: '^app-' }] },
+          { exclude: [{ name: '^deploy-' }] }
+        )
+
+        const plugin = configure(merged)
+
+        expect(plugin.exclude).toHaveLength(2)
+        expect(plugin.isExcluded('app-owner')).toBe(true)
+        expect(plugin.isExcluded('deploy-status')).toBe(true)
+        expect(plugin.isExcluded('jira-team')).toBe(false)
+      })
+
+      it('lets a narrower scope override an included value while keeping org excludes', async () => {
+        github.paginate.mockResolvedValue([
+          { property_name: 'jira-team', value: 'OldTeam' },
+          { property_name: 'app-owner', value: 'team-a' }
+        ])
+
+        const merged = mergeScopes(
+          { include: [{ name: 'jira-team', value: 'Platform' }], exclude: [{ name: '^app-' }] },
+          { include: [{ name: 'jira-team', value: 'RepoTeam' }] }
+        )
+
+        const plugin = configure(merged)
+        await plugin.sync()
+
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues).toHaveBeenCalledTimes(1)
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues).toHaveBeenCalledWith(
+          expect.objectContaining({
+            properties: [{ property_name: 'jira-team', value: 'RepoTeam' }]
+          })
+        )
+      })
+
+      it('applies includes contributed by different scopes together', async () => {
+        github.paginate.mockResolvedValue([])
+
+        const merged = mergeScopes(
+          { include: [{ name: 'jira-team', value: 'Platform' }], exclude: [{ name: '.*' }] },
+          { include: [{ name: 'tier', value: 'gold' }] }
+        )
+
+        const plugin = configure(merged)
+        await plugin.sync()
+
+        const written = github.rest.repos.createOrUpdateCustomPropertiesValues.mock.calls
+          .map(call => call[0].properties[0])
+
+        expect(written).toEqual(
+          expect.arrayContaining([
+            { property_name: 'jira-team', value: 'Platform' },
+            { property_name: 'tier', value: 'gold' }
+          ])
+        )
+      })
+
+      it('keeps an org-level exclude protecting properties when a repo adds an include', async () => {
+        github.paginate.mockResolvedValue([
+          { property_name: 'deploy-status', value: 'green' },
+          { property_name: 'cost-center', value: '4417' }
+        ])
+
+        const merged = mergeScopes(
+          { exclude: [{ name: '.*' }] },
+          { include: [{ name: 'tier', value: 'gold' }] }
+        )
+
+        const plugin = configure(merged)
+        await plugin.sync()
+
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues).toHaveBeenCalledTimes(1)
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues).toHaveBeenCalledWith(
+          expect.objectContaining({
+            properties: [{ property_name: 'tier', value: 'gold' }]
+          })
+        )
+      })
+
+      // Mixing the two shapes across scopes merges the array into the object under
+      // numeric keys. The same happens for `labels`, which shares this array-or-object
+      // config duality. The plugin must not throw on it, and the declared
+      // include/exclude must still be honoured.
+      it('does not throw when scopes mix the array and object shapes', async () => {
+        github.paginate.mockResolvedValue([
+          { property_name: 'app-owner', value: 'team-a' }
+        ])
+
+        const merged = mergeScopes(
+          [{ name: 'jira-team', value: 'Platform' }],
+          { include: [{ name: 'tier', value: 'gold' }], exclude: [{ name: '^app-' }] }
+        )
+
+        let plugin
+        expect(() => { plugin = configure(merged) }).not.toThrow()
+
+        await expect(plugin.sync()).resolves.not.toThrow()
+
+        expect(plugin.isExcluded('app-owner')).toBe(true)
+        expect(github.rest.repos.createOrUpdateCustomPropertiesValues).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            properties: [{ property_name: 'app-owner', value: null }]
+          })
+        )
+      })
     })
   })
 })


### PR DESCRIPTION
Lets a `custom_properties` config declare the properties it manages and leave
properties owned by other automation untouched, instead of clearing every property
it does not list.

Closes #986 — implements the `include`/`exclude` shape requested there, mirroring
the Labels plugin as the issue suggests.

## What

```yaml
custom_properties:
  include:
    - name: ruleset-tier
      value: strict
  exclude:
    # Regexes, matched against the property name
    - name: ^team-
```

To manage only what you declare and leave every other property alone, exclude
everything with `.*`:

```yaml
custom_properties:
  include:
    - name: ruleset-tier
      value: strict
  exclude:
    - name: .*
```

The existing plain-array shape is unchanged.

## Why

Custom properties cannot be deleted through the API, so `Diffable`'s removal path
sets `value: null`. Any property present on a repository but absent from config was
therefore cleared on every sync — including values written by other automation. In
effect safe-settings claimed exclusive ownership of the entire custom-properties
surface of any repo with a `custom_properties` section, with no way to opt out short
of dropping the section altogether. That is exactly the case #986 describes:
org-wide properties should be enforced while per-repo ones are left alone.

## Behavior

- A property matching an `exclude` regex is never cleared.
- A property in `include` is created/updated as before, even if it also matches an
  `exclude` pattern. `include` wins.
- `exclude` on its own still means safe-settings manages this repo's properties —
  everything not matching a pattern is cleared. To manage nothing, omit the section.

Config mistakes fail closed rather than clearing values — see the design notes below.

## Changes

- **`lib/plugins/custom_properties.js`** — config-shape detection, exclude-pattern
  compilation, exclude check in `remove()`
- **`test/unit/lib/plugins/custom_properties.test.js`** — 28 new tests
- **`README.md`** — "Preserving custom properties that `safe-settings` does not
  manage", alongside the existing include/exclude notes for `collaborators`, `teams`
  and `labels`
- **`docs/sample-settings/settings.yml`** — worked example, linking to the README for
  the semantics
- **`schema/{repos,settings,suborgs}.json`** — accept both shapes; require the object
  form to carry `include`, `exclude`, or both
- **`schema/dereferenced/*.json`** — 6 of the 10 changed files are these generated
  schemas. Their `custom_properties` blocks are verified byte-equal to
  `npm run build:schema` output. They are spliced in rather than committed wholesale
  because a full regeneration also pulls in unrelated `repositories`/`teams`/`rulesets`
  churn from the live GitHub API description, which drifts on `main-enterprise`
  independently of this change.

## Testing

**New behavior** — `test/unit/lib/plugins/custom_properties.test.js` passes 33/33,
covering exclude protection, `include`-wins precedence, casing on both the API
response and the pattern, nop mode, degenerate configs, invalid regexes, and
malformed object configs.

**Existing behavior is provably unchanged.** Since this touches a path that nulls out
property values, the old behavior was verified directly rather than by inspection: a
15-scenario matrix (× apply and nop modes = 30 runs) was run against the plugin as it
exists on `main-enterprise` and against this branch, capturing API writes,
`NopCommand`s, normalized entries, and recorded errors for each. **The two transcripts
are byte-identical.** The matrix uses only pre-change config shapes — plain arrays,
`null`, `undefined` — and covers update, create, no-op, clearing unmanaged properties,
the `property_name` key variant, mixed casing on both sides, nameless and non-object
entries, and multi-property syncs. 11 of the 30 runs perform API writes and 11 emit
`NopCommand`s, so the comparison is exercising real output.

The schemas were checked the same way: every config shape that validated against the
schema on `main-enterprise` still validates here — empty array, `{name,value}`,
`{property_name,value}`, multiple entries, name-only, and no `custom_properties` key.
Zero regressions.

`npm run test:unit` (what CI runs) passes 162 tests across 16 suites. `standard` is
clean on both changed files, and `eslint` reports the same 145 pre-existing problems
as the base commit — no new lint.

### Verified against a real organization

The unit tests stub the GitHub client, so the plugin was also dry-run against a real
organization using `ProbotOctokit` in nop mode — real API, real response shapes, real
pagination — with the write endpoint replaced by a guard that throws if called, so no
modification was possible.

Setup: three custom properties defined on a scratch org and set on one repository.
`safe-settings-managed` is the property safe-settings declares; `ext-deploy-status`
and `ext-cost-center` stand in for values written by other automation.

| plugin | config | properties it would clear |
|---|---|---|
| `main-enterprise` | legacy array | `ext-cost-center`, `ext-deploy-status` — **2 Delete commands** |
| this branch | same legacy array | `ext-cost-center`, `ext-deploy-status` — **2 Delete commands** (identical) |
| this branch | `include` + `exclude: ^ext-` | **none — 0 Delete commands** |

The middle row is the backward-compatibility check: with a legacy config the plan this
branch produces is byte-identical to the plan the current plugin produces, against the
same live repository. The third row is the fix. All three runs recorded 0 write
attempts. The org was cleaned up afterwards.

Two things this surfaced that are worth flagging:

- **`@octokit/plugin-rest-endpoint-methods` v17 renamed both endpoints this plugin
  calls** — `getCustomPropertiesValues` and `createOrUpdateCustomPropertiesValues` are
  both `undefined` on the currently installed client, so `find()` throws against a real
  API regardless of this PR. That is issue #981 / PR #1032; the dry run shimmed the old
  names onto the new ones to get past it. Worth noting that #1032 is effectively a
  prerequisite for this feature working at runtime. The unit tests do not catch it
  because they stub the client methods by name.
- In nop mode the "Changes found" summary still lists excluded properties under
  `deletions`, because `Diffable.sync()` computes that summary from `compareDeep`
  before `remove()` runs. No Delete command is emitted and nothing is written — the
  listing is cosmetic, but a dry-run reader may find it confusing.

<details>
<summary>Design notes: why config errors fail closed, and where this diverges from Labels</summary>

The `include`/`exclude` vocabulary and the unanchored-regex matching follow
`lib/plugins/labels.js`. Two deliberate divergences, both because the cost of
misreading an exclude pattern here is cleared property values rather than a stray
label:

- **Patterns are lowercased when compiled.** Property names are lowercased before
  matching, so an uppercase pattern would otherwise be a valid regex that silently
  matches nothing and clears the properties it was written to protect.
- **An invalid pattern fails closed.** It is recorded as a per-repo config error and
  every property on that repo is treated as excluded, so a typo protects values
  rather than clearing them. This matters because these are regexes, not globs — the
  intuitive `*` is not a valid pattern, and under a fail-open reading it would clear
  every unmanaged property. Properties in `include` are still applied.

A malformed object config fails closed the same way. The object form requires
`include`, `exclude`, or both; the schemas reject anything else, but the plugin does
not rely on them — they are authoring aids, not a runtime gate, since nothing in
`lib/` validates config against them. Without the runtime check
`custom_properties: {}` reached `normalizeEntries` and threw a `TypeError` out of the
constructor.

Errors are recorded rather than thrown throughout: child plugins are constructed
outside any try/catch in `Settings.updateRepos`, so throwing would reject the org-wide
`Promise.all` and abort the sync for every other repo. A bad config in one repo should
not take down the org's sync.

</details>

Happy to rebase if #1032 lands first — it touches the same plugin.



