### PR TITLE
Add gallagher branch to CodeQL workflow triggers

### DIFF
--- a/.github/workflows/advanced-codeql.yml
+++ b/.github/workflows/advanced-codeql.yml
@@ -14,9 +14,9 @@ name: "CodeQL Advanced"
 on:
   workflow_dispatch: 
   push:
-    branches: [ "main-enterprise" ]
+    branches: [ "main-enterprise", "gallagher" ]
   pull_request:
-    branches: [ "main-enterprise" ]
+    branches: [ "main-enterprise", "gallagher" ]
 
 
 jobs:


### PR DESCRIPTION
## Add `gallagher` to CodeQL's trigger branches

`advanced-codeql.yml` currently only scans `main-enterprise` (push and PR). Since `gallagher` is now this repo's default and control branch, none of our own changes ever get scanned — `main-enterprise` only ever sees genuine upstream commits, never anything we add on top.

This adds `gallagher` alongside `main-enterprise` (not replacing it), so:

- **`main-enterprise`** keeps scanning incoming upstream content as it lands — a useful automated check on top of the tracking branch's review, which is provenance-only ("is this really from upstream?"), not a content/security review.
- **`gallagher`** now scans everything Gallagher-authored: in-tree fixes (e.g. `teams.js`), workflow/config changes like this one, and future upstream integration merges — none of which `main-enterprise`'s trigger would ever catch.

No functional change to what CodeQL analyzes, just where it runs. Also needed as a prerequisite for `gallagher`'s CodeQL checks to be selectable as required status checks later, since GitHub only offers checks it's actually seen run.
