### PR TITLE
build(deps): bump js-yaml to 4.2.0 and shell-quote to 1.8.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9532,9 +9532,19 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -12192,10 +12202,13 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
-      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }


### PR DESCRIPTION
## Summary

Pulls the safe, in-range dependency bumps from #1001 into `yadhav/fix-recent-issues`. Lock-file only — no manifest or source changes.

| Dependency | From | To | Rationale |
|---|---|---|---|
| js-yaml | 4.1.0 | **4.2.0** | Direct prod dependency; range `^4.1.0` allows it. Includes a DoS security fix. |
| shell-quote | 1.8.1 | **1.8.4** | Transitive dev dependency via `npm-run-all` (`^1.6.1`); range allows it. |

## What is intentionally **not** included

The third bump from #1001 — **qs 6.13.0 → 6.15.2** — is **excluded**. qs is hard-pinned to 6.13.0 by `express 4.21.2` / `body-parser 1.20.3`, and qs 6.15.x is only reachable through `body-parser 2.x ← express 5.x ← probot 14.x`. That means qs requires a full **probot 13 → 14 major upgrade** (which also requires Node 22+, ESM/octokit changes, and a codebase-wide `github.rest.*` migration). That upgrade is being tracked/decided separately and is out of scope for this PR.

## Validation

- `git diff` limited to `package-lock.json` only.
- **311 unit tests pass** (`npx jest` unit suites).
- probot 13.4.4, express 4.21.2, qs 6.13.0 all unchanged — no behavioral/runtime impact.

Pre-existing lint errors and integration-test failures on the base branch are unaffected by this change (identical source).