### PR TITLE
fix(branches): incorporate PR #1017 log/label fixes + mitigate integration appId harness

### DIFF
--- a/lib/plugins/branches.js
+++ b/lib/plugins/branches.js
@@ -57,8 +57,8 @@ module.exports = class Branches extends ErrorStash {
               return this.github.repos.getBranchProtection(params).then((result) => {
                 const mergeDeep = new MergeDeep(this.log, this.github, ignorableFields)
                 const changes = mergeDeep.compareDeep({ branch: { protection: this.reformatAndReturnBranchProtection(result.data) } }, { branch: { protection: Overrides.removeOverrides(overrides, branch.protection, result.data) } })
-                const results = { msg: `Followings changes will be applied to the branch protection for ${params.branch.name} branch`, additions: changes.additions, modifications: changes.modifications, deletions: changes.deletions }
-                this.log.debug(`Result of compareDeep = ${results}`)
+                const results = { msg: `The following changes will be applied to the branch protection for ${params.branch} branch`, additions: changes.additions, modifications: changes.modifications, deletions: changes.deletions }
+                this.log.debug(`Result of compareDeep = ${JSON.stringify(results)}`)
 
                 if (!changes.hasChanges) {
                   this.log.debug(`There are no changes for branch ${JSON.stringify(params)}. Skipping branch protection changes`)
@@ -76,10 +76,10 @@ module.exports = class Branches extends ErrorStash {
                 Object.assign(params, branch.protection, { headers: previewHeaders })
 
                 if (this.nop) {
-                  resArray.push(new NopCommand(this.constructor.name, this.repo, this.github.repos.updateBranchProtection.endpoint(params), 'Add Branch Protection'))
+                  resArray.push(new NopCommand(this.constructor.name, this.repo, this.github.repos.updateBranchProtection.endpoint(params), 'Update Branch Protection'))
                   return Promise.resolve(resArray)
                 }
-                this.log.debug(`Adding branch protection ${JSON.stringify(params)}`)
+                this.log.debug(`Updating branch protection ${JSON.stringify(params)}`)
                 return this.github.repos.updateBranchProtection(params).then(res => this.log.debug(`Branch protection applied successfully ${JSON.stringify(res.url)}`)).catch(e => { this.logError(`Error applying branch protection ${JSON.stringify(e)}`); return [] })
               }).catch((e) => {
                 if (e.status === 404) {

--- a/test/integration/common.js
+++ b/test/integration/common.js
@@ -16,7 +16,28 @@ const repository = {
 }
 
 function loadInstance () {
-  const probot = createProbot({ id: 1, cert: 'test', githubToken: 'test' })
+  // Probot 13's `createProbot` only reads `overrides`/`defaults`/`env`, so the
+  // old positional `{ id, cert, githubToken }` args were silently dropped,
+  // leaving no credentials and making `@octokit/auth-app` throw
+  // "appId option is required". Provide dummy credentials via `overrides`.
+  // Using a `githubToken` selects Octokit's token auth strategy, which avoids
+  // the app-auth JWT/installation-token calls that the nock scopes don't mock.
+  //
+  // The app also runs `info()` on load, which lists app installations. Stub
+  // that startup call with an empty list so it resolves cleanly under
+  // `nock.disableNetConnect()` without interfering with the per-test scopes.
+  nock('https://api.github.com')
+    .persist()
+    .get('/app/installations')
+    .query(true)
+    .reply(200, [])
+
+  const probot = createProbot({
+    overrides: {
+      appId: 1,
+      githubToken: 'test'
+    }
+  })
   probot.load(settingsBot)
 
   return probot

--- a/test/unit/lib/plugins/branches.test.js
+++ b/test/unit/lib/plugins/branches.test.js
@@ -272,6 +272,60 @@ describe('Branches', () => {
     })
   })
 
+  describe('in nop mode', () => {
+    function configureNop (config) {
+      return new Branches(true, github, { owner: 'bkeepers', repo: 'test' }, config, log, [])
+    }
+
+    beforeEach(() => {
+      github.repos.updateBranchProtection.endpoint = jest.fn().mockImplementation(params => {
+        return { url: 'updateBranchProtection', body: params }
+      })
+      github.repos.deleteBranchProtection.endpoint = jest.fn().mockImplementation(params => {
+        return { url: 'deleteBranchProtection', body: params }
+      })
+    })
+
+    describe('when branch protection already exists', () => {
+      it('labels the NopCommand as an update and names the branch in the diff message', () => {
+        const plugin = configureNop(
+          [{
+            name: 'master',
+            protection: { enforce_admins: true }
+          }]
+        )
+
+        return plugin.sync().then(res => {
+          const messages = res.map(nopCommand => nopCommand.action.msg)
+          expect(messages).toContain('Update Branch Protection')
+          expect(messages).not.toContain('Add Branch Protection')
+          const diffMessage = messages.find(msg => typeof msg === 'string' && msg.includes('will be applied to the branch protection'))
+          expect(diffMessage).toBeDefined()
+          expect(diffMessage).toContain('for master branch')
+          expect(diffMessage).not.toContain('undefined')
+        })
+      })
+    })
+
+    describe('when branch protection does not exist yet', () => {
+      it('labels the NopCommand as an add', () => {
+        github.repos.getBranchProtection = jest.fn().mockRejectedValue({ status: 404 })
+        const plugin = configureNop(
+          [{
+            name: 'master',
+            protection: { enforce_admins: true }
+          }]
+        )
+
+        return plugin.sync().then(res => {
+          const messages = res.map(nopCommand => nopCommand.action.msg)
+          expect(messages).toContain('Add Branch Protection')
+          expect(messages).not.toContain('Update Branch Protection')
+        })
+      })
+    })
+  })
+
   describe.skip('return values', () => {
     it('returns updateBranchProtection Promise', () => {
       const plugin = configure(


### PR DESCRIPTION
## Why

PR #1017 fixes two long-standing cosmetic-but-confusing bugs in the branch-protection plugin's log and dry-run output, and those fixes were not present in this branch. This brings them in (adapted to this branch's `this.github.repos` convention rather than the PR's `this.github.rest.repos`). It also unblocks the integration test harness, which currently cannot even instantiate Probot.

## What changed

**Branch-protection log/label fixes (`lib/plugins/branches.js`)**
- The diff message read `params.branch.name`, but `params.branch` is already the branch string, so every branch-protection diff in logs and dry-run reports said "for **undefined** branch". Fixed to use `params.branch`, and the adjacent debug log now `JSON.stringify`s the results object instead of interpolating `[object Object]`.
- In NOP (dry-run) mode, the path that runs after `getBranchProtection` succeeds (protection already exists, so this is an update) pushed a `NopCommand` labeled `Add Branch Protection`, identical to the real 404/add path. Plans could not tell "create protection" from "change protection". The update path now says `Update Branch Protection` (debug "Updating"); the 404 path keeps its `Add` label.
- Added an `in nop mode` unit block asserting the update label when protection exists, the add label on 404, and that the diff message names the actual branch (never `undefined`).

**Integration harness appId mitigation (`test/integration/common.js`)**
- Under probot 13, `createProbot` only reads `overrides`/`defaults`/`env`, so the old positional `{ id, cert, githubToken }` args were silently dropped, leaving no credentials and making `@octokit/auth-app` throw `appId option is required` before any test ran. The harness now passes dummy credentials via `overrides` (a `githubToken`, which selects token auth and avoids the app-auth JWT/installation-token calls the nock scopes don't mock).
- The app also runs `info()` on load, which lists app installations. That startup call is stubbed with an empty list so the app loads cleanly under `nock.disableNetConnect()` without interfering with the per-test scopes.

## Notes for reviewers

- This branch uses `this.github.repos.*` (not `this.github.rest.repos.*`), so the incorporated code differs textually from PR #1017 while preserving its intent.
- The appId mitigation removes the harness blocker (the `appId option is required` error is fully gone). Some legacy per-plugin integration tests still fail for a separate, pre-existing reason: they predate this branch's org-level admin-config loading and expect an `installation` in the event payload. Fully greening them is a larger harness/fixture rewrite and is intentionally out of scope here.

## Testing

- Unit suite: all green, including the new NOP-mode branch tests. Lint clean on changed files.
- Smoke test (live, real org): 181 passed / 11 failed, with all 11 failures environmental (GH_TOKEN PAT permissions on `gh api` drift-setup steps, and enterprise app-installation apply timeouts) and unrelated to this change.